### PR TITLE
Develop

### DIFF
--- a/app/events/handler_registry.py
+++ b/app/events/handler_registry.py
@@ -223,20 +223,7 @@ class EventHandlerRegistry:
                     streamer.last_updated = datetime.now(timezone.utc)
                     db.commit()
 
-                    notification = {
-                        "type": "stream.online",
-                        "data": {
-                            "streamer_id": streamer.id,
-                            "twitch_id": data["broadcaster_user_id"],
-                            "streamer_name": streamer.username,
-                            "started_at": data["started_at"],
-                            "title": streamer.title,
-                            "category_name": streamer.category_name,
-                            "language": streamer.language
-                        }
-                    }
-                    await self.manager.send_notification(notification)
-
+                    # Send notification only via notification_service to avoid duplicates
                     await self.notification_service.send_stream_notification(
                         streamer_name=streamer.username,
                         event_type="online",
@@ -295,15 +282,7 @@ class EventHandlerRegistry:
                 
                     db.commit()
             
-                    await self.manager.send_notification({
-                        "type": "stream.offline",
-                        "data": {
-                            "streamer_id": streamer.id,
-                            "twitch_id": data["broadcaster_user_id"],
-                            "streamer_name": streamer.username
-                        }
-                    })
-                
+                    # Send notification only via notification_service to avoid duplicates
                     await self.notification_service.send_stream_notification(
                         streamer_name=streamer.username,
                         event_type="offline",
@@ -362,22 +341,7 @@ class EventHandlerRegistry:
                     else:
                         logger.info(f"Streamer {streamer.username} is offline, storing update for future use")
                 
-                    notification = {
-                        "type": "channel.update",
-                        "data": {
-                            "streamer_id": streamer.id,
-                            "twitch_id": data["broadcaster_user_id"],
-                            "streamer_name": streamer.username,
-                            "title": data.get("title"),
-                            "category_name": data.get("category_name"),
-                            "language": data.get("language"),
-                            "is_live": streamer.is_live
-                        }
-                    }
-                
-                    await self.manager.send_notification(notification)
-                    logger.debug(f"WebSocket notification sent for channel.update: {notification}")
-                
+                    # Send notification only via notification_service to avoid duplicates
                     logger.debug(f"Attempting to send notification for {streamer.username}, event_type=update")
                     notification_result = await self.notification_service.send_stream_notification(
                         streamer_name=streamer.username,

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -172,8 +172,13 @@ class NotificationService:
         try:
             # Send WebSocket notification first
             if self.websocket_manager:
+                # Map event types to correct WebSocket types
+                websocket_type = f"stream.{event_type}"
+                if event_type == "update":
+                    websocket_type = "channel.update"
+                
                 websocket_notification = {
-                    "type": f"stream.{event_type}",
+                    "type": websocket_type,
                     "data": {
                         "streamer_name": streamer_name,
                         "username": streamer_name,  # For compatibility
@@ -182,7 +187,10 @@ class NotificationService:
                         "language": details.get("language"),
                         "started_at": details.get("started_at"),
                         "url": details.get("url"),
-                        "profile_image_url": details.get("profile_image_url")
+                        "profile_image_url": details.get("profile_image_url"),
+                        "streamer_id": details.get("streamer_id"),
+                        "twitch_id": details.get("twitch_id"),
+                        "is_live": details.get("is_live")
                     }
                 }
                 logger.debug(f"Sending WebSocket notification: {websocket_notification}")


### PR DESCRIPTION
This pull request introduces changes to streamline the notification handling system, reduce duplicate notifications, and enhance the notification service's functionality. The key updates focus on backend notification logic, frontend duplicate prevention, and improved WebSocket compatibility.

### Backend Notification Handling:
* Removed direct WebSocket notifications from `handle_stream_online`, `handle_stream_offline`, and `handle_stream_update` in `app/events/handler_registry.py`. Notifications are now sent exclusively via `notification_service` to prevent duplication. [[1]](diffhunk://#diff-207aa70abfe00325cf52d4adbcf433a05758c4070d2da11f7b8c84804d3f8e7dL226-R226) [[2]](diffhunk://#diff-207aa70abfe00325cf52d4adbcf433a05758c4070d2da11f7b8c84804d3f8e7dL298-R285) [[3]](diffhunk://#diff-207aa70abfe00325cf52d4adbcf433a05758c4070d2da11f7b8c84804d3f8e7dL365-R344)
* Enhanced the `send_stream_notification` method in `app/services/notification_service.py` to include additional fields (`streamer_id`, `twitch_id`, `is_live`) in WebSocket notifications and mapped `update` events to `channel.update` for consistency. [[1]](diffhunk://#diff-c096b505c57fbd568618d31178a65d0361d2afa8116a358c4c6a94a1636c10e3R175-R181) [[2]](diffhunk://#diff-c096b505c57fbd568618d31178a65d0361d2afa8116a358c4c6a94a1636c10e3L185-R193)

### Frontend Duplicate Prevention:
* Introduced a debounce mechanism in `app/frontend/src/components/NotificationFeed.vue` to prevent rapid duplicate notifications. A `recentNotifications` map tracks the last notification timestamps, and duplicates within a defined debounce time are ignored. [[1]](diffhunk://#diff-6cce6ed5609589aa59139b25305f9cd682cdae10f1c1b8bc14734988a2dadcb3R109-R117) [[2]](diffhunk://#diff-6cce6ed5609589aa59139b25305f9cd682cdae10f1c1b8bc14734988a2dadcb3L248-R312)
* Enhanced duplicate detection logic in `addNotification` to account for specific event types (e.g., `stream.online`, `channel.update`) and their unique criteria, such as time thresholds and content comparison.