### PR TITLE
refactor: streamline migration 014 by removing downgrade function andenhancing session management

### DIFF
--- a/migrations/014_add_streamer_preferences.py
+++ b/migrations/014_add_streamer_preferences.py
@@ -9,8 +9,10 @@ import logging
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-# Add parent directory to path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add parent directory to path for imports
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.insert(0, parent_dir)
 
 from app.config.settings import settings
 
@@ -21,8 +23,12 @@ def run_migration():
     """Add preference fields to streamers table"""
     session = None
     try:
+        # Validate DATABASE_URL
+        if not settings.DATABASE_URL:
+            raise ValueError("DATABASE_URL not configured")
+        
         # Connect to the database
-        engine = create_engine(settings.DATABASE_URL)
+        engine = create_engine(settings.DATABASE_URL, echo=False)
         Session = sessionmaker(bind=engine)
         session = Session()
         


### PR DESCRIPTION
This pull request refactors the migration script `014_add_streamer_preferences.py` to improve its structure, enhance error handling, and streamline execution. The changes include replacing the `upgrade` and `downgrade` functions with a unified `run_migration` function, restructuring database connection logic, and adding proper resource cleanup.

### Migration script refactor:

* Replaced the `upgrade` and `downgrade` functions with a single `run_migration` function, simplifying the script and removing the downgrade logic.
* Added database connection setup using `create_engine` and `sessionmaker` from SQLAlchemy, with proper handling of `settings.DATABASE_URL` for configuration.
* Improved resource management by ensuring the database session is closed in a `finally` block and rolling back transactions on exceptions.

### Logging and execution:

* Enhanced logging setup with `logging.basicConfig` for consistent log formatting and levels.
* Made the script executable as a standalone program by adding a `__main__` entry point.