### PR TITLE
refactor: Separate Twitch services for cleaner architecture

### DIFF
--- a/app/routes/twitch_auth.py
+++ b/app/routes/twitch_auth.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import RedirectResponse
-from app.services.twitch_auth_service import TwitchAuthService
+from app.services.twitch_oauth_service import TwitchOAuthService
 from app.services.streamer_service import StreamerService
 from app.dependencies import get_streamer_service
 from typing import List, Dict, Any
@@ -10,30 +10,30 @@ logger = logging.getLogger("streamvault")
 
 router = APIRouter(
     prefix="/api/twitch",
-    tags=["twitch-auth"]
+    tags=["twitch-oauth"]
 )
 
-def get_twitch_auth_service(
+def get_twitch_oauth_service(
     streamer_service: StreamerService = Depends(get_streamer_service)
-) -> TwitchAuthService:
-    return TwitchAuthService(streamer_service)
+) -> TwitchOAuthService:
+    return TwitchOAuthService(streamer_service)
 
 @router.get("/auth-url")
 async def get_twitch_auth_url(
-    auth_service: TwitchAuthService = Depends(get_twitch_auth_service)
+    oauth_service: TwitchOAuthService = Depends(get_twitch_oauth_service)
 ):
     """Get Twitch OAuth authorization URL"""
-    auth_url = auth_service.get_auth_url()
+    auth_url = oauth_service.get_auth_url()
     return {"auth_url": auth_url}
 
 @router.get("/callback")
 async def twitch_callback(
     code: str = Query(...),
-    auth_service: TwitchAuthService = Depends(get_twitch_auth_service)
+    oauth_service: TwitchOAuthService = Depends(get_twitch_oauth_service)
 ):
     """Handle Twitch OAuth callback"""
     # Exchange code for access token
-    token_data = await auth_service.exchange_code(code)
+    token_data = await oauth_service.exchange_code(code)
     
     if not token_data or "access_token" not in token_data:
         logger.error("Failed to get access token from Twitch")
@@ -50,12 +50,12 @@ async def twitch_callback(
 @router.get("/followed-channels")
 async def get_followed_channels(
     access_token: str = Query(...),
-    auth_service: TwitchAuthService = Depends(get_twitch_auth_service)
+    oauth_service: TwitchOAuthService = Depends(get_twitch_oauth_service)
 ):
     """Get channels that the authenticated user follows"""
     logger.debug(f"Fetching followed channels with access token: {access_token[:10]}...")
     
-    followed_channels = await auth_service.get_user_followed_channels(access_token)
+    followed_channels = await oauth_service.get_user_followed_channels(access_token)
     
     if followed_channels is None:
         logger.error("Invalid access token or failed to fetch channels")
@@ -66,13 +66,13 @@ async def get_followed_channels(
 @router.post("/import-streamers")
 async def import_streamers(
     streamers: List[Dict[str, Any]],
-    auth_service: TwitchAuthService = Depends(get_twitch_auth_service)
+    oauth_service: TwitchOAuthService = Depends(get_twitch_oauth_service)
 ):
     """Import selected streamers from followed channels"""
     if not streamers:
         raise HTTPException(status_code=400, detail="No streamers provided")
         
-    results = await auth_service.import_followed_streamers(streamers)
+    results = await oauth_service.import_followed_streamers(streamers)
     return results
 
 @router.get("/callback-url")

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -34,7 +34,7 @@ from app.services.migration_service import MigrationService
 from app.services.thumbnail_service import ThumbnailService
 from app.services.artwork_service import ArtworkService
 from app.services.system_config_service import SystemConfigService
-from app.services.twitch_auth_service import TwitchAuthService
+from app.services.twitch_oauth_service import TwitchOAuthService
 from app.services.webpush_service import ModernWebPushService  # Changed to correct class name
 from app.services.websocket_manager import ConnectionManager
 from app.services.unified_image_service import UnifiedImageService
@@ -54,7 +54,7 @@ __all__ = [
     "ThumbnailService",
     "ArtworkService",
     "SystemConfigService",
-    "TwitchAuthService",
+    "TwitchOAuthService",
     "ModernWebPushService",  # Changed from WebPushService
     "ConnectionManager",
     "UnifiedImageService",


### PR DESCRIPTION
- Rename twitch_auth_service.py → twitch_oauth_service.py for clarity
- Update TwitchAuthService → TwitchOAuthService class name
- OAuth service now focuses solely on user authentication and follower import
- General Twitch API calls remain in twitch_api.py with app credentials
- Update all imports and references to use new service naming
- Remove old auth service file to eliminate confusion

This separation provides:
- twitch_api.py: General API calls with app-level authentication
- twitch_oauth_service.py: User OAuth flows for follower import only
- twitch_auth.py routes: HTTP endpoints for OAuth callbacks

Follower import functionality in TwitchImportForm.vue is preserved and should work exactly as before.