### PR TITLE
refactor: remove DatabaseService and update exports for CategoryImage…

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -33,7 +33,6 @@ from app.services.settings_service import SettingsService
 from app.services.category_image_service import CategoryImageService
 from app.services.system_config_service import SystemConfigService
 from app.services.migration_service import MigrationService
-from app.services.database_service import DatabaseService
 from app.services.config_service import ConfigService
 from app.services.thumbnail_service import ThumbnailService
 from app.services.artwork_service import ArtworkService
@@ -45,9 +44,8 @@ __all__ = [
     "NotificationService",
     "MetadataService",
     "ConfigService",
-    "DatabaseService",
     "AuthService",
-    "CategoryImageService",  # Changed from CategoryService
+    "CategoryImageService",
     "MigrationService",
     "CleanupService",
     "EnhancedPushService",


### PR DESCRIPTION
This pull request removes the `DatabaseService` import and its corresponding entry from the `__all__` list in the `app/services/__init__.py` file. Additionally, it fixes a comment related to `CategoryImageService`.

Key changes:

### Removed `DatabaseService`:
* [`app/services/__init__.py`](diffhunk://#diff-2524ba0f7f7809da2ef4e1abca54bf82ae008986955a7d8cbb6f5e193c227b45L36): The import statement for `DatabaseService` was removed, along with its entry in the `__all__` list, indicating that this service is no longer part of the module's public API. [[1]](diffhunk://#diff-2524ba0f7f7809da2ef4e1abca54bf82ae008986955a7d8cbb6f5e193c227b45L36) [[2]](diffhunk://#diff-2524ba0f7f7809da2ef4e1abca54bf82ae008986955a7d8cbb6f5e193c227b45L48-R48)

### Comment correction:
* [`app/services/__init__.py`](diffhunk://#diff-2524ba0f7f7809da2ef4e1abca54bf82ae008986955a7d8cbb6f5e193c227b45L48-R48): The comment for `CategoryImageService` was corrected to remove "Changed from CategoryService," ensuring clarity and accuracy.…Service