### PR TITLE
Refactor streamer ID handling to ensure consistent type comparison in…

### DIFF
--- a/app/frontend/src/views/HomeView.vue
+++ b/app/frontend/src/views/HomeView.vue
@@ -44,7 +44,7 @@ async function fetchLastRecording() {
   const latestStream = endedStreams[0] || null
   lastRecording.value = latestStream
   if (latestStream) {
-    lastRecordingStreamer.value = streamers.value.find(s => s.id === latestStream.streamer_id)
+    lastRecordingStreamer.value = streamers.value.find(s => String(s.id) === String(latestStream.streamer_id))
   }
   isLoadingLastRecording.value = false
 }
@@ -59,7 +59,7 @@ watch(messages, (newMessages) => {
   switch (message.type) {
     case 'stream.online': {
       console.log('HomeView: Processing stream online:', message.data)
-      updateStreamer(message.data.streamer_id, {
+      updateStreamer(String(message.data.streamer_id), {
         is_live: true,
         title: message.data.title || '',
         category_name: message.data.category_name || '',
@@ -70,7 +70,7 @@ watch(messages, (newMessages) => {
     }
     case 'stream.offline': {
       console.log('HomeView: Processing stream offline:', message.data)
-      updateStreamer(message.data.streamer_id, {
+      updateStreamer(String(message.data.streamer_id), {
         is_live: false,
         last_updated: new Date().toISOString()
       })
@@ -79,7 +79,7 @@ watch(messages, (newMessages) => {
     case 'recording.started': {
       console.log('HomeView: Processing recording started:', message.data)
       const streamerId = Number(message.data.streamer_id)
-      const streamer = streamers.value.find(s => s.id === streamerId)
+      const streamer = streamers.value.find(s => String(s.id) === String(streamerId))
       if (streamer) {
         streamer.is_recording = true
       }
@@ -90,7 +90,7 @@ watch(messages, (newMessages) => {
     case 'recording.stopped': {
       console.log('HomeView: Processing recording stopped:', message.data)
       const streamerId = Number(message.data.streamer_id)
-      const streamer = streamers.value.find(s => s.id === streamerId)
+      const streamer = streamers.value.find(s => String(s.id) === String(streamerId))
       if (streamer) {
         streamer.is_recording = false
       }


### PR DESCRIPTION
This pull request makes several changes to improve consistency in type handling for streamer IDs in the `HomeView.vue` file. Specifically, it ensures that streamer IDs are consistently compared as strings, addressing potential mismatches caused by type differences.

Changes to type handling for streamer IDs:

* [`fetchLastRecording`](diffhunk://#diff-a8c35b8258bb019ccf72da14097f4b838d789b8d23977b4483da59c6eb463059L47-R47): Updated the comparison of `streamer_id` to use `String()` for both sides, ensuring type consistency when finding the last recording streamer.
* `watch(messages, (newMessages) => {`:
  * For `stream.online` and `stream.offline` messages, modified the `updateStreamer` calls to convert `streamer_id` to a string before passing it, ensuring consistent handling. [[1]](diffhunk://#diff-a8c35b8258bb019ccf72da14097f4b838d789b8d23977b4483da59c6eb463059L62-R62) [[2]](diffhunk://#diff-a8c35b8258bb019ccf72da14097f4b838d789b8d23977b4483da59c6eb463059L73-R73)
  * For `recording.started` and `recording.stopped` messages, updated the `streamers.value.find` calls to compare `streamer_id` as strings, resolving potential type mismatches. [[1]](diffhunk://#diff-a8c35b8258bb019ccf72da14097f4b838d789b8d23977b4483da59c6eb463059L82-R82) [[2]](diffhunk://#diff-a8c35b8258bb019ccf72da14097f4b838d789b8d23977b4483da59c6eb463059L93-R93)… fetchLastRecording and WebSocket message processing