### PR TITLE
fix(metadata_service.py): update NFO file paths to save in streamer d…

### DIFF
--- a/app/services/metadata_service.py
+++ b/app/services/metadata_service.py
@@ -156,19 +156,19 @@ class MetadataService:
             # 1. tvshow.nfo - for show/season data (uses streamer image)
             # 2. episode.nfo - for the specific stream episode (uses stream thumbnail)
             
-            # Paths for NFO files
+            # Paths for NFO files - alle im Streamer-Ordner!
             episode_nfo_path = base_path / f"{base_filename}.nfo"
-            tvshow_nfo_path = base_path.parent / "tvshow.nfo"
-            season_nfo_path = base_path.parent / "season.nfo"
-            
-            # Check if path contains season directory
-            is_in_season_dir = "season" in base_path.name.lower() or f"s{stream.started_at.strftime('%Y%m')}" in base_path.name.lower()
             
             # Determine streamer directory (one or two levels up)
+            is_in_season_dir = "season" in base_path.name.lower() or f"s{stream.started_at.strftime('%Y%m')}" in base_path.name.lower()
             if is_in_season_dir:
                 streamer_dir = base_path.parent.parent
             else:
                 streamer_dir = base_path.parent
+            
+            # Show-level NFO goes into streamer directory, not parent
+            tvshow_nfo_path = streamer_dir / "tvshow.nfo"
+            season_nfo_path = streamer_dir / "season.nfo"
                     
             # 1. Generate Show/Season NFO
             show_root = ET.Element("tvshow")
@@ -240,9 +240,9 @@ class MetadataService:
                 # Season poster
                 if streamer.profile_image_url:
                     ET.SubElement(season_root, "thumb").text = "poster.jpg"
-                    # Save season image
-                    await self._download_image(streamer.profile_image_url, base_path.parent / "poster.jpg")
-                    await self._download_image(streamer.profile_image_url, base_path.parent / "season.jpg")
+                    # Save season image im Streamer-Ordner
+                    await self._download_image(streamer.profile_image_url, streamer_dir / "poster.jpg")
+                    await self._download_image(streamer.profile_image_url, streamer_dir / "season.jpg")
                     
                 # Write XML
                 season_tree = ET.ElementTree(season_root)


### PR DESCRIPTION
This pull request updates the `generate_nfo_file` function in `app/services/metadata_service.py` to improve the organization of NFO files and associated images by ensuring they are stored in the correct streamer directory. The changes also include minor adjustments to comments for clarity.

### Changes to NFO file paths and organization:

* Updated the logic for determining the streamer directory (`streamer_dir`) to ensure that show-level and season-level NFO files (`tvshow.nfo` and `season.nfo`) are stored in the streamer directory rather than the parent directory.
* Adjusted the paths for saving season-related images (`poster.jpg` and `season.jpg`) to ensure they are stored in the streamer directory, aligning with the updated NFO file organization.

### Comment improvements:

* Enhanced comments to clarify the purpose and location of NFO files and associated images, including adding a note that all files are stored in the streamer directory. [[1]](diffhunk://#diff-0749819bdf8af8b75c01c6994fb51cb80182b99044068dfe68180d355df8b9feL159-R172) [[2]](diffhunk://#diff-0749819bdf8af8b75c01c6994fb51cb80182b99044068dfe68180d355df8b9feL243-R245)…irectory and improve image download logic