### PR TITLE
Fix IndentationError in twitch_auth_service.py

### DIFF
--- a/app/services/twitch_auth_service.py
+++ b/app/services/twitch_auth_service.py
@@ -94,27 +94,22 @@ class TwitchAuthService:
         """Get a page of followed channels using the new API endpoint"""
         try:
             follows = await twitch_api.get_user_followed_streamers(user_id, access_token)
-                        pagination = data.get("pagination", {})
-                        next_cursor = pagination.get("cursor")
-                        
-                        # Debug logging 
-                        logger.debug(f"Successfully fetched {len(follows)} followed channels")
-                        
-                        # Extract broadcaster info
-                        streamers = []
-                        for follow in follows:
-                            streamer = {
-                                "id": follow["broadcaster_id"],
-                                "login": follow["broadcaster_login"],
-                                "display_name": follow["broadcaster_name"]
-                            }
-                            streamers.append(streamer)
-                            
-                        return streamers, next_cursor
-                    else:
-                        error_text = await response.text()
-                        logger.error(f"Failed to get follows: {response.status} - {error_text}")
-                        return [], None
+            
+            # Debug logging 
+            logger.debug(f"Successfully fetched {len(follows)} followed channels")
+            
+            # Extract broadcaster info
+            streamers = []
+            for follow in follows:
+                streamer = {
+                    "id": follow["broadcaster_id"],
+                    "login": follow["broadcaster_login"],
+                    "display_name": follow["broadcaster_name"]
+                }
+                streamers.append(streamer)
+                
+            return streamers, None  # No pagination cursor since we get all at once
+            
         except Exception as e:
             logger.error(f"Error getting follows page: {e}")
             return [], None


### PR DESCRIPTION
This pull request simplifies the `_get_follows_page` method in `twitch_auth_service.py` by removing pagination handling and assuming all followed streamers are fetched in a single call.

Changes to pagination handling:

* [`app/services/twitch_auth_service.py`](diffhunk://#diff-7e2450b77f186f7573a4e873421405f490d659defb1411255b2de177df9346c3L97-L98): Removed the logic for extracting the pagination cursor (`next_cursor`) from the response, as the method now assumes all followed streamers are fetched in one call.
* [`app/services/twitch_auth_service.py`](diffhunk://#diff-7e2450b77f186f7573a4e873421405f490d659defb1411255b2de177df9346c3L113-R112): Updated the return statement to always return `None` for the pagination cursor, reflecting the removal of pagination support.- Remove duplicate and incorrectly indented code lines