### PR TITLE
fix: Remove output_directory from settings handling in useRecordingSettings

### DIFF
--- a/app/frontend/src/composables/useRecordingSettings.ts
+++ b/app/frontend/src/composables/useRecordingSettings.ts
@@ -105,7 +105,6 @@ export function useRecordingSettings() {
         const data = await response.json();
         settings.value = {
           enabled: data.enabled,
-          output_directory: data.output_directory,
           filename_template: data.filename_template,
           filename_preset: data.filename_preset,
           default_quality: data.default_quality,
@@ -135,7 +134,6 @@ export function useRecordingSettings() {
         },
         body: JSON.stringify({
           enabled: newSettings.enabled,
-          output_directory: newSettings.output_directory,
           filename_template: newSettings.filename_template,
           filename_preset: newSettings.filename_preset,
           default_quality: newSettings.default_quality,
@@ -149,7 +147,6 @@ export function useRecordingSettings() {
         const data = await response.json();
         settings.value = {
           enabled: data.enabled,
-          output_directory: data.output_directory,
           filename_template: data.filename_template,
           filename_preset: data.filename_preset,
           default_quality: data.default_quality,


### PR DESCRIPTION
This pull request modifies the `useRecordingSettings` composable in `app/frontend/src/composables/useRecordingSettings.ts` to remove the `output_directory` property from the recording settings. This change simplifies the settings structure and aligns it with the updated requirements.

Key changes:

### Removal of `output_directory` from recording settings:
* Removed the `output_directory` property from the `settings.value` object when parsing the response JSON. (`[[1]](diffhunk://#diff-e4c41421d87a9a8e8ef2462a47710b0738c7c5f8dbbcf7f77ee66f1bc0d9b79fL108)`, `[[2]](diffhunk://#diff-e4c41421d87a9a8e8ef2462a47710b0738c7c5f8dbbcf7f77ee66f1bc0d9b79fL152)`)
* Excluded the `output_directory` property from the `body` of the request when updating recording settings. (`[app/frontend/src/composables/useRecordingSettings.tsL138](diffhunk://#diff-e4c41421d87a9a8e8ef2462a47710b0738c7c5f8dbbcf7f77ee66f1bc0d9b79fL138)`)