### PR TITLE
Optimize workflow

### DIFF
--- a/app/frontend/src/components/StreamList.vue
+++ b/app/frontend/src/components/StreamList.vue
@@ -11,9 +11,6 @@
       <div class="empty-icon">🎬</div>
       <h3>No Streams Found</h3>
       <p>This streamer hasn't streamed yet or all streams have been deleted.</p>
-      <button @click="handleBack" class="btn btn-primary">
-        <i class="fas fa-arrow-left"></i> Back to Streamers
-      </button>
     </div>
     
     <!-- Streams Content -->

--- a/app/services/images/image_refresh_service.py
+++ b/app/services/images/image_refresh_service.py
@@ -72,10 +72,11 @@ class ImageRefreshService:
                 batch_tasks = []
                 for streamer in batch:
                     if streamer.profile_image_url and streamer.profile_image_url.startswith('http'):
-                        # Check if cached file exists
-                        expected_path = self.media_dir / "profiles" / f"streamer_{streamer.id}.jpg"
+                        # Check if cached file exists (try both old and new naming)
+                        expected_path_new = self.media_dir / "profiles" / f"profile_avatar_{streamer.id}.jpg"
+                        expected_path_old = self.media_dir / "profiles" / f"streamer_{streamer.id}.jpg"
                         
-                        if not expected_path.exists():
+                        if not expected_path_new.exists() and not expected_path_old.exists():
                             logger.info(f"Profile image missing for streamer {streamer.id}, re-downloading...")
                             task = self._download_profile_image(streamer)
                             batch_tasks.append(task)

--- a/docs/media_server_integration_v2.md
+++ b/docs/media_server_integration_v2.md
@@ -22,7 +22,7 @@ StreamVault has been refactored for compatibility with media server containers (
     │       ├── banner.jpg      # Banner image  
     │       └── fanart.jpg      # Background image
     ├── profiles/
-    │   └── streamer_123.jpg    # Profile images
+    │   └── profile_avatar_123.jpg    # Profile images
     └── categories/
         └── category_456.jpg    # Category icons
 ```

--- a/docs/unified_image_service.md
+++ b/docs/unified_image_service.md
@@ -15,16 +15,16 @@ The Unified Image Service provides centralized image management for StreamVault,
 ```
 /recordings/.images/
 ├── profiles/          # Streamer profile images
-│   ├── streamer_123.jpg
-│   └── streamer_456.jpg
+│   ├── profile_avatar_123.jpg
+│   └── profile_avatar_456.jpg
 ├── categories/        # Category/game images
 │   ├── just_chatting.jpg
 │   └── league_of_legends.jpg
 └── artwork/          # Stream artwork/thumbnails
-    ├── streamer_123/
+    ├── profile_avatar_123/
     │   ├── stream_789.jpg
     │   └── stream_790.jpg
-    └── streamer_456/
+    └── profile_avatar_456/
         └── stream_791.jpg
 ```
 
@@ -58,7 +58,7 @@ The service is automatically integrated into the streamers API. Profile images n
 
 // After: Uses cached local URLs with fallback
 {
-  "profile_image_url": "/data/images/profiles/streamer_123.jpg"
+  "profile_image_url": "/data/images/profiles/profile_avatar_123.jpg"
 }
 ```
 
@@ -95,7 +95,7 @@ The `.images` directory is hidden and won't be detected as media by most media s
 ### Metadata Integration
 Images can be referenced in NFO files using relative paths:
 ```xml
-<thumb>/recordings/.images/profiles/streamer_123.jpg</thumb>
+<thumb>/recordings/.images/profiles/profile_avatar_123.jpg</thumb>
 ```
 
 ## Performance


### PR DESCRIPTION
This pull request introduces changes to standardize the naming convention for streamer profile images and update related code, documentation, and functionality. The key updates include transitioning from the `streamer_X` naming format to the `profile_avatar_X` format, ensuring backward compatibility, and cleaning up unused code.

### Changes to profile image naming conventions:

* Updated the naming format for profile images from `streamer_X.jpg` to `profile_avatar_X.jpg` across the codebase, including image downloads (`app/services/images/profile_image_service.py`, [[1]](diffhunk://#diff-81a08549823803db481bfcc04f6b85ca2328ba69fdd82a5f7503c87bf90cb920L76-R83) cache loading (`app/services/images/profile_image_service.py`, [[2]](diffhunk://#diff-81a08549823803db481bfcc04f6b85ca2328ba69fdd82a5f7503c87bf90cb920R42-R49) and cleanup of unused images (`app/services/images/profile_image_service.py`, [[3]](diffhunk://#diff-81a08549823803db481bfcc04f6b85ca2328ba69fdd82a5f7503c87bf90cb920L167-R182).
* Modified the logic to check for both old (`streamer_X.jpg`) and new (`profile_avatar_X.jpg`) formats to maintain backward compatibility during image existence checks (`app/services/images/image_refresh_service.py`, [app/services/images/image_refresh_service.pyL75-R79](diffhunk://#diff-74f654e5783fe91f689f4a27dfeacb74bfc737e5e2d74ed59979aff1568bcfbbL75-R79)).

### Documentation updates:

* Updated file structure examples and references in documentation to reflect the new naming convention (`docs/media_server_integration_v2.md`, [[1]](diffhunk://#diff-ab9e0719169d7765c34b8d5afbcb73fd405368025eda444b8dc97b0932c0bd75L25-R25); `docs/unified_image_service.md`, [[2]](diffhunk://#diff-43cf81f07e66bee36d3fac270f241b9503b41344cac18b714a5a72a26a1aa1e2L18-R27) [[3]](diffhunk://#diff-43cf81f07e66bee36d3fac270f241b9503b41344cac18b714a5a72a26a1aa1e2L61-R61) [[4]](diffhunk://#diff-43cf81f07e66bee36d3fac270f241b9503b41344cac18b714a5a72a26a1aa1e2L98-R98).

### UI and code cleanup:

* Removed an unused "Back to Streamers" button from the `StreamList` component (`app/frontend/src/components/StreamList.vue`, [app/frontend/src/components/StreamList.vueL14-L16](diffhunk://#diff-dc8da8a9109f343ac4ab7f2d125674d933dad2d8330bb46160771bea205313b5L14-L16)).