### PR TITLE
feat: add error handling for profile image loading to display placeholder on failure

### DIFF
--- a/app/frontend/src/components/StreamerList.vue
+++ b/app/frontend/src/components/StreamerList.vue
@@ -172,6 +172,15 @@ const navigateToTwitch = (username: string) => {
   window.open(`https://twitch.tv/${username}`, '_blank')
 }
 
+const handleImageError = (event: Event) => {
+  const target = event.target as HTMLImageElement
+  if (target) {
+    // Hide the broken image and let the placeholder show instead
+    target.style.display = 'none'
+    console.warn('Failed to load profile image:', target.src)
+  }
+}
+
 const handleDelete = async (streamerId: string) => {
   if (!confirm('Are you sure you want to delete this streamer?')) return
   


### PR DESCRIPTION
This pull request introduces a new utility function to handle image loading errors in the `StreamerList` component. This change ensures a smoother user experience by hiding broken images and displaying a placeholder instead.

* **Error handling for profile images**:
  * [`app/frontend/src/components/StreamerList.vue`](diffhunk://#diff-1a7ea803bd90d1e656cf836c0158da2a471d27144296c20c17ea8361903ecf7cR175-R183): Added a `handleImageError` function to hide broken images and log a warning when a profile image fails to load.