### PR TITLE
Develop

### DIFF
--- a/app/services/logging_service.py
+++ b/app/services/logging_service.py
@@ -1,7 +1,9 @@
 import os
 import logging
 import asyncio
-from datetime import datetime, timezone
+import time
+import re
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
@@ -18,11 +20,18 @@ class LoggingService:
         self.ffmpeg_logs_dir = self.logs_base_dir / "ffmpeg"
         self.app_logs_dir = self.logs_base_dir / "app"
         
+        # Log retention settings
+        self.streamer_log_retention_days = 14  # Keep streamer-specific logs for 14 days
+        self.system_log_retention_days = 30    # Keep system logs for 30 days
+        
         # Create directories
         self._ensure_log_directories()
         
         # Initialize loggers
         self._setup_loggers()
+        
+        # Clean up old logs on initialization
+        self.cleanup_old_logs()
     
     def _ensure_log_directories(self):
         """Create log directories if they don't exist"""
@@ -81,16 +90,23 @@ class LoggingService:
     def get_streamlink_log_path(self, streamer_name: str) -> str:
         """Get log file path for a specific streamer's streamlink session"""
         today = datetime.now().strftime("%Y-%m-%d")
-        log_file = self.streamlink_logs_dir / f"{streamer_name}_{today}.log"
+        timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+        
+        # Format consistently with FFmpeg logs: streamer_streamlink_timestamp_date.log
+        streamer_name = streamer_name.replace(" ", "_")  # Remove spaces from streamer name
+        log_file = self.streamlink_logs_dir / f"{streamer_name}_streamlink_{timestamp_str}_{today}.log"
         return str(log_file)
     
     def get_ffmpeg_log_path(self, operation: str, streamer_name: str) -> str:
         """Get log file path for FFmpeg operations with mandatory streamer name"""
         today = datetime.now().strftime("%Y-%m-%d")
         timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
-        # Always include the streamer name in the log file path for better organization
-        # Add timestamp to ensure unique files even for same-day operations
-        log_file = self.ffmpeg_logs_dir / f"{operation}_{streamer_name}_{today}_{timestamp_str}.log"
+        
+        # Place streamer name first for better organization and visual scanning
+        # Format: streamer_operation_timestamp_date.log
+        # This makes it easier to find logs for a specific streamer
+        streamer_name = streamer_name.replace(" ", "_")  # Remove spaces from streamer name
+        log_file = self.ffmpeg_logs_dir / f"{streamer_name}_{operation}_{timestamp_str}_{today}.log"
         return str(log_file)
     
     def log_streamlink_start(self, streamer_name: str, quality: str, output_path: str, cmd: List[str]):
@@ -138,19 +154,116 @@ class LoggingService:
             else:
                 self.ffmpeg_logger.error(f"{prefix} STDERR (exit {exit_code}):\n{stderr_text}")
     
-    def cleanup_old_logs(self, days_to_keep: int = 30):
-        """Clean up log files older than specified days"""
+    def cleanup_old_logs(self):
+        """Clean up old log files based on retention settings.
+        
+        This removes:
+        - Old streamer-specific FFmpeg log files older than streamer_log_retention_days
+        - Old streamer-specific Streamlink log files older than streamer_log_retention_days
+        - Keeps main system logs according to system_log_retention_days
+        """
         try:
-            import time
-            cutoff_time = time.time() - (days_to_keep * 24 * 60 * 60)
+            logger.info(f"Starting log cleanup. Retention: streamer logs={self.streamer_log_retention_days} days, system logs={self.system_log_retention_days} days")
             
-            for log_dir in [self.streamlink_logs_dir, self.ffmpeg_logs_dir, self.app_logs_dir]:
-                for log_file in log_dir.glob("*.log*"):
-                    if log_file.stat().st_mtime < cutoff_time:
-                        log_file.unlink()
-                        logger.info(f"Cleaned up old log file: {log_file}")
+            # Clean FFmpeg logs
+            self._cleanup_directory(
+                self.ffmpeg_logs_dir, 
+                self.streamer_log_retention_days,
+                self.system_log_retention_days
+            )
+            
+            # Clean Streamlink logs
+            self._cleanup_directory(
+                self.streamlink_logs_dir, 
+                self.streamer_log_retention_days,
+                self.system_log_retention_days
+            )
+            
+            # Clean App logs (all considered system logs)
+            self._cleanup_directory(
+                self.app_logs_dir, 
+                self.system_log_retention_days,
+                self.system_log_retention_days
+            )
+            
+            logger.info("Log cleanup completed")
         except Exception as e:
-            logger.error(f"Error cleaning up old logs: {e}", exc_info=True)
+            logger.error(f"Error during log cleanup: {e}", exc_info=True)
+    
+    def _is_system_log(self, filename: str) -> bool:
+        """Determine if a file is a system log or a streamer-specific log.
+        
+        Args:
+            filename: The filename to check
+            
+        Returns:
+            bool: True if it's a system log, False if it's a streamer-specific log
+        """
+        system_log_patterns = [
+            r"ffmpeg_system",
+            r"streamlink\.log",
+            r"recording_activity",
+        ]
+        
+        for pattern in system_log_patterns:
+            if re.search(pattern, filename):
+                return True
+                
+        return False
+
+    def _cleanup_directory(self, directory: Path, streamer_retention_days: int, system_retention_days: int):
+        """Clean up log files in a directory based on retention days.
+        
+        Args:
+            directory: Directory to clean up
+            streamer_retention_days: Days to retain streamer-specific logs
+            system_retention_days: Days to retain system logs
+        """
+        if not directory.exists():
+            return
+            
+        now = datetime.now()
+        streamer_cutoff = now - timedelta(days=streamer_retention_days)
+        system_cutoff = now - timedelta(days=system_retention_days)
+        
+        deleted_count = 0
+        skipped_count = 0
+        
+        for log_file in directory.glob("*.log*"):
+            try:
+                # Check file modification time
+                mtime = datetime.fromtimestamp(log_file.stat().st_mtime)
+                
+                # Determine if this is a system log or a streamer log
+                is_system = self._is_system_log(log_file.name)
+                
+                # Check against the appropriate cutoff date
+                cutoff = system_cutoff if is_system else streamer_cutoff
+                
+                if mtime < cutoff:
+                    # Log file is older than the cutoff, delete it
+                    os.remove(log_file)
+                    deleted_count += 1
+                else:
+                    skipped_count += 1
+                    
+            except Exception as e:
+                logger.error(f"Error processing log file {log_file}: {e}", exc_info=True)
+        
+        logger.info(f"Cleaned {directory}: deleted {deleted_count} log files, kept {skipped_count}")
+    
+    async def _schedule_cleanup(self, interval_hours: int = 24):
+        """Schedule periodic log cleanup.
+        
+        Args:
+            interval_hours: How often to run cleanup (in hours)
+        """
+        while True:
+            # Sleep for the specified interval
+            await asyncio.sleep(interval_hours * 3600)
+            
+            # Run cleanup
+            self.cleanup_old_logs()
     
     # === Recording Activity Logging Methods ===
     

--- a/app/services/metadata_service.py
+++ b/app/services/metadata_service.py
@@ -1527,15 +1527,20 @@ class MetadataService:
             logger.info(f"Starting metadata embedding for stream {stream_id}, mp4: {mp4_path}")
             mp4_path_obj = Path(mp4_path)
             
+            # Import logging service
+            from app.services.logging_service import logging_service
+            
             # Validate source file exists and has reasonable size
             if not mp4_path_obj.exists():
                 logger.error(f"MP4 file does not exist: {mp4_path}")
+                logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_FAILED] MP4 file does not exist: {mp4_path}")
                 return False
                 
             # Check file size to ensure it's not empty or corrupted
             mp4_size = mp4_path_obj.stat().st_size
             if mp4_size < 10000:
                 logger.error(f"MP4 file is too small ({mp4_size} bytes), likely corrupted: {mp4_path}")
+                logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_FAILED] MP4 file too small: {mp4_path}, {mp4_size} bytes")
                 return False
                 
             logger.info(f"Source MP4 validation passed: {mp4_path}, size: {mp4_size} bytes")
@@ -1544,30 +1549,68 @@ class MetadataService:
             chapters_path_obj = Path(chapters_path) if chapters_path else None
             logger.debug(f"Using chapters file: {chapters_path}")
             
+            # Create unique log file for validation
+            timestamp_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            validation_log_path = logging_service.get_ffmpeg_log_path(f"metadata_validate_{timestamp_str}", f"stream_{stream_id}")
+            
             # Validate the MP4 file using ffprobe to ensure it's not corrupted
             logger.info(f"Validating MP4 file with ffprobe: {mp4_path}")
             validate_cmd = [
                 "ffprobe",
                 "-v", "error",
                 "-select_streams", "v:0",
-                "-show_entries", "stream=codec_name",
+                "-show_entries", "stream=codec_name,duration,width,height",
                 "-of", "json",
                 str(mp4_path_obj)
             ]
             
+            # Log the validation command
+            logging_service.ffmpeg_logger.info(f"[METADATA_VALIDATION_START] Validating MP4: {mp4_path}")
+            logging_service.ffmpeg_logger.info(f"[FFPROBE_CMD] {' '.join(validate_cmd)}")
+            
+            # Set up environment for ffprobe log
+            env = os.environ.copy()
+            env["FFREPORT"] = f"file={validation_log_path}:level=32"
+            
             validate_process = await asyncio.create_subprocess_exec(
                 *validate_cmd,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
+                stderr=asyncio.subprocess.PIPE,
+                env=env
             )
             
             validate_stdout, validate_stderr = await validate_process.communicate()
             
             if validate_process.returncode != 0:
-                logger.error(f"MP4 file validation failed: {validate_stderr.decode('utf-8', errors='ignore')}")
+                error_message = validate_stderr.decode('utf-8', errors='ignore')
+                logger.error(f"MP4 file validation failed: {error_message}")
+                logging_service.ffmpeg_logger.error(f"[METADATA_VALIDATION_FAILED] MP4 validation failed: {error_message}")
                 return False
                 
-            logger.info(f"MP4 file validation successful with ffprobe")
+            # Parse the validation output to confirm video stream is present
+            try:
+                import json
+                validation_data = json.loads(validate_stdout.decode('utf-8', errors='ignore'))
+                if "streams" not in validation_data or len(validation_data["streams"]) == 0:
+                    logger.error(f"No video streams found in MP4: {mp4_path}")
+                    logging_service.ffmpeg_logger.error(f"[METADATA_VALIDATION_FAILED] No video streams found: {mp4_path}")
+                    return False
+                
+                # Log video details
+                stream = validation_data["streams"][0]
+                codec = stream.get("codec_name", "unknown")
+                width = stream.get("width", "unknown")
+                height = stream.get("height", "unknown")
+                duration = stream.get("duration", "unknown")
+                
+                logger.info(f"MP4 file validation successful: {codec}, {width}x{height}, duration: {duration}s")
+                logging_service.ffmpeg_logger.info(
+                    f"[METADATA_VALIDATION_SUCCESS] MP4 validated: {mp4_path}, codec: {codec}, "
+                    f"resolution: {width}x{height}, duration: {duration}s"
+                )
+            except Exception as e:
+                logger.error(f"Error parsing validation result: {e}")
+                # Continue even if parsing fails as the ffprobe command succeeded
             
             # Get stream and streamer information
             with SessionLocal() as db:
@@ -1590,7 +1633,7 @@ class MetadataService:
                 logger.info(f"No chapters file found at: {chapters_path}")
             
             # Create temporary metadata file with all metadata
-            meta_path = mp4_path_obj.with_name(f"{mp4_path_obj.stem}-combined-metadata.txt")
+            meta_path = mp4_path_obj.with_name(f"{mp4_path_obj.stem}-combined-metadata-{timestamp_str}.txt")
             logger.info(f"Creating combined metadata file: {meta_path}")
             
             with open(str(meta_path), 'w', encoding='utf-8') as f:
@@ -1620,6 +1663,7 @@ class MetadataService:
                 # Add encoding metadata
                 f.write("encoded_by=StreamVault\n")
                 f.write("encoding_tool=StreamVault\n")
+                f.write(f"metadata_date={datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}\n")
                 
                 # Add chapters if available
                 if has_chapters:
@@ -1641,7 +1685,7 @@ class MetadataService:
             # Import remux function from utilities
             from app.utils.file_utils import remux_file
             
-            temp_output = f"{str(mp4_path_obj)}.temp.mp4"
+            temp_output = f"{str(mp4_path_obj)}.temp_{timestamp_str}.mp4"
             streamer_name = streamer.username if streamer else "unknown"
             
             # Call the remux_file utility with logging service
@@ -1649,7 +1693,7 @@ class MetadataService:
             logger.debug(f"Starting remux process: input={mp4_path}, output={temp_output}, metadata={meta_path}")
             
             # Log metadata operation through the logging service
-            logging_service.ffmpeg_logger.info(f"Starting metadata embedding for {streamer_name}, file: {mp4_path}")
+            logging_service.ffmpeg_logger.info(f"[METADATA_EMBED_START] {streamer_name}, stream ID: {stream_id}, file: {mp4_path}")
             
             # Log command details to ffmpeg log
             ffmpeg_cmd = [
@@ -1662,14 +1706,15 @@ class MetadataService:
                 "-y", 
                 temp_output
             ]
-            logging_service.log_ffmpeg_start("metadata_embed", ffmpeg_cmd, streamer_name)
+            logging_service.log_ffmpeg_start("metadata_embed", ffmpeg_cmd, f"{streamer_name}_stream{stream_id}")
             
+            # Call remux with detailed logging
             result = await remux_file(
                 input_path=str(mp4_path_obj), 
                 output_path=temp_output,
                 overwrite=True, 
                 metadata_file=str(meta_path),
-                streamer_name=streamer_name,
+                streamer_name=f"{streamer_name}_stream{stream_id}",
                 logging_service=logging_service
             )
             
@@ -1680,29 +1725,54 @@ class MetadataService:
                     temp_file_size = os.path.getsize(temp_output)
                     logger.info(f"Remux completed, temp file size: {temp_file_size} bytes")
                     
+                    # Validate the output MP4 file with ffprobe
+                    validate_output_cmd = [
+                        "ffprobe",
+                        "-v", "error",
+                        "-show_entries", "format=duration",
+                        "-of", "json",
+                        temp_output
+                    ]
+                    
+                    validate_output_process = await asyncio.create_subprocess_exec(
+                        *validate_output_cmd,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE
+                    )
+                    
+                    validate_output_stdout, validate_output_stderr = await validate_output_process.communicate()
+                    
+                    if validate_output_process.returncode != 0:
+                        error_msg = f"Output file validation failed: {validate_output_stderr.decode('utf-8', errors='ignore')}"
+                        logger.error(error_msg)
+                        logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_FAILED] {error_msg}")
+                        if os.path.exists(temp_output):
+                            os.remove(temp_output)
+                        return False
+                    
                     # Check if output file is not too small (which would indicate corruption)
                     if temp_file_size > (mp4_size * 0.9):  # Should be at least 90% of original
                         # Replace original with temp file
                         logger.info(f"Temp file passed validation, replacing original file")
                         os.replace(temp_output, str(mp4_path_obj))
                         logger.info(f"Successfully embedded metadata into {mp4_path}")
-                        logging_service.ffmpeg_logger.info(f"Successfully embedded metadata for {streamer_name}: {mp4_path}")
+                        logging_service.ffmpeg_logger.info(f"[METADATA_EMBED_SUCCESS] {streamer_name}: {mp4_path}")
                         success = True
                     else:
                         error_msg = f"Output file appears corrupted: size {temp_file_size} bytes is significantly smaller than original {mp4_size} bytes"
                         logger.error(error_msg)
-                        logging_service.ffmpeg_logger.error(f"Metadata embedding failed for {streamer_name}: {error_msg}")
+                        logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_FAILED] {streamer_name}: {error_msg}")
                         # Keep the original file, don't replace it
                         if os.path.exists(temp_output):
                             os.remove(temp_output)
                 else:
                     error_msg = "Temp output file was not created"
                     logger.error(error_msg)
-                    logging_service.ffmpeg_logger.error(f"Metadata embedding failed for {streamer_name}: {error_msg}")
+                    logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_FAILED] {streamer_name}: {error_msg}")
             else:
                 error_msg = f"Failed to embed metadata: {result.get('stderr', 'Unknown error')}"
                 logger.error(error_msg)
-                logging_service.ffmpeg_logger.error(f"Metadata embedding failed for {streamer_name}: {error_msg}")
+                logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_FAILED] {streamer_name}: {error_msg}")
                 # Clean up temp file if it exists despite failure
                 if os.path.exists(temp_output):
                     os.remove(temp_output)
@@ -1722,25 +1792,27 @@ class MetadataService:
                         stream_metadata.metadata_embedded_at = datetime.now(timezone.utc)
                         db.commit()
                         logger.info(f"Updated database for stream {stream_id}, metadata marked as embedded")
-                        logging_service.ffmpeg_logger.info(f"Database updated for {streamer_name}, metadata marked as embedded for stream {stream_id}")
+                        logging_service.ffmpeg_logger.info(f"[DATABASE_UPDATE] {streamer_name}, metadata marked as embedded for stream {stream_id}")
                     else:
                         logger.warning(f"No metadata record found for stream {stream_id}")
-                        logging_service.ffmpeg_logger.warning(f"No metadata record found for stream {stream_id} ({streamer_name})")
+                        logging_service.ffmpeg_logger.warning(f"[DATABASE_WARNING] No metadata record found for stream {stream_id} ({streamer_name})")
             
             # Create additional chapter files for various media servers
             if success:
                 logger.info(f"Creating additional chapter files for media servers")
                 await self._create_media_server_chapters(stream_id, mp4_path, use_category_as_chapter_title=False)
-                logging_service.ffmpeg_logger.info(f"Created additional chapter files for stream {stream_id} ({streamer_name})")
+                logging_service.ffmpeg_logger.info(f"[CHAPTERS_CREATED] Additional chapter files for stream {stream_id} ({streamer_name})")
             
             status_str = 'Success' if success else 'Failed'
             logger.info(f"Metadata embedding process completed with status: {status_str}")
-            logging_service.ffmpeg_logger.info(f"Metadata embedding process for {streamer_name} completed with status: {status_str}")
+            logging_service.ffmpeg_logger.info(f"[METADATA_EMBED_COMPLETE] {streamer_name} - Status: {status_str}")
             return success
         except Exception as e:
             logger.error(f"Error embedding all metadata: {e}", exc_info=True)
+            from app.services.logging_service import logging_service
+            logging_service.ffmpeg_logger.error(f"[METADATA_EMBED_EXCEPTION] Unhandled error: {str(e)}")
             return False
-            
+    
     async def _create_media_server_chapters(self, stream_id: int, mp4_path: str, use_category_as_chapter_title: bool = False) -> None:
         """Create additional chapter files for better media server compatibility
         

--- a/app/services/metadata_service.py
+++ b/app/services/metadata_service.py
@@ -772,10 +772,23 @@ class MetadataService:
                 str(thumbnail_path)
             ]
             
+            # Create a unique log file for this thumbnail extraction
+            streamer_name = video_path_obj.stem.split('-')[0] if '-' in video_path_obj.stem else 'unknown'
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            ffmpeg_log_path = os.path.join('logs', 'ffmpeg', f"thumbnail_{streamer_name}_{timestamp}.log")
+            
+            # Ensure the log directory exists
+            os.makedirs(os.path.dirname(ffmpeg_log_path), exist_ok=True)
+            
+            # Set up environment for FFmpeg log
+            env = os.environ.copy()
+            env["FFREPORT"] = f"file={ffmpeg_log_path}:level=40"
+            
             process = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
+                stderr=asyncio.subprocess.PIPE,
+                env=env
             )
             
             stdout, stderr = await process.communicate()

--- a/app/services/recording_service.py
+++ b/app/services/recording_service.py
@@ -2008,7 +2008,7 @@ class RecordingService:
             self.activity_logger.log_process_monitoring(
                 streamer_name, 
                 "DURATION_CHECK_SUCCESS", 
-                f"MP4: {mp4_duration:.2f}s, TS: {ts_duration:.2f if ts_duration else 'unknown'}s"
+                f"MP4: {mp4_duration:.2f}s, TS: {ts_duration:.2f if ts_duration is not None else 'unknown'}s"
             )
             
             return {

--- a/app/services/recording_service.py
+++ b/app/services/recording_service.py
@@ -2005,10 +2005,13 @@ class RecordingService:
                 }
                 
             logger.info(f"MP4 duration check passed: {mp4_duration:.2f}s")
+            
+            # Format the TS duration message properly with conditional
+            ts_duration_msg = f"{ts_duration:.2f}s" if ts_duration is not None else "unknown"
             self.activity_logger.log_process_monitoring(
                 streamer_name, 
                 "DURATION_CHECK_SUCCESS", 
-                f"MP4: {mp4_duration:.2f}s, TS: {ts_duration:.2f if ts_duration is not None else 'unknown'}s"
+                f"MP4: {mp4_duration:.2f}s, TS: {ts_duration_msg}"
             )
             
             return {

--- a/app/utils/file_utils.py
+++ b/app/utils/file_utils.py
@@ -163,7 +163,7 @@ async def remux_file(
             os.makedirs(log_dir, exist_ok=True)
             
             # Configure FFmpeg to create a detailed report - ensure higher log level
-            env["FFREPORT"] = f"file={ffmpeg_log_path}:level=40:append=true"
+            env["FFREPORT"] = f"file={ffmpeg_log_path}:level=40"
             logger.info(f"FFmpeg log will be written to: {ffmpeg_log_path}")
         
         # Start the process

--- a/app/utils/file_utils.py
+++ b/app/utils/file_utils.py
@@ -94,12 +94,15 @@ async def remux_file(
         # Copy streams without re-encoding
         cmd.extend(["-c", "copy"])
         
-        # Add aac bitstream filter for non-audio containers
-        if not output_path.endswith('.aac'):
-            cmd.extend(["-bsf:a", "aac_adtstoasc"])
+        # Determine if this is a metadata embedding operation (MP4 to MP4)
+        is_metadata_embedding = metadata_file and input_path.endswith('.mp4') and output_path.endswith('.mp4')
         
         # Optimize for mp4 files with advanced options to prevent corruption
         if output_path.endswith('.mp4'):
+            # For TS to MP4 conversions, add the aac bitstream filter (needed for ADTS to ASC conversion)
+            if input_path.endswith('.ts') and not is_metadata_embedding:
+                cmd.extend(["-bsf:a", "aac_adtstoasc"])
+                
             # Better handling of timestamp issues and muxing
             cmd.extend(["-avoid_negative_ts", "make_zero"])  
             cmd.extend(["-map", "0:v:0?"])  # Map video if exists

--- a/app/utils/file_utils.py
+++ b/app/utils/file_utils.py
@@ -4,6 +4,7 @@ import re
 import asyncio
 import logging
 import tempfile
+from datetime import datetime
 from typing import Dict, Optional, Any
 
 logger = logging.getLogger("streamvault")
@@ -37,6 +38,26 @@ async def remux_file(
         
         logger.info(f"Starting remux of {input_path} to {output_path}")
         
+        # Validate input file exists and has content
+        if not os.path.exists(input_path):
+            logger.error(f"Input file {input_path} does not exist")
+            return {
+                "success": False,
+                "code": -1,
+                "stdout": "",
+                "stderr": "Input file does not exist"
+            }
+            
+        input_size = os.path.getsize(input_path)
+        if input_size == 0:
+            logger.error(f"Input file {input_path} is empty")
+            return {
+                "success": False,
+                "code": -1,
+                "stdout": "",
+                "stderr": "Input file is empty"
+            }
+        
         # Check if output file already exists
         empty_file = os.path.exists(output_path) and os.path.getsize(output_path) == 0
         
@@ -52,8 +73,14 @@ async def remux_file(
         if empty_file:
             os.remove(output_path)
             
-        # Build ffmpeg command similar to the TypeScript implementation
+        # Build comprehensive ffmpeg command with robust error handling
         cmd = ["ffmpeg"]
+        
+        # Add error resilience flags for corrupted inputs
+        cmd.extend(["-fflags", "+genpts+igndts+ignidx+discardcorrupt"])
+        cmd.extend(["-err_detect", "ignore_err"])
+        cmd.extend(["-analyzeduration", "50M"])
+        cmd.extend(["-probesize", "50M"])
         
         # Input file
         cmd.extend(["-i", input_path])
@@ -71,34 +98,73 @@ async def remux_file(
         if not output_path.endswith('.aac'):
             cmd.extend(["-bsf:a", "aac_adtstoasc"])
         
-        # Optimize for mp4 files
+        # Optimize for mp4 files with advanced options to prevent corruption
         if output_path.endswith('.mp4'):
-            cmd.extend(["-movflags", "faststart"])
+            # Better handling of timestamp issues and muxing
+            cmd.extend(["-avoid_negative_ts", "make_zero"])  
+            cmd.extend(["-map", "0:v:0?"])  # Map video if exists
+            cmd.extend(["-map", "0:a:0?"])  # Map audio if exists
+            cmd.extend(["-movflags", "+faststart+empty_moov+frag_keyframe"])
+            cmd.extend(["-ignore_unknown"])
+            cmd.extend(["-max_muxing_queue_size", "16384"])
+            cmd.extend(["-max_interleave_delta", "0"])
+            cmd.extend(["-fflags", "+discardcorrupt"])
+            cmd.extend(["-async", "0"])
+            cmd.extend(["-fps_mode", "passthrough"])
         
         # Overwrite if specified
         if overwrite or empty_file:
             cmd.append("-y")
         
-        # Add verbose logging if needed
-        if hasattr(settings, 'verbose_logging') and settings.verbose_logging:
-            cmd.extend(["-loglevel", "repeat+level+verbose"])
+        # Add proper logging level with details
+        cmd.extend(["-loglevel", "info"])
+        cmd.extend(["-stats_period", "30"]) # Show stats every 30 seconds
+        
+        # Add report flag for detailed logs
+        cmd.extend(["-report"])
         
         # Add output path
         cmd.append(output_path)
         
+        # Generate a unique timestamp for this operation
+        remux_timestamp = int(datetime.now().timestamp())
+        timestamp_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        operation_id = f"remux_{streamer_name}_{timestamp_str}"
+        
         # Set up logging if the service is available
         ffmpeg_log_path = None
         if logging_service:
-            ffmpeg_log_path = logging_service.get_ffmpeg_log_path("remux", streamer_name)
-            logging_service.log_ffmpeg_start("remux", cmd, streamer_name)
-            logging_service.log_file_operation("REMUX_START", input_path, True, f"Starting remux to {output_path}")
+            # Create a unique log file for each remux operation with timestamp and streamer name
+            log_prefix = "metadata" if metadata_file else "remux"
+            ffmpeg_log_path = logging_service.get_ffmpeg_log_path(f"{log_prefix}_{streamer_name}", streamer_name)
+            
+            # Log the command in different formats for better traceability
+            logging_service.ffmpeg_logger.info(f"[FFMPEG_{log_prefix.upper()}_START] {streamer_name} - {input_path} -> {output_path}")
+            logging_service.ffmpeg_logger.info(f"[FFMPEG_CMD] {' '.join(cmd)}")
+            logging_service.log_ffmpeg_start(f"{log_prefix}", cmd, streamer_name)
+            
+            operation_type = "METADATA_EMBED_START" if metadata_file else "REMUX_START"
+            logging_service.log_file_operation(operation_type, input_path, True, 
+                                             f"Starting {log_prefix} to {output_path} (Input size: {os.path.getsize(input_path)/1024/1024:.2f} MB)")
+            
+            # Log input file size and details
+            if os.path.exists(input_path):
+                input_size = os.path.getsize(input_path)
+                logging_service.ffmpeg_logger.info(f"Input file: {input_path}, size: {input_size} bytes ({input_size/1024/1024:.2f} MB)")
         
-        logger.debug(f"Starting FFmpeg remux: {' '.join(cmd)}")
+        logger.info(f"Starting FFmpeg {log_prefix if metadata_file else 'remux'}: {operation_id}")
+        logger.debug(f"Command: {' '.join(cmd)}")
         
-        # Set environment variable for FFmpeg report
+        # Set environment variable for FFmpeg report - ensure the directory exists
         env = os.environ.copy()
         if ffmpeg_log_path:
-            env["FFREPORT"] = f"file={ffmpeg_log_path}:level=32"
+            # Ensure the directory exists
+            log_dir = os.path.dirname(ffmpeg_log_path)
+            os.makedirs(log_dir, exist_ok=True)
+            
+            # Configure FFmpeg to create a detailed report - ensure higher log level
+            env["FFREPORT"] = f"file={ffmpeg_log_path}:level=40:append=true"
+            logger.info(f"FFmpeg log will be written to: {ffmpeg_log_path}")
         
         # Start the process
         process = await asyncio.create_subprocess_exec(
@@ -108,26 +174,99 @@ async def remux_file(
             env=env
         )
         
-        stdout, stderr = await process.communicate()
-        stdout_str = stdout.decode('utf-8', errors='ignore') if stdout else ""
-        stderr_str = stderr.decode('utf-8', errors='ignore') if stderr else ""
-        exit_code = process.returncode or 0
+        # Use a timeout to avoid hanging forever
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=7200)  # 2 hours timeout
+            stdout_str = stdout.decode('utf-8', errors='ignore') if stdout else ""
+            stderr_str = stderr.decode('utf-8', errors='ignore') if stderr else ""
+            exit_code = process.returncode or 0
+        except asyncio.TimeoutError:
+            logger.error(f"FFmpeg remux timed out after 2 hours: {input_path} to {output_path}")
+            if process:
+                try:
+                    process.kill()
+                except:
+                    pass
+            stdout_str = ""
+            stderr_str = "Process timed out after 2 hours"
+            exit_code = -1
         
         # Log the process output if logging service available
         if logging_service:
-            logging_service.log_ffmpeg_output("remux", stdout, stderr, exit_code, streamer_name)
+            log_prefix = "metadata" if metadata_file else "remux"
+            logging_service.log_ffmpeg_output(f"{log_prefix}_{timestamp_str}", stdout, stderr, exit_code, streamer_name)
         
-        success = exit_code == 0 and os.path.exists(output_path) and os.path.getsize(output_path) > 0
+        # Basic success check
+        basic_success = exit_code == 0 and os.path.exists(output_path) and os.path.getsize(output_path) > 0
         
-        if success:
-            logger.info(f"Successfully remuxed {input_path} to {output_path}")
+        # Additional validation if success
+        if basic_success:
+            output_size = os.path.getsize(output_path)
+            input_size = os.path.getsize(input_path) if os.path.exists(input_path) else 0
+            
+            # Log file sizes
             if logging_service:
-                logging_service.log_file_operation("REMUX_SUCCESS", output_path, True, f"Remuxed from {input_path}")
+                log_prefix = "Metadata embedding" if metadata_file else "Remux"
+                logging_service.ffmpeg_logger.info(
+                    f"{log_prefix} complete - Input: {input_size/1024/1024:.2f} MB, Output: {output_size/1024/1024:.2f} MB"
+                )
+            
+            # Calculate ratio for reasonable size check
+            size_ratio = output_size / input_size if input_size > 0 else 1
+            
+            if output_size < 1024 * 1024:  # Less than 1MB
+                logger.error(f"Output file is too small: {output_size} bytes")
+                if logging_service:
+                    operation_type = "METADATA_EMBED_FAILED" if metadata_file else "REMUX_FAILED"
+                    logging_service.log_file_operation(
+                        operation_type, output_path, False, f"Output file too small: {output_size} bytes"
+                    )
+                basic_success = False
+            elif input_size > 0 and size_ratio < 0.8:
+                logger.warning(
+                    f"Output file size ({output_size}) is significantly smaller than input ({input_size}), ratio: {size_ratio:.2f}"
+                )
+                if logging_service:
+                    logging_service.ffmpeg_logger.warning(
+                        f"Size ratio warning: {size_ratio:.2f} (input: {input_size}, output: {output_size})"
+                    )
+            
+            # Check if ffmpeg produced warnings about audio/video sync
+            if stderr_str and ("Non-monotonous DTS" in stderr_str or "Invalid timestamp" in stderr_str):
+                logger.warning(f"FFmpeg reported timestamp issues: {stderr_str[:200]}...")
+                if logging_service:
+                    logging_service.ffmpeg_logger.warning(f"Timestamp issues detected: check the log file for details")
+        
+        if basic_success:
+            log_prefix = "metadata embedding" if metadata_file else "remux"
+            logger.info(f"Successfully completed {log_prefix} {input_path} to {output_path}")
+            if logging_service:
+                operation_type = "METADATA_EMBED_SUCCESS" if metadata_file else "REMUX_SUCCESS"
+                logging_service.log_file_operation(
+                    operation_type, 
+                    output_path, 
+                    True, 
+                    f"Operation from {input_path}, output size: {os.path.getsize(output_path)/1024/1024:.2f} MB"
+                )
         else:
-            error_message = f"Failed to remux {input_path} to {output_path}: Exit code {exit_code}"
+            log_prefix = "metadata embedding" if metadata_file else "remux"
+            error_message = f"Failed to complete {log_prefix} {input_path} to {output_path}: Exit code {exit_code}"
             logger.error(error_message)
+            
+            # Log more detailed error information
+            if stderr_str:
+                # Extract the most relevant error messages (last few lines)
+                error_lines = stderr_str.splitlines()
+                relevant_errors = error_lines[-10:] if len(error_lines) > 10 else error_lines
+                error_summary = "\n".join(relevant_errors)
+                logger.error(f"FFmpeg error details: {error_summary}")
+            
             if logging_service:
-                logging_service.log_file_operation("REMUX_FAILED", output_path, False, error_message)
+                operation_type = "METADATA_EMBED_FAILED" if metadata_file else "REMUX_FAILED"
+                logging_service.log_file_operation(operation_type, output_path, False, error_message)
+        
+        # Set the success flag for return value
+        success = basic_success
         
         return {
             "success": success,

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -100,7 +100,7 @@ def generate_filename(
         "datetime": now.strftime("%Y-%m-%d_%H-%M-%S"),
         "id": stream_data.get("id", ""),
         "season": f"S{now.year}{now.month:02d}",  # Season without hyphen
-        "episode": f"E{episode}",  # Add prefix E to episode number
+        "episode": episode,  # Episode number without prefix, templates already include E
     }
 
     # Check if template is a preset name


### PR DESCRIPTION
This pull request introduces significant enhancements to the logging infrastructure and metadata services, focusing on log retention, organization, and integration with FFmpeg operations. The changes improve log management, streamline logging formats, and enhance the ability to debug FFmpeg processes. Below are the most important changes grouped by theme.

### Logging Infrastructure Enhancements:
* Added a log cleanup service to `async def lifespan(app: FastAPI)` in `app/main.py`, scheduling daily log cleanup tasks and handling errors during initialization.
* Introduced log retention settings in `LoggingService` for streamer-specific logs (14 days) and system logs (30 days), and implemented a cleanup mechanism for old logs based on these settings. [[1]](diffhunk://#diff-154a229f55d90debcde11bc5f4b422e9da1466cda5f75cba567b30455690b50aR23-R35) [[2]](diffhunk://#diff-154a229f55d90debcde11bc5f4b422e9da1466cda5f75cba567b30455690b50aL116-R266)
* Refactored log filenames to include streamer names, timestamps, and operation types for better organization and visual scanning. [[1]](diffhunk://#diff-154a229f55d90debcde11bc5f4b422e9da1466cda5f75cba567b30455690b50aL84-R109) [[2]](diffhunk://#diff-154a229f55d90debcde11bc5f4b422e9da1466cda5f75cba567b30455690b50aL116-R266)

### FFmpeg Logging Integration:
* Modified FFmpeg logging methods to require streamer names, ensuring logs are properly associated with streamers.
* Integrated FFmpeg log file creation into the `extract_thumbnail` method in `MetadataService`, redirecting FFmpeg output to unique log files and appending stdout/stderr content for better debugging.

### Codebase Improvements:
* Added missing imports (`copy`, `tempfile`) and updated existing imports for consistency across services. [[1]](diffhunk://#diff-0749819bdf8af8b75c01c6994fb51cb80182b99044068dfe68180d355df8b9feR6-R8) [[2]](diffhunk://#diff-0749819bdf8af8b75c01c6994fb51cb80182b99044068dfe68180d355df8b9feR19)
* Fixed minor syntax issues, such as semicolon usage in `import_manual_chapters`.