### PR TITLE
refactor: replace PostProcessingManager with PipelineManager in Recor…

### DIFF
--- a/app/services/recording/recording_service.py
+++ b/app/services/recording/recording_service.py
@@ -26,7 +26,7 @@ from app.services.recording.process_manager import ProcessManager
 from app.services.recording.recording_logger import RecordingLogger
 from app.services.recording.notification_manager import NotificationManager
 from app.services.recording.stream_info_manager import StreamInfoManager
-from app.services.recording.post_processing_manager import PostProcessingManager
+from app.services.recording.pipeline_manager import PipelineManager
 
 # Import utils
 from app.utils.path_utils import generate_filename
@@ -46,7 +46,7 @@ class RecordingService:
         self.recording_logger = RecordingLogger(config_manager=self.config_manager)
         self.notification_manager = NotificationManager(config_manager=self.config_manager)
         self.stream_info_manager = StreamInfoManager(config_manager=self.config_manager)
-        self.post_processing_manager = PostProcessingManager(config_manager=self.config_manager)
+        self.pipeline_manager = PipelineManager(config_manager=self.config_manager)
         
         # Active recordings tracking
         self.active_recordings = {}
@@ -314,7 +314,7 @@ class RecordingService:
                 
                 # Post-processing
                 try:
-                    processing_results = await self.post_processing_manager.process_completed_recording(
+                    processing_results = await self.pipeline_manager.start_post_processing_pipeline(
                         stream_id=stream.id,
                         ts_path=ts_output_path
                     )


### PR DESCRIPTION
This pull request refactors the `RecordingService` class to replace the `PostProcessingManager` with the `PipelineManager`. The changes streamline the recording post-processing workflow and ensure consistent naming conventions across the codebase.

### Refactoring to use `PipelineManager`:

* **Dependency Replacement**: Replaced the import of `PostProcessingManager` with `PipelineManager` in `app/services/recording/recording_service.py`.
* **Initialization Update**: Updated the `__init__` method of `RecordingService` to initialize `pipeline_manager` instead of `post_processing_manager`.
* **Method Update**: Modified the `_monitor_and_process_recording` method to use `pipeline_manager.start_post_processing_pipeline` instead of `post_processing_manager.process_completed_recording`.…dingService