### PR TITLE
fix: Enhance finalization of segmented recordings by moving concatenated files and triggering post-processing

### DIFF
--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -7,6 +7,7 @@ Includes support for 24h+ streams through segment splitting and automatic proces
 import logging
 import asyncio
 import os
+import shutil
 import time
 from datetime import datetime, timedelta
 from typing import Dict, Optional, List, Tuple
@@ -496,7 +497,6 @@ class ProcessManager:
             
             # Move the file
             if concatenated_file.exists():
-                import shutil
                 shutil.move(str(concatenated_file), str(final_path))
                 logger.info(f"Moved concatenated file from {concatenated_file} to {final_path}")
                 


### PR DESCRIPTION
This pull request enhances the segmented recording finalization process by introducing new steps for handling concatenated files and triggering post-processing. The most important changes include moving the concatenated file to a parent directory, triggering post-processing for the moved file, and ensuring cleanup happens only after post-processing begins.

### Enhancements to segmented recording finalization:

* **Moving concatenated file to parent directory:**
  - Added a new method `_move_concatenated_file_to_parent` to move the concatenated file from the segments directory to its parent directory.
  - Updates the `segment_info` dictionary with the new file path for subsequent operations.

* **Triggering post-processing for the moved file:**
  - Introduced a new method `_trigger_post_processing_for_segmented_recording` to update the recording status in the database and trigger post-processing using the moved file's path.
  - Ensures the recording lifecycle manager handles the post-processing.

* **Adjusting cleanup sequence:**
  - Modified `_finalize_segmented_recording` to perform segment cleanup only after the post-processing has been triggered, ensuring no premature deletion of files.