### PR TITLE
fix: Enhance notification class handling for toast notifications

### DIFF
--- a/app/frontend/src/components/NotificationFeed.vue
+++ b/app/frontend/src/components/NotificationFeed.vue
@@ -44,11 +44,11 @@
       <div v-for="notification in sortedNotifications" 
           :key="notification.id" 
           class="notification-item"
-          :class="getNotificationClass(notification.type)">
-        <div class="notification-indicator" :class="getNotificationClass(notification.type)"></div>
+          :class="getNotificationClass(notification.type, notification)">
+        <div class="notification-indicator" :class="getNotificationClass(notification.type, notification)"></div>
         
         <div class="notification-icon">
-          <div class="icon-wrapper" :class="getNotificationClass(notification.type)">
+          <div class="icon-wrapper" :class="getNotificationClass(notification.type, notification)">
             <!-- Toast notification icons -->
             <span v-if="notification.type === 'toast_notification' && notification.data?.toast_type === 'success'">✅</span>
             <span v-else-if="notification.type === 'toast_notification' && notification.data?.toast_type === 'error'">❌</span>
@@ -239,7 +239,7 @@ const formatMessage = (notification: Notification): string => {
 }
 
 // Get CSS class based on notification type
-const getNotificationClass = (type: string): string => {
+const getNotificationClass = (type: string, notification?: Notification): string => {
   switch (type) {
     case 'stream.online':
       return 'online'
@@ -256,7 +256,7 @@ const getNotificationClass = (type: string): string => {
       return 'error'
     case 'toast_notification':
       // Use the toast_type from data if available
-      return notification.data?.toast_type || 'info'
+      return notification?.data?.toast_type || 'info'
     case 'test':
       return 'test'
     default:


### PR DESCRIPTION
This pull request updates the `NotificationFeed.vue` component to enhance the handling of notification-specific CSS classes by passing the entire notification object to the `getNotificationClass` function. This allows for more dynamic class assignment based on notification properties.

### Enhancements to notification class handling:

* Updated the `getNotificationClass` function to accept an optional `notification` object in addition to the `type` parameter, enabling more flexible class determination. (`app/frontend/src/components/NotificationFeed.vue`, [app/frontend/src/components/NotificationFeed.vueL242-R242](diffhunk://#diff-6cce6ed5609589aa59139b25305f9cd682cdae10f1c1b8bc14734988a2dadcb3L242-R242))
* Modified the logic for `toast_notification` types within `getNotificationClass` to safely access the `toast_type` property from the `notification` object, preventing potential undefined errors. (`app/frontend/src/components/NotificationFeed.vue`, [app/frontend/src/components/NotificationFeed.vueL259-R259](diffhunk://#diff-6cce6ed5609589aa59139b25305f9cd682cdae10f1c1b8bc14734988a2dadcb3L259-R259))

### Component updates:

* Updated all instances of `getNotificationClass` usage in the template to pass the `notification` object along with the `type`, ensuring consistent behavior across the component. (`app/frontend/src/components/NotificationFeed.vue`, [app/frontend/src/components/NotificationFeed.vueL47-R51](diffhunk://#diff-6cce6ed5609589aa59139b25305f9cd682cdae10f1c1b8bc14734988a2dadcb3L47-R51))