### PR TITLE
refactor: Replace log_request middleware with direct logging in delete_stream function

### DIFF
--- a/app/routes/streams.py
+++ b/app/routes/streams.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import Stream, StreamMetadata, Recording, StreamEvent, ActiveRecordingState
-from app.middleware.logging import log_request
 from app.services.system.background_queue_service import get_background_queue_service
 import logging
 
@@ -20,7 +19,7 @@ async def delete_stream(
     db: Session = Depends(get_db)
 ):
     """Delete a specific stream and all associated metadata"""
-    log_request(request, logger)
+    logger.info(f"Request {request.method} {request.url.path}")
     
     try:
         # Check if the stream exists


### PR DESCRIPTION
This pull request includes changes to streamline logging in the `delete_stream` route by removing the `log_request` middleware and replacing it with direct logging using `logger.info`.

Logging updates:

* [`app/routes/streams.py`](diffhunk://#diff-a8ee39080390545a9cff622e71190471a9501f577e53cab6fd57c907f68ec214L5): Removed the import for `log_request` from `app.middleware.logging` as it is no longer used.
* [`app/routes/streams.py`](diffhunk://#diff-a8ee39080390545a9cff622e71190471a9501f577e53cab6fd57c907f68ec214L23-R22): Replaced the `log_request` middleware call with a direct `logger.info` statement to log the request method and URL path in the `delete_stream` function.