### PR TITLE
fix: Import Recording and ActiveRecordingState models in streamers.py for proper functionality

### DIFF
--- a/app/routes/streamers.py
+++ b/app/routes/streamers.py
@@ -8,7 +8,7 @@ from app.schemas.streamers import StreamerResponse, StreamerList
 from app.events.handler_registry import EventHandlerRegistry
 from app.dependencies import get_streamer_service, get_event_registry
 from app.database import SessionLocal, get_db
-from app.models import Stream, Streamer, NotificationSettings, StreamerRecordingSettings, StreamMetadata, StreamEvent
+from app.models import Stream, Streamer, NotificationSettings, StreamerRecordingSettings, StreamMetadata, StreamEvent, Recording, ActiveRecordingState
 from app.schemas.streams import StreamList, StreamResponse
 from sqlalchemy.orm import Session
 import logging
@@ -565,7 +565,6 @@ async def delete_stream(
             db.delete(metadata)
         
         # Check for recordings associated with this stream and collect their paths
-        from app.models import Recording
         recordings = db.query(Recording).filter(Recording.stream_id == stream_id).all()
         for recording in recordings:
             if recording.path:
@@ -577,7 +576,6 @@ async def delete_stream(
         db.query(StreamEvent).filter(StreamEvent.stream_id == stream_id).delete()
         
         # Delete any active recording state entries for this stream
-        from app.models import ActiveRecordingState
         db.query(ActiveRecordingState).filter(ActiveRecordingState.stream_id == stream_id).delete()
         
         # Delete the stream record itself
@@ -826,7 +824,6 @@ async def delete_all_streams(
         streams = db.query(Stream).filter(Stream.streamer_id == streamer_id).all()
         
         # Also handle orphaned recordings with null stream_id for this streamer
-        from app.models import Recording
         orphaned_recordings = db.query(Recording).filter(
             Recording.stream_id.is_(None)
         ).all()
@@ -876,7 +873,6 @@ async def delete_all_streams(
             db.query(StreamEvent).filter(StreamEvent.stream_id == stream.id).delete()
             
             # Delete active recording state for this stream
-            from app.models import ActiveRecordingState
             db.query(ActiveRecordingState).filter(ActiveRecordingState.stream_id == stream.id).delete()
             
             # Delete the stream record itself


### PR DESCRIPTION
This pull request refactors the `app/routes/streamers.py` file to streamline imports by moving `Recording` and `ActiveRecordingState` model imports to the top of the file. This change improves code readability and consistency by avoiding repeated inline imports within functions.

### Refactoring imports for better code organization:

* Consolidated imports of `Recording` and `ActiveRecordingState` models at the top of the `app/routes/streamers.py` file, removing redundant inline imports in the `delete_stream` and `delete_all_streams` functions. [[1]](diffhunk://#diff-792f40d7b51ff447b092998e4cd76dc7ae62b1bfb4bd9aa5403ddfaef1024924L11-R11) [[2]](diffhunk://#diff-792f40d7b51ff447b092998e4cd76dc7ae62b1bfb4bd9aa5403ddfaef1024924L568) [[3]](diffhunk://#diff-792f40d7b51ff447b092998e4cd76dc7ae62b1bfb4bd9aa5403ddfaef1024924L580) [[4]](diffhunk://#diff-792f40d7b51ff447b092998e4cd76dc7ae62b1bfb4bd9aa5403ddfaef1024924L829) [[5]](diffhunk://#diff-792f40d7b51ff447b092998e4cd76dc7ae62b1bfb4bd9aa5403ddfaef1024924L879)