### PR TITLE
fix: Correct import for background queue service in streams.py

### DIFF
--- a/app/routes/streams.py
+++ b/app/routes/streams.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import Stream, StreamMetadata, Recording, StreamEvent, ActiveRecordingState
-from app.services.system.background_queue_service import get_background_queue_service
+from app.services.background_queue_service import background_queue_service
 import logging
 
 logger = logging.getLogger("streamvault")
@@ -69,7 +69,7 @@ async def delete_stream(
         
         # Schedule file deletion in background
         if files_to_delete:
-            background_queue = get_background_queue_service()
+            background_queue = background_queue_service
             await background_queue.add_task(
                 "cleanup",
                 {


### PR DESCRIPTION
This pull request updates the `app/routes/streams.py` file to simplify the usage of the background queue service by directly referencing the `background_queue_service` instance instead of calling the `get_background_queue_service` function.

Code simplification:

* [`app/routes/streams.py`](diffhunk://#diff-a8ee39080390545a9cff622e71190471a9501f577e53cab6fd57c907f68ec214L5-R5): Replaced the `get_background_queue_service` function with the direct use of the `background_queue_service` instance for scheduling background tasks. This change was made both in the import statement and within the `delete_stream` function. [[1]](diffhunk://#diff-a8ee39080390545a9cff622e71190471a9501f577e53cab6fd57c907f68ec214L5-R5) [[2]](diffhunk://#diff-a8ee39080390545a9cff622e71190471a9501f577e53cab6fd57c907f68ec214L72-R72)