### PR TITLE
feat: enhance error handling for profile image URL retrieval in get_streamers_status

### DIFF
--- a/app/api/background_queue_endpoints.py
+++ b/app/api/background_queue_endpoints.py
@@ -33,12 +33,18 @@ async def get_active_tasks() -> List[Dict[str, Any]]:
         # Get active tasks from the queue service
         for task_id, task in queue_service.active_tasks.items():
             task_info = task.to_dict()
+            # Debug logging for task payload
+            streamer_name = task_info.get('payload', {}).get('streamer_name', 'NOT_FOUND')
+            logger.info(f"Active task {task_id}: type={task_info.get('task_type')}, streamer_name={streamer_name}, payload_keys={list(task_info.get('payload', {}).keys())}")
             active_tasks.append(task_info)
         
         # Also include external tasks (like recordings)
         for task_id, task in queue_service.external_tasks.items():
             if task.status.value in ['running', 'pending']:
                 task_info = task.to_dict()
+                # Debug logging for external task payload
+                streamer_name = task_info.get('payload', {}).get('streamer_name', 'NOT_FOUND')
+                logger.info(f"External task {task_id}: type={task_info.get('task_type')}, streamer_name={streamer_name}, payload_keys={list(task_info.get('payload', {}).keys())}")
                 active_tasks.append(task_info)
         
         return active_tasks

--- a/app/models.py
+++ b/app/models.py
@@ -84,6 +84,7 @@ class Stream(Base):
     streamer = relationship("Streamer", backref="streams")
     stream_metadata = relationship("StreamMetadata", back_populates="stream", uselist=False)
     active_recording_state = relationship("ActiveRecordingState", back_populates="stream", uselist=False, cascade="all, delete-orphan")
+    events = relationship("StreamEvent", back_populates="stream", cascade="all, delete-orphan")
     
     @property
     def is_live(self):
@@ -106,6 +107,9 @@ class StreamEvent(Base):
     category_name = Column(String, nullable=True)
     language = Column(String, nullable=True)
     timestamp = Column(DateTime(timezone=True), server_default=func.now(), index=True)
+    
+    # Relationships
+    stream = relationship("Stream", back_populates="events")
     
 class User(Base):
     __tablename__ = "users"

--- a/app/routes/status.py
+++ b/app/routes/status.py
@@ -230,14 +230,14 @@ async def get_streamers_status() -> Dict[str, Any]:
                 
                 # Get profile image URL safely
                 profile_image_url = None
-                try:
-                    if unified_image_service:
+                if unified_image_service:
+                    try:
                         profile_image_url = unified_image_service.get_profile_image_url(
                             streamer.id, 
                             streamer.profile_image_url
                         )
-                except Exception as e:
-                    logger.warning(f"Failed to get profile image URL for streamer {streamer.id}: {e}")
+                    except Exception as e:
+                        logger.warning(f"Failed to get profile image URL for streamer {streamer.id}: {e}")
                 
                 streamer_status.append({
                     "id": streamer.id,

--- a/app/routes/status.py
+++ b/app/routes/status.py
@@ -228,15 +228,23 @@ async def get_streamers_status() -> Dict[str, Any]:
                 if is_live:
                     online_count += 1
                 
+                # Get profile image URL safely
+                profile_image_url = None
+                try:
+                    if unified_image_service:
+                        profile_image_url = unified_image_service.get_profile_image_url(
+                            streamer.id, 
+                            streamer.profile_image_url
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to get profile image URL for streamer {streamer.id}: {e}")
+                
                 streamer_status.append({
                     "id": streamer.id,
                     "name": streamer.username,
                     "display_name": streamer.display_name,
                     "twitch_id": streamer.twitch_id,
-                    "profile_image_url": unified_image_service.get_profile_image_url(
-                        streamer.id, 
-                        streamer.profile_image_url
-                    ),
+                    "profile_image_url": profile_image_url,
                     "is_live": is_live,
                     "is_recording": is_recording,
                     "is_favorite": streamer.is_favorite,


### PR DESCRIPTION
This pull request improves the error handling and robustness of the `get_streamers_status` function by safely retrieving profile image URLs and logging any failures.

### Enhancements to error handling:

* [`app/routes/status.py`](diffhunk://#diff-d4ea8cf9ba9d64ec8fcb5467f2cb63ba49c8f6757f051073649af430f240d38cR231-R247): Updated the `get_streamers_status` function to wrap the call to `unified_image_service.get_profile_image_url` in a `try-except` block. This ensures that any exceptions during the retrieval of profile image URLs are caught and logged, preventing the function from failing entirely.