### PR TITLE
Optimize workflow

### DIFF
--- a/app/frontend/src/components/StreamerList.vue
+++ b/app/frontend/src/components/StreamerList.vue
@@ -107,8 +107,8 @@ interface StreamerUpdateData {
   last_updated: string
 }
 
-interface StreamerWithTwitchId {
-  twitch_id: string
+interface StreamerWithProfileImage {
+  profile_image_url?: string
 }
 
 // Use hybrid status for real-time streamer updates
@@ -172,9 +172,8 @@ const formatDate = (date: string | undefined): string => {
   return updated.toLocaleString()
 }
 
-const getProfileImageUrl = (streamer: StreamerWithTwitchId): string | undefined => {
-  if (!streamer.twitch_id) return undefined
-  return `/static/profiles/profile_avatar_${streamer.twitch_id}.jpg`
+const getProfileImageUrl = (streamer: StreamerWithProfileImage): string | undefined => {
+  return streamer.profile_image_url
 }
 
 const navigateToTwitch = (username: string) => {

--- a/app/frontend/src/composables/useHybridStatus.ts
+++ b/app/frontend/src/composables/useHybridStatus.ts
@@ -47,6 +47,7 @@ interface StreamerStatus {
   name: string
   display_name: string
   twitch_id: string
+  profile_image_url?: string
   is_live: boolean
   is_recording: boolean
   is_favorite: boolean

--- a/app/routes/status.py
+++ b/app/routes/status.py
@@ -15,6 +15,7 @@ from app.database import get_db, SessionLocal
 from app.models import Recording, Stream, Streamer, NotificationSettings, PushSubscription, GlobalSettings, StreamEvent
 from app.schemas import ActiveRecordingSchema
 from app.services.background_queue_service import background_queue_service
+from app.services.unified_image_service import unified_image_service
 from sqlalchemy import text
 
 router = APIRouter(prefix="/status", tags=["status"])
@@ -232,6 +233,10 @@ async def get_streamers_status() -> Dict[str, Any]:
                     "name": streamer.username,
                     "display_name": streamer.display_name,
                     "twitch_id": streamer.twitch_id,
+                    "profile_image_url": unified_image_service.get_profile_image_url(
+                        streamer.id, 
+                        streamer.profile_image_url
+                    ),
                     "is_live": is_live,
                     "is_recording": is_recording,
                     "is_favorite": streamer.is_favorite,


### PR DESCRIPTION
This pull request introduces changes to streamline the handling of streamer profile images by replacing the use of `twitch_id` for constructing URLs with a new `profile_image_url` field. This improves flexibility and centralizes the management of profile image URLs. The most important changes span updates to TypeScript interfaces, Vue components, and backend Python logic.

### Frontend Changes:

* **Updated TypeScript interfaces**:
  - Replaced `StreamerWithTwitchId` with `StreamerWithProfileImage`, which includes an optional `profile_image_url` field (`app/frontend/src/components/StreamerList.vue`).
  - Added `profile_image_url` as an optional field to the `StreamerStatus` interface (`app/frontend/src/composables/useHybridStatus.ts`).

* **Simplified profile image URL logic**:
  - Refactored the `getProfileImageUrl` function in `StreamerList.vue` to directly use the `profile_image_url` field instead of constructing URLs using `twitch_id` (`app/frontend/src/components/StreamerList.vue`).

### Backend Changes:

* **Introduced centralized profile image handling**:
  - Integrated `unified_image_service` to fetch the `profile_image_url` in the `get_streamers_status` API endpoint (`app/routes/status.py`).
  - Imported `unified_image_service` into the `status.py` file to support the new logic (`app/routes/status.py`).