### PR TITLE
fix: Remove obsolete twitch_id index from streamers and stream_id index from streams for optimization

### DIFF
--- a/migrations/004_add_database_indexes.py
+++ b/migrations/004_add_database_indexes.py
@@ -28,7 +28,6 @@ def run_migration():
         logger.info("🔄 Adding database indexes...")
         
         # Streamers indexes
-        session.execute(text("CREATE INDEX IF NOT EXISTS idx_streamers_twitch_id ON streamers (twitch_id)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streamers_name ON streamers (name)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streamers_display_name ON streamers (display_name)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streamers_is_live ON streamers (is_live)"))
@@ -39,7 +38,6 @@ def run_migration():
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_streamer_id ON streams (streamer_id)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_started_at ON streams (started_at)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_ended_at ON streams (ended_at)"))
-        session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_stream_id ON streams (stream_id)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_streamer_active ON streams (streamer_id, ended_at)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_streamer_recent ON streams (streamer_id, started_at)"))
         session.execute(text("CREATE INDEX IF NOT EXISTS idx_streams_time_range ON streams (started_at, ended_at)"))


### PR DESCRIPTION
This pull request updates the `migrations/004_add_database_indexes.py` file by removing unused database index creation statements to optimize the migration script.

### Database index cleanup:

* Removed the creation of the `idx_streamers_twitch_id` index on the `streamers` table, as it is no longer needed. (`[migrations/004_add_database_indexes.pyL31](diffhunk://#diff-7dcbfca83c0bff18cdd2524ef49ff391060a2087de795f20acffd84a84839e7dL31)`)
* Removed the creation of the `idx_streams_stream_id` index on the `streams` table, as it is no longer required. (`[migrations/004_add_database_indexes.pyL42](diffhunk://#diff-7dcbfca83c0bff18cdd2524ef49ff391060a2087de795f20acffd84a84839e7dL42)`)