### PR TITLE
fix: Enable comparison and equality for QueueTask to support priorityordering

### DIFF
--- a/app/services/queues/task_progress_tracker.py
+++ b/app/services/queues/task_progress_tracker.py
@@ -43,6 +43,19 @@ class QueueTask:
     max_retries: int = 3
     progress: float = 0.0
     
+    def __lt__(self, other):
+        """Enable comparison for PriorityQueue"""
+        if not isinstance(other, QueueTask):
+            return NotImplemented
+        # Compare by created_at timestamp for FIFO ordering of same priority tasks
+        return self.created_at < other.created_at
+    
+    def __eq__(self, other):
+        """Enable equality comparison"""
+        if not isinstance(other, QueueTask):
+            return NotImplemented
+        return self.id == other.id
+    
     def to_dict(self) -> Dict[str, Any]:
         """Convert task to dictionary for serialization"""
         return {


### PR DESCRIPTION
This pull request adds comparison methods to the `QueueTask` class to enhance its compatibility with `PriorityQueue` and enable equality checks. These changes improve task ordering and comparison functionality.

Enhancements to `QueueTask` class:

* [`app/services/queues/task_progress_tracker.py`](diffhunk://#diff-d93055fc9ef89c587aa9f1495bdeabab634c2aa3f8e1532efb3de0a2fc7d5effR46-R58): Added the `__lt__` method to allow FIFO ordering of tasks with the same priority based on their `created_at` timestamp.
* [`app/services/queues/task_progress_tracker.py`](diffhunk://#diff-d93055fc9ef89c587aa9f1495bdeabab634c2aa3f8e1532efb3de0a2fc7d5effR46-R58): Added the `__eq__` method to enable equality comparison of tasks based on their `id`.