### PR TITLE
Optimize workflow

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -248,7 +248,7 @@ class Settings(BaseSettings):
             if not self.VAPID_PUBLIC_KEY or not self.VAPID_PRIVATE_KEY:
                 # Import here to avoid circular imports and check if database is ready
                 try:
-                    from app.services.system_config_service import system_config_service
+                    from app.services.system.system_config_service import system_config_service
                     
                     # Try to load from database
                     stored_keys = system_config_service.get_vapid_keys()
@@ -307,7 +307,7 @@ class Settings(BaseSettings):
                 
                 # Store in database for persistence
                 try:
-                    from app.services.system_config_service import system_config_service
+                    from app.services.system.system_config_service import system_config_service
                     system_config_service.set_vapid_keys(
                         public_key, 
                         private_key, 

--- a/app/routes/categories.py
+++ b/app/routes/categories.py
@@ -160,7 +160,7 @@ async def preload_category_images(
     try:
         # Start the preloading in the background
         # Use unified image service for category sync
-        from app.services.image_sync_service import image_sync_service
+        from app.services.images.image_sync_service import image_sync_service
         for category_name in category_names:
             background_tasks.add_task(unified_image_service.download_category_image, category_name)
         

--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -56,7 +56,7 @@ async def get_videos(request: Request, db: Session = Depends(get_db)):
         raise HTTPException(status_code=401, detail="Authentication required")
     
     # Validate session
-    from app.services.auth_service import AuthService
+    from app.services.core.auth_service import AuthService
     auth_service = AuthService(db)
     if not await auth_service.validate_session(session_token):
         raise HTTPException(status_code=401, detail="Invalid session")
@@ -136,7 +136,7 @@ async def debug_video_access(stream_id: int, request: Request, db: Session = Dep
         logger.info(f"DEBUG: Session token found: {session_token[:20]}...")
         
         # Validate session
-        from app.services.auth_service import AuthService
+        from app.services.core.auth_service import AuthService
         auth_service = AuthService(db)
         session_valid = await auth_service.validate_session(session_token)
         logger.info(f"DEBUG: Session validation result: {session_valid}")
@@ -206,7 +206,7 @@ async def stream_video_by_id(stream_id: int, request: Request, db: Session = Dep
         
         # Validate session
         try:
-            from app.services.auth_service import AuthService
+            from app.services.core.auth_service import AuthService
             auth_service = AuthService(db)
             session_valid = await auth_service.validate_session(session_token)
             logger.info(f"Session validation result: {session_valid}")
@@ -330,7 +330,7 @@ async def stream_video(streamer_name: str, filename: str, request: Request, db: 
             raise HTTPException(status_code=401, detail="Authentication required")
         
         # Validate session
-        from app.services.auth_service import AuthService
+        from app.services.core.auth_service import AuthService
         auth_service = AuthService(db)
         if not await auth_service.validate_session(session_token):
             raise HTTPException(status_code=401, detail="Invalid session")
@@ -448,7 +448,7 @@ async def get_streamer_videos(streamer_name: str, request: Request, db: Session 
             raise HTTPException(status_code=401, detail="Authentication required")
         
         # Validate session
-        from app.services.auth_service import AuthService
+        from app.services.core.auth_service import AuthService
         auth_service = AuthService(db)
         if not await auth_service.validate_session(session_token):
             raise HTTPException(status_code=401, detail="Invalid session")
@@ -530,7 +530,7 @@ async def debug_video_access(stream_id: int, request: Request, db: Session = Dep
         logger.info(f"DEBUG: Session token found: {session_token[:20]}...")
         
         # Validate session
-        from app.services.auth_service import AuthService
+        from app.services.core.auth_service import AuthService
         auth_service = AuthService(db)
         session_valid = await auth_service.validate_session(session_token)
         logger.info(f"DEBUG: Session validation result: {session_valid}")
@@ -590,7 +590,7 @@ async def get_videos_by_streamer(streamer_id: int, request: Request, db: Session
         raise HTTPException(status_code=401, detail="Authentication required")
     
     # Validate session
-    from app.services.auth_service import AuthService
+    from app.services.core.auth_service import AuthService
     auth_service = AuthService(db)
     if not await auth_service.validate_session(session_token):
         raise HTTPException(status_code=401, detail="Invalid session")
@@ -663,7 +663,7 @@ async def stream_video_by_filename(filename: str, request: Request, db: Session 
             raise HTTPException(status_code=401, detail="Authentication required")
         
         # Validate session
-        from app.services.auth_service import AuthService
+        from app.services.core.auth_service import AuthService
         auth_service = AuthService(db)
         if not await auth_service.validate_session(session_token):
             raise HTTPException(status_code=401, detail="Invalid session")
@@ -782,7 +782,7 @@ async def test_video_access(stream_id: int, request: Request, db: Session = Depe
         
         if session_token:
             # Test session validation
-            from app.services.auth_service import AuthService
+            from app.services.core.auth_service import AuthService
             auth_service = AuthService(db)
             session_valid = await auth_service.validate_session(session_token)
             logger.info(f"Session valid: {session_valid}")

--- a/app/services/media/metadata_service.py
+++ b/app/services/media/metadata_service.py
@@ -1553,7 +1553,7 @@ class MetadataService:
             mp4_path_obj = Path(mp4_path)
             
             # Import logging service
-            from app.services.logging_service import logging_service
+            from app.services.system.logging_service import logging_service
             
             # Validate source file exists and has reasonable size
             if not mp4_path_obj.exists():

--- a/app/services/media/thumbnail_service.py
+++ b/app/services/media/thumbnail_service.py
@@ -267,7 +267,7 @@ class ThumbnailService:
                         
                         try:
                             # Use the logging service to create per-streamer logs
-                            from app.services.logging_service import logging_service
+                            from app.services.system.logging_service import logging_service
                             if logging_service:
                                 streamer_log_path = logging_service.log_ffmpeg_start("thumbnail_extract", cmd, streamer.name)
                                 logger.info(f"FFmpeg logs will be written to: {streamer_log_path}")

--- a/app/services/processing/post_processing_task_handlers.py
+++ b/app/services/processing/post_processing_task_handlers.py
@@ -26,7 +26,7 @@ class PostProcessingTaskHandlers:
         
         # Initialize logging service
         try:
-            from app.services.logging_service import logging_service
+            from app.services.system.logging_service import logging_service
             self.logging_service = logging_service
         except Exception as e:
             logger.warning(f"Could not initialize logging service: {e}")

--- a/app/services/recording/recording_orchestrator.py
+++ b/app/services/recording/recording_orchestrator.py
@@ -53,7 +53,7 @@ class RecordingOrchestrator:
         
         # Initialize logging service
         try:
-            from app.services.logging_service import logging_service
+            from app.services.system.logging_service import logging_service
             self.logging_service = logging_service
         except Exception as e:
             logger.warning(f"Could not initialize logging service: {e}")


### PR DESCRIPTION
This pull request refactors import paths across multiple files to improve modularity and organization in the codebase. The changes primarily involve moving services into more specific subdirectories within the `app.services` package, such as `system`, `images`, and `core`. These updates enhance code clarity and maintainability by grouping related services logically.

### Refactoring of import paths:

#### System services:
* Updated the import path for `system_config_service` in `app/config/settings.py` to `app.services.system.system_config_service` for better alignment with other system-related services. [[1]](diffhunk://#diff-b855bb64e5796dfbc5e1297b782bc0e3542252a82e7622120fff29913e099d45L251-R251) [[2]](diffhunk://#diff-b855bb64e5796dfbc5e1297b782bc0e3542252a82e7622120fff29913e099d45L310-R310)
* Changed the import path for `logging_service` in files such as `app/services/media/metadata_service.py`, `app/services/media/thumbnail_service.py`, `app/services/processing/post_processing_task_handlers.py`, and `app/services/recording/recording_orchestrator.py` to `app.services.system.logging_service` for consistency. [[1]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L1556-R1556) [[2]](diffhunk://#diff-f15c15da75910636e8163b399851f57b6d0fe5efc8cb6caed942f831799ed636L270-R270) [[3]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2L29-R29) [[4]](diffhunk://#diff-a1663db1cdcc438a61b559fce01aa1d33ba989cb7dd1b12f65daf9cc26c747f5L56-R56)

#### Image services:
* Updated the import path for `image_sync_service` in `app/routes/categories.py` to `app.services.images.image_sync_service` to reflect its role in image-related operations.

#### Core services:
* Refactored the import path for `AuthService` across multiple endpoints in `app/routes/videos.py` to `app.services.core.auth_service` for clearer categorization under core functionality. [[1]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L59-R59) [[2]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L139-R139) [[3]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L209-R209) [[4]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L333-R333) [[5]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L451-R451) [[6]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L533-R533) [[7]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L593-R593) [[8]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L666-R666) [[9]](diffhunk://#diff-4caa21fec61b098caeeb625db0a7a6c267317e4e393a62dfa5245804e6e34977L785-R785)