### PR TITLE
fix: pass metadata to generate_nfo_file in generate_metadata_for_stream method

### DIFF
--- a/app/services/metadata_service.py
+++ b/app/services/metadata_service.py
@@ -70,7 +70,7 @@ class MetadataService:
                     # JSON metadata
                     self.generate_json_metadata(db, stream, streamer, base_path_obj, base_filename, metadata),
                     # NFO for media servers
-                    self.generate_nfo_file(db, stream, streamer, base_path_obj, base_filename),
+                    self.generate_nfo_file(db, stream, streamer, base_path_obj, base_filename, metadata),
                     # All chapter formats
                     self.ensure_all_chapter_formats(stream_id, base_path_obj / f"{base_filename}.mp4", db),
                     # Media server specific files (poster.jpg, etc.)


### PR DESCRIPTION
This pull request updates the `generate_metadata_for_stream` method in `metadata_service.py` to include metadata as an additional parameter when generating NFO files. This change ensures that NFO files are created with richer metadata content.

Key change:

* [`app/services/metadata_service.py`](diffhunk://#diff-0749819bdf8af8b75c01c6994fb51cb80182b99044068dfe68180d355df8b9feL73-R73): Updated the `generate_nfo_file` method call to include the `metadata` parameter, enhancing the NFO file generation process to incorporate metadata.…am method