### PR TITLE
fix: Update sessions table to add default value for expires_at and enforce NOT NULL constraints

### DIFF
--- a/migrations/002_create_main_entities.py
+++ b/migrations/002_create_main_entities.py
@@ -67,13 +67,13 @@ def run_migration():
         """))
         logger.info("✅ Created streams table")
         
-        # 3. Sessions table - with NOT NULL constraints for security
+        # 3. Sessions table - with NOT NULL constraints for security and default for expires_at
         session.execute(text("""
             CREATE TABLE IF NOT EXISTS sessions (
                 id SERIAL PRIMARY KEY,
                 user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
                 token VARCHAR(255) NOT NULL UNIQUE,
-                expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                expires_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (CURRENT_TIMESTAMP + INTERVAL '24 hours'),
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )
         """))


### PR DESCRIPTION
This pull request updates the `migrations/002_create_main_entities.py` file to enhance the `sessions` table creation by adding a default value for the `expires_at` column.

* Database schema improvement:
  * [`migrations/002_create_main_entities.py`](diffhunk://#diff-36454327462a2910f8a6ad59c34651c8f91da176cc0685b13da48358224c122eL70-R76): Modified the `CREATE TABLE` statement for the `sessions` table to include a default value for the `expires_at` column, setting it to `CURRENT_TIMESTAMP + INTERVAL '24 hours'`. This ensures that session expiration is automatically set to 24 hours after creation if not explicitly provided.