### PR TITLE
fix: Remove redundant type definition inclusion from tsconfig.json

### DIFF
--- a/app/frontend/tsconfig.json
+++ b/app/frontend/tsconfig.json
@@ -6,8 +6,7 @@
         "src/**/*.ts",
         "src/**/*.d.ts",
         "src/**/*.tsx",
-        "src/**/*.vue",
-        "src/types/**/*.d.ts"
+        "src/**/*.vue"
     ],
     "compilerOptions": {
         "baseUrl": ".",


### PR DESCRIPTION
This pull request modifies the TypeScript configuration in the `app/frontend/tsconfig.json` file to adjust the included file patterns.

Configuration updates:

* Removed the inclusion of `src/types/**/*.d.ts` from the `include` array, simplifying the file patterns for type definitions. (`[app/frontend/tsconfig.jsonL9-R9](diffhunk://#diff-5ca7a4e5cf4aaacdd6ad32d323a3f737480a0185cf85119c8e86a510eb4d0f58L9-R9)`)