### PR TITLE
Optimize workflow

### DIFF
--- a/app/services/background_queue_service.py
+++ b/app/services/background_queue_service.py
@@ -147,7 +147,7 @@ class BackgroundQueueService:
         completed_tasks = self.get_completed_tasks()
         # Convert to list and limit
         recent_list = list(completed_tasks.values())[-limit:]
-        return {task.task_id: task for task in recent_list}
+        return {task.id: task for task in recent_list}
 
     async def send_queue_statistics(self):
         """Send queue statistics via WebSocket"""

--- a/app/services/system/logging_service.py
+++ b/app/services/system/logging_service.py
@@ -27,7 +27,7 @@ class LoggingService:
         # Create directories
         self._ensure_log_directories()
         
-        # Initialize loggers
+                # Initialize loggers
         self._setup_loggers()
         
         # Clean up old logs on initialization
@@ -37,8 +37,6 @@ class LoggingService:
         """Create log directories if they don't exist"""
         for log_dir in [self.streamlink_logs_dir, self.ffmpeg_logs_dir, self.app_logs_dir]:
             log_dir.mkdir(parents=True, exist_ok=True)
-            # Ensure proper permissions
-            os.chmod(log_dir, 0o755)
     
     def _setup_loggers(self):
         """Setup separate loggers for different components"""
@@ -60,7 +58,7 @@ class LoggingService:
         # FFmpeg logger (now streamer-specific, so this is for general/fallback messages only)
         self.ffmpeg_logger = logging.getLogger("streamvault.ffmpeg")
         ffmpeg_handler = TimedRotatingFileHandler(
-            self.ffmpeg_logs_dir / "ffmpeg_system.log",  # Changed from generic ffmpeg.log
+            self.ffmpeg_logs_dir / "ffmpeg_system.log",
             when="midnight",
             interval=1,
             backupCount=30,
@@ -72,30 +70,26 @@ class LoggingService:
         self.ffmpeg_logger.addHandler(ffmpeg_handler)
         self.ffmpeg_logger.setLevel(logging.DEBUG)
         
-        # Recording activity logger
+        # Recording logger for recording activities
         self.recording_logger = logging.getLogger("streamvault.recording")
         recording_handler = TimedRotatingFileHandler(
-            self.app_logs_dir / "recording_activity.log",
+            self.app_logs_dir / "recording.log",
             when="midnight",
             interval=1,
             backupCount=30,
             encoding="utf-8"
         )
         recording_handler.setFormatter(
-            logging.Formatter("[{asctime}][{levelname}] {message}", style="{")
+            logging.Formatter("[{asctime}][{name}][{levelname}] {message}", style="{")
         )
         self.recording_logger.addHandler(recording_handler)
         self.recording_logger.setLevel(logging.DEBUG)
     
     def get_streamlink_log_path(self, streamer_name: str) -> str:
         """Get log file path for a specific streamer's streamlink session"""
-        today = datetime.now().strftime("%Y-%m-%d")
-        timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
-        # Format consistently with FFmpeg logs: streamer_streamlink_timestamp_date.log
-        streamer_name = streamer_name.replace(" ", "_")  # Remove spaces from streamer name
-        log_file = self.streamlink_logs_dir / f"{streamer_name}_streamlink_{timestamp_str}_{today}.log"
-        return str(log_file)
+        safe_streamer_name = "".join(c for c in streamer_name if c.isalnum() or c in ('-', '_')).lower()
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        return str(self.streamlink_logs_dir / f"{safe_streamer_name}_streamlink_{timestamp}.log")
     
     def get_ffmpeg_log_path(self, operation: str, streamer_name: str) -> str:
         """Get log file path for FFmpeg operations with mandatory streamer name"""

--- a/app/utils/ffmpeg_utils.py
+++ b/app/utils/ffmpeg_utils.py
@@ -5,7 +5,10 @@ import logging
 import subprocess
 import tempfile
 from datetime import datetime
-from typing import Optional, Dict, Any
+from pathlib import Path
+from typing import Optional, Dict, Any, List
+
+from app.services.system.logging_service import logging_service
 
 logger = logging.getLogger("streamvault")
 

--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -14,8 +14,7 @@ from typing import List, Optional, Dict, Any, Tuple
 from pathlib import Path
 
 from app.models import GlobalSettings
-# Use lazy imports to avoid circular dependencies
-# We'll import logging_service when needed
+from app.services.system.logging_service import logging_service
 
 # Get the logger
 logger = logging.getLogger(__name__)
@@ -122,9 +121,6 @@ def get_streamlink_command(
     
     # Use the streamlink log path for this recording session if not provided
     if not log_path:
-        # Lazy import to avoid circular dependencies
-        from importlib import import_module
-        logging_service = import_module("app.services.system.logging_service").logging_service
         log_path = logging_service.get_streamlink_log_path(streamer_name)
     
     # Core streamlink command with enhanced stability parameters


### PR DESCRIPTION
This pull request introduces several updates across different parts of the codebase, focusing on enhancing task management, improving logging, and simplifying imports. Key changes include extending task retrieval functions to include external tasks, refining logging configurations, and removing lazy imports for better maintainability.

### Enhancements to Task Management:
* [`app/api/background_queue_endpoints.py`](diffhunk://#diff-7d9fb13f3bc11af81b1c30b1b0f016f7ed0bb2b3df3137f58fde6f0e0867589eR37-R42): Updated `get_active_tasks` to include running and pending external tasks, and `get_recent_tasks` to include completed external tasks, sort them by time, and limit the total returned tasks to 50. [[1]](diffhunk://#diff-7d9fb13f3bc11af81b1c30b1b0f016f7ed0bb2b3df3137f58fde6f0e0867589eR37-R42) [[2]](diffhunk://#diff-7d9fb13f3bc11af81b1c30b1b0f016f7ed0bb2b3df3137f58fde6f0e0867589eL60-R81)
* [`app/services/background_queue_service.py`](diffhunk://#diff-49ef0879f7f18e7952e5d18b78bf49a865c93046c8dbf5f69417006ba5699d45L150-R150): Fixed a minor issue in `get_recent_tasks` by using `task.id` instead of `task.task_id` for consistency.

### Improvements to Logging:
* [`app/services/system/logging_service.py`](diffhunk://#diff-b572236cc698655ad043c6840b94e8e26e40776739cfdb2452a0a36c1f2f73a6L40-L41): Removed redundant permission setting for log directories, updated log file naming conventions, and improved log formatting for clarity. Additionally, sanitized streamer names in log file paths to ensure valid filenames. [[1]](diffhunk://#diff-b572236cc698655ad043c6840b94e8e26e40776739cfdb2452a0a36c1f2f73a6L40-L41) [[2]](diffhunk://#diff-b572236cc698655ad043c6840b94e8e26e40776739cfdb2452a0a36c1f2f73a6L63-R61) [[3]](diffhunk://#diff-b572236cc698655ad043c6840b94e8e26e40776739cfdb2452a0a36c1f2f73a6L75-R92)

### Code Simplifications:
* `app/utils/ffmpeg_utils.py` and `app/utils/streamlink_utils.py`: Replaced lazy imports of `logging_service` with direct imports to avoid circular dependencies and improve code readability. [[1]](diffhunk://#diff-17fab5e713f93a36d0f2e1b517f2da8c5e0d4706d9ba254c04e549bf37424626L8-R11) [[2]](diffhunk://#diff-9c8c99638a7910c64a1331c9a0f7c18bd4b257e1b9c733b807a8efd95687d340L17-R17) [[3]](diffhunk://#diff-9c8c99638a7910c64a1331c9a0f7c18bd4b257e1b9c733b807a8efd95687d340L125-L127)