### PR TITLE
Optimize workflow

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -65,6 +65,7 @@ class Stream(Base):
     twitch_stream_id = Column(String, nullable=True, index=True)
     recording_path = Column(String, nullable=True)  # Path to the recorded MP4 file
     episode_number = Column(Integer, nullable=True)  # Episode number for this stream
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
     
     # Relationships
     streamer = relationship("Streamer", backref="streams")

--- a/migrations/002_create_main_entities.py
+++ b/migrations/002_create_main_entities.py
@@ -59,7 +59,7 @@ def run_migration():
                 twitch_stream_id VARCHAR(255),
                 recording_path VARCHAR(1024),
                 episode_number INTEGER,
-                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
             )
         """))
         logger.info("✅ Created streams table")

--- a/migrations/002_create_main_entities.py
+++ b/migrations/002_create_main_entities.py
@@ -58,7 +58,8 @@ def run_migration():
                 ended_at TIMESTAMP WITH TIME ZONE,
                 twitch_stream_id VARCHAR(255),
                 recording_path VARCHAR(1024),
-                episode_number INTEGER
+                episode_number INTEGER,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )
         """))
         logger.info("✅ Created streams table")


### PR DESCRIPTION
This pull request introduces a new `created_at` timestamp field to the `Stream` model and updates the corresponding database migration to include this field. The changes ensure that the creation time of each stream is automatically recorded.

### Model and database schema updates:

* Added a `created_at` column to the `Stream` model in `app/models.py`, which stores the timestamp of when a stream is created. The column uses `DateTime` with timezone support and defaults to the current timestamp (`func.now()`).
* Updated the `run_migration` function in `migrations/002_create_main_entities.py` to include the `created_at` column in the `streams` table, with a default value of the current timestamp.