### PR TITLE
feat: improve profile image handling with error fallback and placeholder for missing images

### DIFF
--- a/app/frontend/src/components/StreamerList.vue
+++ b/app/frontend/src/components/StreamerList.vue
@@ -9,12 +9,16 @@
           <div class="streamer-info">
             <div class="profile-image-wrapper">
               <img 
-                v-if="(streamer as any).profile_image_url || (streamer as any).image_url"
-                :src="(streamer as any).profile_image_url || (streamer as any).image_url"
+                v-if="streamer.profile_image_url"
+                :src="streamer.profile_image_url"
                 class="profile-image"
                 :alt="streamer.name"
                 loading="lazy"
+                @error="handleImageError"
               />
+              <div v-else class="profile-image-placeholder">
+                {{ streamer.name.charAt(0).toUpperCase() }}
+              </div>
               <span class="status-dot" :class="{ 'live': streamer.is_live }"></span>
             </div>
             <h3 class="streamer-name-link" @click="navigateToTwitch(streamer.name)">


### PR DESCRIPTION
This pull request refines the `StreamerList` component in the frontend by improving how profile images are handled and displayed. The changes enhance code readability and user experience by removing redundant logic and adding a fallback for missing profile images.

### Improvements to profile image handling:

* [`app/frontend/src/components/StreamerList.vue`](diffhunk://#diff-1a7ea803bd90d1e656cf836c0158da2a471d27144296c20c17ea8361903ecf7cL12-R21): Simplified the logic for displaying profile images by removing the fallback to `image_url` and relying solely on `profile_image_url`. Added a `handleImageError` method to handle broken image links and introduced a placeholder with the streamer's initial when no profile image is available.