### PR TITLE
fix: Update supported video extensions for filename cleanup in recording lifecycle manager

### DIFF
--- a/app/services/recording/recording_lifecycle_manager.py
+++ b/app/services/recording/recording_lifecycle_manager.py
@@ -24,6 +24,9 @@ class RecordingLifecycleManager:
     SEGMENT_DIR_SUFFIX = "_segments"
     SEGMENT_PART_IDENTIFIER = "_part"
     
+    # Supported video extensions for filename cleanup
+    SUPPORTED_VIDEO_EXTENSIONS = ['.mp4', '.ts', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.webm']
+    
     def __init__(self, config_manager=None, process_manager=None, 
                  database_service=None, websocket_service=None, state_manager=None):
         self.config_manager = config_manager
@@ -412,9 +415,10 @@ class RecordingLifecycleManager:
             
             # Clean up filename and add .ts extension
             # Remove any existing video extensions from the filename
-            for ext in ['.mp4', '.ts', '.mkv', '.avi', '.mov']:
+            for ext in self.SUPPORTED_VIDEO_EXTENSIONS:
                 if filename.endswith(ext):
                     filename = filename[:-len(ext)]
+                    break  # Stop after first match to avoid unnecessary iterations
             
             # Add .ts extension
             filename += '.ts'


### PR DESCRIPTION
This pull request enhances the `RecordingLifecycleManager` class by improving video filename cleanup functionality. The changes introduce a centralized list of supported video extensions and optimize the filename cleanup logic.

### Improvements to video filename cleanup:

* [`app/services/recording/recording_lifecycle_manager.py`](diffhunk://#diff-69e1ea3a9312285e5a2d66a6397d3b9f60ed4a468a50f17d7966ed0bc0b2d936R27-R29): Added a class-level constant `SUPPORTED_VIDEO_EXTENSIONS` containing a comprehensive list of supported video file extensions for filename cleanup.
* [`app/services/recording/recording_lifecycle_manager.py`](diffhunk://#diff-69e1ea3a9312285e5a2d66a6397d3b9f60ed4a468a50f17d7966ed0bc0b2d936L415-R421): Updated the `_generate_recording_path` method to use the new `SUPPORTED_VIDEO_EXTENSIONS` list and added a `break` statement to stop iteration after the first match, improving efficiency.