### PR TITLE
fix: Improve handling of active recordings in WebSocket message processing

### DIFF
--- a/app/frontend/src/composables/useRecordingSettings.ts
+++ b/app/frontend/src/composables/useRecordingSettings.ts
@@ -33,12 +33,43 @@ export function useRecordingSettings() {
         }
       } else if (latestMessage.type === 'recording_started') {
         
-        // Refresh active recordings or add the new recording
-        fetchActiveRecordings();
-      } else if (latestMessage.type === 'recording_stopped') {
+        // Add the new recording to active recordings
+        if (latestMessage.data) {
+          const newRecording = {
+            ...latestMessage.data,
+            streamer_id: parseInt(latestMessage.data.streamer_id.toString())
+          };
+          
+          // Check if recording already exists to avoid duplicates
+          const existingIndex = activeRecordings.value.findIndex(
+            rec => rec.recording_id === newRecording.recording_id
+          );
+          
+          if (existingIndex === -1) {
+            activeRecordings.value.push(newRecording);
+          } else {
+            // Update existing recording
+            activeRecordings.value[existingIndex] = newRecording;
+          }
+        }
+      } else if (latestMessage.type === 'recording_stopped' || latestMessage.type === 'recording_status_update') {
+        
+        // Handle recording stopped or status update
+        if (latestMessage.type === 'recording_status_update') {
+          // For status updates, only remove if status indicates recording is no longer active
+          const inactiveStatuses = ['completed', 'failed', 'stopped', 'cancelled'];
+          if (!inactiveStatuses.includes(latestMessage.data?.status)) {
+            return; // Recording is still active, don't remove from list
+          }
+        }
         
         // Remove the recording from active recordings
-        if (latestMessage.data?.streamer_id) {
+        if (latestMessage.data?.recording_id) {
+          activeRecordings.value = activeRecordings.value.filter(
+            rec => rec.recording_id !== latestMessage.data.recording_id
+          );
+        } else if (latestMessage.data?.streamer_id) {
+          // Fallback to streamer_id if recording_id not available
           activeRecordings.value = activeRecordings.value.filter(
             rec => rec.streamer_id !== latestMessage.data.streamer_id
           );


### PR DESCRIPTION
This pull request refines the handling of active recordings in the `useRecordingSettings` composable. Key updates include improved logic for adding, updating, and removing recordings based on incoming messages, as well as handling recording status updates.

### Updates to recording management:

* Enhanced logic to add or update recordings:
  - New recordings are added to the `activeRecordings` list, ensuring no duplicates by checking `recording_id`.
  - Existing recordings are updated if a matching `recording_id` is found. (`[app/frontend/src/composables/useRecordingSettings.tsL36-R72](diffhunk://#diff-e4c41421d87a9a8e8ef2462a47710b0738c7c5f8dbbcf7f77ee66f1bc0d9b79fL36-R72)`)

* Improved handling of recording removal:
  - Recordings are removed based on `recording_id` or fallback to `streamer_id` if `recording_id` is unavailable. (`[app/frontend/src/composables/useRecordingSettings.tsL36-R72](diffhunk://#diff-e4c41421d87a9a8e8ef2462a47710b0738c7c5f8dbbcf7f77ee66f1bc0d9b79fL36-R72)`)

* Added support for recording status updates:
  - Status updates are processed to remove recordings only if their status indicates inactivity (e.g., `completed`, `failed`, `stopped`, `cancelled`). (`[app/frontend/src/composables/useRecordingSettings.tsL36-R72](diffhunk://#diff-e4c41421d87a9a8e8ef2462a47710b0738c7c5f8dbbcf7f77ee66f1bc0d9b79fL36-R72)`)