### PR TITLE
Optimize workflow

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -38,12 +38,9 @@ from app.services.api.twitch_oauth_service import TwitchOAuthService
 from app.services.communication.webpush_service import ModernWebPushService  # Changed to correct class name
 from app.services.communication.websocket_manager import ConnectionManager
 from app.services.unified_image_service import UnifiedImageService
-try:
-    from app.services.process_monitor import ProcessMonitor, process_monitor
-except ImportError:
-    # ProcessMonitor not available, disable process monitoring
-    ProcessMonitor = None
-    process_monitor = None
+# ProcessMonitor integration temporarily disabled for stability
+ProcessMonitor = None
+process_monitor = None
 
 __all__ = [
     "LoggingService",

--- a/app/services/background_queue_service.py
+++ b/app/services/background_queue_service.py
@@ -18,11 +18,8 @@ from .queues.task_progress_tracker import QueueTask, TaskStatus, TaskPriority
 
 logger = logging.getLogger("streamvault")
 
-try:
-    from .process_monitor import process_monitor
-except ImportError:
-    logger.warning("ProcessMonitor not available, process monitoring disabled")
-    process_monitor = None
+# ProcessMonitor integration temporarily disabled for stability
+process_monitor = None
 
 
 class BackgroundQueueService:
@@ -51,9 +48,9 @@ class BackgroundQueueService:
         self.is_running = self.queue_manager.is_running
         self.dependency_worker = self.queue_manager.dependency_worker
         
-        # Start process monitor
-        if process_monitor:
-            await process_monitor.start()
+        # Start process monitor - temporarily disabled
+        # if process_monitor:
+        #     await process_monitor.start()
 
     async def stop(self):
         """Stop the background queue service"""
@@ -61,9 +58,9 @@ class BackgroundQueueService:
         self.is_running = self.queue_manager.is_running
         self.dependency_worker = self.queue_manager.dependency_worker
         
-        # Stop process monitor
-        if process_monitor:
-            await process_monitor.stop()
+        # Stop process monitor - temporarily disabled
+        # if process_monitor:
+        #     await process_monitor.stop()
 
     def register_task_handler(self, task_type: str, handler: Callable):
         """Register a handler for a specific task type"""
@@ -151,12 +148,12 @@ class BackgroundQueueService:
         """Send queue statistics via WebSocket"""
         await self.queue_manager.send_queue_statistics()
         
-        # Also send process monitor statistics
-        if process_monitor:
-            try:
-                await process_monitor.send_system_status()
-            except Exception as e:
-                logger.warning(f"Could not send process monitor stats: {e}")
+        # Also send process monitor statistics - temporarily disabled
+        # if process_monitor:
+        #     try:
+        #         await process_monitor.send_system_status()
+        #     except Exception as e:
+        #         logger.warning(f"Could not send process monitor stats: {e}")
 
     # External task tracking methods
     

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -17,9 +17,13 @@ from app.utils.streamlink_utils import get_streamlink_command, get_proxy_setting
 from app.services.recording.exceptions import ProcessError, StreamUnavailableError
 from app.models import Stream
 from app.utils import async_file
-from app.services.process_monitor import process_monitor, ProcessType, ProcessStatus
 
 logger = logging.getLogger("streamvault")
+
+# ProcessMonitor integration temporarily disabled for stability
+process_monitor = None
+ProcessType = None
+ProcessStatus = None
 
 class ProcessManager:
     """Manages subprocess execution and cleanup for recording processes"""
@@ -173,20 +177,21 @@ class ProcessManager:
                 'process_pid': process.pid
             })
             
-            # Register process with ProcessMonitor
-            await process_monitor.register_process(
-                process_id=f"streamlink_{stream.id}_{segment_info['segment_count']}",
-                process_type=ProcessType.STREAMLINK,
-                pid=process.pid,
-                command=' '.join(cmd),
-                streamer_id=stream.streamer_id,
-                stream_id=stream.id,
-                metadata={
-                    'segment_path': segment_path,
-                    'segment_count': segment_info['segment_count'],
-                    'quality': quality
-                }
-            )
+            # Register process with ProcessMonitor - temporarily disabled
+            # if process_monitor and ProcessType:
+            #     await process_monitor.register_process(
+            #         process_id=f"streamlink_{stream.id}_{segment_info['segment_count']}",
+            #         process_type=ProcessType.STREAMLINK,
+            #         pid=process.pid,
+            #         command=' '.join(cmd),
+            #         streamer_id=stream.streamer_id,
+            #         stream_id=stream.id,
+            #         metadata={
+            #             'segment_path': segment_path,
+            #             'segment_count': segment_info['segment_count'],
+            #             'quality': quality
+            #         }
+            #     )
                 
             logger.info(f"Started segment recording for stream {stream.id} with PID {process.pid}")
             return process

--- a/app/services/recording/recording_orchestrator.py
+++ b/app/services/recording/recording_orchestrator.py
@@ -21,7 +21,9 @@ from app.services.recording.process_manager import ProcessManager
 from app.services.recording.recording_logger import RecordingLogger
 from app.services.recording.notification_manager import NotificationManager
 from app.services.recording.stream_info_manager import StreamInfoManager
-from app.services.process_monitor import process_monitor
+
+# ProcessMonitor integration temporarily disabled for stability
+process_monitor = None
 
 logger = logging.getLogger("streamvault")
 


### PR DESCRIPTION
This pull request temporarily disables the integration with `ProcessMonitor` across several services for stability purposes. The changes involve removing or commenting out the usage of `ProcessMonitor` while maintaining placeholders to ensure the codebase remains functional without it.

### Disabling `ProcessMonitor` Integration:

* [`app/services/__init__.py`](diffhunk://#diff-2524ba0f7f7809da2ef4e1abca54bf82ae008986955a7d8cbb6f5e193c227b45L41-R41): Removed the import of `ProcessMonitor` and replaced it with a `None` assignment, along with a comment explaining the temporary disablement.
* [`app/services/background_queue_service.py`](diffhunk://#diff-49ef0879f7f18e7952e5d18b78bf49a865c93046c8dbf5f69417006ba5699d45L21-R21): Commented out the initialization, start, stop, and statistics reporting of `ProcessMonitor` in multiple methods (`start`, `stop`, and `send_queue_statistics`). Added a placeholder with `None` for `process_monitor`. [[1]](diffhunk://#diff-49ef0879f7f18e7952e5d18b78bf49a865c93046c8dbf5f69417006ba5699d45L21-R21) [[2]](diffhunk://#diff-49ef0879f7f18e7952e5d18b78bf49a865c93046c8dbf5f69417006ba5699d45L54-R63) [[3]](diffhunk://#diff-49ef0879f7f18e7952e5d18b78bf49a865c93046c8dbf5f69417006ba5699d45L154-R156)
* [`app/services/recording/process_manager.py`](diffhunk://#diff-06af1a08771daacaa8ed6280e972bdba7bb2f74ab5a51578ce1f0e6fe742126bL20-R27): Removed imports related to `ProcessMonitor` and replaced them with `None` assignments. Disabled the process registration logic in `_start_segment` by commenting it out. [[1]](diffhunk://#diff-06af1a08771daacaa8ed6280e972bdba7bb2f74ab5a51578ce1f0e6fe742126bL20-R27) [[2]](diffhunk://#diff-06af1a08771daacaa8ed6280e972bdba7bb2f74ab5a51578ce1f0e6fe742126bL176-R194)
* [`app/services/recording/recording_orchestrator.py`](diffhunk://#diff-a1663db1cdcc438a61b559fce01aa1d33ba989cb7dd1b12f65daf9cc26c747f5L24-R26): Removed the import of `process_monitor` and replaced it with a `None` assignment.