### PR TITLE
fix(docker-build.yml): enhance release notes generation with full com…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -203,17 +203,26 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: release } = await github.rest.repos.generateReleaseNotes({
+            // Get commits since last release
+            const { data: commits } = await github.rest.repos.compareCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: 'v${{ needs.version.outputs.new_version }}',
-              previous_tag_name: await github.rest.repos.getLatestRelease({ 
+              base: await github.rest.repos.getLatestRelease({ 
                 owner: context.repo.owner, 
                 repo: context.repo.repo 
-              }).then(r => r.data.tag_name).catch(() => null)
+              }).then(r => r.data.tag_name).catch(() => 'HEAD~10'),
+              head: 'HEAD'
             });
             
-            // Enhance the release notes with Docker-specific information
+            // Format commits with full messages (not truncated)
+            const commitList = commits.commits.map(commit => {
+              const message = commit.commit.message.split('\n')[0]; // First line only
+              const author = commit.author?.login || commit.commit.author.name;
+              const sha = commit.sha.substring(0, 7);
+              return `* ${message} by @${author} in ${sha}`;
+            }).join('\n');
+            
+            // Create enhanced release notes
             const dockerInfo = `
             ## 🐳 Docker Image Update v${{ needs.version.outputs.new_version }}
             
@@ -231,9 +240,14 @@ jobs:
             docker-compose pull && docker-compose up -d
             \`\`\`
             
-            ---
+            ## What's Changed
             
-            ${release.body}
+            ${commitList}
+            
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${await github.rest.repos.getLatestRelease({ 
+              owner: context.repo.owner, 
+              repo: context.repo.repo 
+            }).then(r => r.data.tag_name).catch(() => 'v1.0.0')}...v${{ needs.version.outputs.new_version }}
             `;
             
             core.setOutput('release_notes', dockerInfo);
@@ -290,4 +304,4 @@ jobs:
           body: ${{ steps.github_release_notes.outputs.release_notes }}
           draft: false
           prerelease: false
-          generate_release_notes: true
+          generate_release_notes: false


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-build.yml` file to enhance the release notes generation process for Docker builds by replacing the auto-generated notes with a more detailed and customized format. The most important changes are grouped below:

### Improvements to release notes generation:

* Replaced the use of `generateReleaseNotes` with a custom script to fetch commits since the last release using `compareCommits`. This ensures that the release notes include detailed commit information.
* Added a formatted list of commits to the release notes, including the first line of each commit message, the author's username, and a short commit SHA.
* Introduced a "What's Changed" section in the release notes to clearly highlight the updates, followed by a full changelog link comparing the last release to the new version.

### Workflow configuration updates:

* Disabled the default `generate_release_notes` option in the `create-release` step, as the release notes are now fully customized.…mit messages and Docker-specific information