### PR TITLE
fix: Update logging service import path for streamlink command stability

### DIFF
--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -124,7 +124,7 @@ def get_streamlink_command(
     if not log_path:
         # Lazy import to avoid circular dependencies
         from importlib import import_module
-        logging_service = import_module("app.services.logging_service").logging_service
+        logging_service = import_module("app.services.system.logging_service").logging_service
         log_path = logging_service.get_streamlink_log_path(streamer_name)
     
     # Core streamlink command with enhanced stability parameters


### PR DESCRIPTION
This pull request updates the `get_streamlink_command` function in `app/utils/streamlink_utils.py` to fix a module path issue for the logging service.

Dependency path update:

* [`app/utils/streamlink_utils.py`](diffhunk://#diff-9c8c99638a7910c64a1331c9a0f7c18bd4b257e1b9c733b807a8efd95687d340L127-R127): Changed the import path for the `logging_service` module from `app.services.logging_service` to `app.services.system.logging_service` to resolve a module organization issue.