### PR TITLE
fix: Start the cleanup scheduler loop in setup_logging for continuous…

### DIFF
--- a/app/config/logging_config.py
+++ b/app/config/logging_config.py
@@ -91,6 +91,7 @@ def setup_logging():
                         logger.error(f"Error during scheduled log cleanup: {e}")
             
             cleanup_task = loop.create_task(cleanup_scheduler())
+            loop.run_forever()
         
         # Start the cleanup scheduler in a daemon thread
         cleanup_thread = threading.Thread(target=start_cleanup_scheduler, daemon=True)


### PR DESCRIPTION
This pull request makes a small but significant change to the `cleanup_scheduler` function in `app/config/logging_config.py`. The change ensures that the event loop runs continuously by adding a call to `loop.run_forever()`.

* [`app/config/logging_config.py`](diffhunk://#diff-5f5fc1aa6865b078bcea373ef4bebfed9325d455ee5e74b385cf6e098905602dR94): Added `loop.run_forever()` to the `start_cleanup_scheduler` function to ensure the event loop remains active for continuous execution.… log management