### PR TITLE
Develop

### DIFF
--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -6,7 +6,7 @@ from typing import List
 import logging
 from pathlib import Path
 import mimetypes
-from werkzeug.utils import secure_filename
+import re
 from sqlalchemy.orm import Session
 from app.database import SessionLocal, get_db
 from app.models import RecordingSettings, Stream, Streamer
@@ -17,6 +17,22 @@ router = APIRouter(
     prefix="/api",
     tags=["videos"]
 )
+
+def secure_filename(filename):
+    """Secure a filename by removing or replacing dangerous characters"""
+    if not filename:
+        return ""
+    
+    # Remove path separators and other dangerous characters
+    filename = re.sub(r'[<>:"/\\|?*]', '', filename)
+    filename = re.sub(r'\.\.+', '.', filename)  # Remove multiple dots
+    filename = filename.strip('. ')  # Remove leading/trailing dots and spaces
+    
+    # Ensure filename is not empty after sanitization
+    if not filename:
+        return "file"
+    
+    return filename
 
 def get_recordings_directory():
     """Get the recordings directory from database settings"""


### PR DESCRIPTION
This pull request introduces support for pre-loaded chapters in the `VideoPlayer` component and enhances filename sanitization in the backend. The most important changes include adding a new `chapters` prop, implementing utility functions for chapter conversion and time parsing, and replacing the `werkzeug.utils.secure_filename` function with a custom implementation.

### Frontend Changes (VideoPlayer Component):

* **Support for Pre-Loaded Chapters:**
  - Added a new `chapters` prop to accept pre-loaded chapters from the API. (`[app/frontend/src/components/VideoPlayer.vueR142-R147](diffhunk://#diff-3d41a029cf11aa1e90c4b8c5a93f22e8963e6816754c4093fa9bcb1290b8af2eR142-R147)`)
  - Updated the `loadChapters` function to prioritize loading chapters from the `chapters` prop if available. (`[app/frontend/src/components/VideoPlayer.vueR243-R249](diffhunk://#diff-3d41a029cf11aa1e90c4b8c5a93f22e8963e6816754c4093fa9bcb1290b8af2eR243-R249)`)
  - Added a `watch` function to dynamically update chapters when the `chapters` prop changes. (`[app/frontend/src/components/VideoPlayer.vueR433-R440](diffhunk://#diff-3d41a029cf11aa1e90c4b8c5a93f22e8963e6816754c4093fa9bcb1290b8af2eR433-R440)`)

* **Utility Functions:**
  - Introduced `convertApiChaptersToInternal` to map API chapter data to the internal format used by the player. (`[app/frontend/src/components/VideoPlayer.vueR282-R316](diffhunk://#diff-3d41a029cf11aa1e90c4b8c5a93f22e8963e6816754c4093fa9bcb1290b8af2eR282-R316)`)
  - Added `parseTimeStringToSeconds` to handle various time formats and convert them into seconds. (`[app/frontend/src/components/VideoPlayer.vueR282-R316](diffhunk://#diff-3d41a029cf11aa1e90c4b8c5a93f22e8963e6816754c4093fa9bcb1290b8af2eR282-R316)`)

### Backend Changes (Filename Sanitization):

* **Custom `secure_filename` Implementation:**
  - Replaced the `werkzeug.utils.secure_filename` function with a custom implementation to sanitize filenames by removing dangerous characters and ensuring a valid output. (`[[1]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L9-R9)`, `[[2]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977R21-R36)`)