### PR TITLE
fix: Update users and system config tables to correct field definitions

### DIFF
--- a/migrations/001_create_base_tables.py
+++ b/migrations/001_create_base_tables.py
@@ -28,12 +28,12 @@ def run_migration():
         
         logger.info("🔄 Creating base tables...")
         
-        # 1. Users table - with password_hash instead of password
+        # 1. Users table - note: using 'password' not 'password_hash' to match the model
         session.execute(text("""
             CREATE TABLE IF NOT EXISTS users (
                 id SERIAL PRIMARY KEY,
                 username VARCHAR(100) UNIQUE NOT NULL,
-                password_hash VARCHAR(255) NOT NULL,
+                password VARCHAR(255) NOT NULL,
                 is_admin BOOLEAN DEFAULT FALSE,
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )
@@ -86,12 +86,13 @@ def run_migration():
         """))
         logger.info("✅ Created recording_settings table")
         
-        # 5. System config table (for VAPID keys etc)
+        # 5. System config table (for VAPID keys etc) - with description column
         session.execute(text("""
             CREATE TABLE IF NOT EXISTS system_config (
                 id SERIAL PRIMARY KEY,
                 key VARCHAR(255) UNIQUE NOT NULL,
                 value TEXT,
+                description VARCHAR(500),
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )


### PR DESCRIPTION
This pull request updates the database migration script `migrations/001_create_base_tables.py` to align table definitions with the application's requirements. The most important changes include modifying the `users` table to use a `password` column instead of `password_hash` and adding a `description` column to the `system_config` table.

### Changes to table definitions:

* `users` table: Replaced the `password_hash` column with a `password` column to match the model.
* `system_config` table: Added a `description` column (type `VARCHAR(500)`) to provide additional context for configuration entries.