### PR TITLE
feat: update global settings migration to include new notification fields and adjust category insertion structure

### DIFF
--- a/migrations/015_add_default_settings.py
+++ b/migrations/015_add_default_settings.py
@@ -21,6 +21,40 @@ from app.config.settings import settings
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+def generate_migration_category_id(category_name: str) -> str:
+    """
+    Generate a migration-specific category ID from a category name.
+    
+    This function creates a standardized twitch_id for categories added during migration
+    to avoid conflicts with real Twitch category IDs that may be added later.
+    
+    Transformation rules:
+    - Convert to lowercase
+    - Replace spaces with underscores
+    - Replace '&' with 'and' 
+    - Replace '+' with 'plus'
+    - Prefix with 'migrate_' to distinguish from real Twitch IDs
+    
+    Args:
+        category_name: The human-readable category name (e.g., "Games + Demos")
+        
+    Returns:
+        A migration-safe category ID (e.g., "migrate_games_plus_demos")
+        
+    Examples:
+        "Just Chatting" -> "migrate_just_chatting"
+        "Games + Demos" -> "migrate_games_plus_demos" 
+        "Talk Shows & Podcasts" -> "migrate_talk_shows_and_podcasts"
+    """
+    # Apply transformations in order
+    normalized = category_name.lower()
+    normalized = normalized.replace(' ', '_')
+    normalized = normalized.replace('&', 'and')
+    normalized = normalized.replace('+', 'plus')
+    
+    # Add migration prefix to avoid conflicts with real Twitch IDs
+    return f"migrate_{normalized}"
+
 def run_migration():
     """Add default settings data to ensure system functionality"""
     session = None
@@ -165,11 +199,14 @@ def run_migration():
                 ]
                 
                 for category in default_categories:
+                    # Use helper function to generate migration-safe category ID
+                    migration_id = generate_migration_category_id(category)
+                    
                     session.execute(text("""
                         INSERT INTO categories (twitch_id, name, box_art_url) 
                         VALUES (:twitch_id, :name, :box_art_url)
                     """), {
-                        "twitch_id": f"default_{category.lower().replace(' ', '_').replace('&', 'and').replace('+', 'plus')}", 
+                        "twitch_id": migration_id, 
                         "name": category,
                         "box_art_url": None
                     })

--- a/migrations/015_add_default_settings.py
+++ b/migrations/015_add_default_settings.py
@@ -106,22 +106,31 @@ def run_migration():
                 logger.info("🔄 Inserting default global settings...")
                 session.execute(text("""
                     INSERT INTO global_settings (
-                        check_interval, 
-                        max_concurrent_recordings, 
-                        default_download_folder, 
+                        notification_url,
+                        notifications_enabled,
+                        notify_online_global,
+                        notify_offline_global,
+                        notify_update_global,
+                        notify_favorite_category_global,
                         http_proxy, 
                         https_proxy
                     ) VALUES (
-                        :check_interval, 
-                        :max_concurrent_recordings, 
-                        :default_download_folder, 
+                        :notification_url,
+                        :notifications_enabled,
+                        :notify_online_global,
+                        :notify_offline_global,
+                        :notify_update_global,
+                        :notify_favorite_category_global,
                         :http_proxy, 
                         :https_proxy
                     )
                 """), {
-                    "check_interval": 60,
-                    "max_concurrent_recordings": 3,
-                    "default_download_folder": "/recordings",
+                    "notification_url": None,
+                    "notifications_enabled": False,
+                    "notify_online_global": True,
+                    "notify_offline_global": True,
+                    "notify_update_global": True,
+                    "notify_favorite_category_global": True,
                     "http_proxy": None,
                     "https_proxy": None
                 })
@@ -157,11 +166,12 @@ def run_migration():
                 
                 for category in default_categories:
                     session.execute(text("""
-                        INSERT INTO categories (name, description) 
-                        VALUES (:name, :description)
+                        INSERT INTO categories (twitch_id, name, box_art_url) 
+                        VALUES (:twitch_id, :name, :box_art_url)
                     """), {
-                        "name": category, 
-                        "description": f"Default category: {category}"
+                        "twitch_id": f"default_{category.lower().replace(' ', '_').replace('&', 'and').replace('+', 'plus')}", 
+                        "name": category,
+                        "box_art_url": None
                     })
                 
                 session.commit()


### PR DESCRIPTION
This pull request updates the migration script `015_add_default_settings.py` to include new settings and modify the structure of the `categories` table. The most important changes involve adding notification-related fields to the `global_settings` table and updating the `categories` table to include a new `twitch_id` column while removing the `description` column.

### Changes to `global_settings` table:
* Added new notification-related fields: `notification_url`, `notifications_enabled`, `notify_online_global`, `notify_offline_global`, `notify_update_global`, and `notify_favorite_category_global`. Default values for these fields were also provided. (`[migrations/015_add_default_settings.pyL109-R133](diffhunk://#diff-3f1b56acc35a5205f90ff10604565261bc7fd5d99e34b3b8189bb2fcd7d078fcL109-R133)`)

### Changes to `categories` table:
* Replaced `description` with a new `twitch_id` field and added a `box_art_url` field. The `twitch_id` is generated dynamically based on the category name. (`[migrations/015_add_default_settings.pyL160-R174](diffhunk://#diff-3f1b56acc35a5205f90ff10604565261bc7fd5d99e34b3b8189bb2fcd7d078fcL160-R174)`)