### PR TITLE
feat: Add force start recording API method and update stop recording endpoint

### DIFF
--- a/app/frontend/src/services/api.js
+++ b/app/frontend/src/services/api.js
@@ -193,8 +193,12 @@ export const recordingApi = {
         return api.post(`/api/recordings/start/${streamerId}`)
     },
 
+    async forceStartRecording(streamerId) {
+        return api.post(`/api/recording/force-start/${streamerId}`)
+    },
+
     async stopRecording(streamerId) {
-        return api.post(`/api/recordings/stop/${streamerId}`)
+        return api.post(`/api/recording/stop/${streamerId}`)
     },
 
     async getRecordingStatus(streamerId) {


### PR DESCRIPTION
This pull request updates the `recordingApi` object in `app/frontend/src/services/api.js` to add a new method for force-starting a recording and to fix an endpoint inconsistency in the `stopRecording` method.

### Key changes in `recordingApi`:

* Added a new `forceStartRecording` method to allow initiating a recording forcefully. This method posts to the `/api/recording/force-start/:streamerId` endpoint.
* Updated the `stopRecording` method to correct the API endpoint from `/api/recordings/stop/:streamerId` to `/api/recording/stop/:streamerId` for consistency.