### PR TITLE
fix: update video stream API endpoint paths for consistency

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -3689,9 +3689,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {

--- a/app/frontend/src/components/VideoModal.vue
+++ b/app/frontend/src/components/VideoModal.vue
@@ -123,7 +123,7 @@ const currentChapter = ref(-1)
 
 const videoUrl = computed(() => {
   // Use the stream ID based endpoint
-  return `/api/videos/stream/${props.video.id}`
+  return `/api/videos/${props.video.id}/stream`
 })
 
 const closeModal = () => {
@@ -237,7 +237,7 @@ const fallbackShare = (url) => {
     
   const shareUrl = url || (sessionToken ? 
     `${window.location.origin}/api/videos/public/${props.video.id}?token=${sessionToken}` :
-    `${window.location.origin}/api/videos/stream/${props.video.id}`)
+    `${window.location.origin}/api/videos/${props.video.id}/stream`)
     
   navigator.clipboard.writeText(shareUrl).then(() => {
     alert('Direct video link copied!\n\nVLC: Press Ctrl+N (or Cmd+N on Mac) and paste the link\nOther players: Use "Open Network Stream" or similar option')

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -231,12 +231,12 @@ export const videoApi = {
 
   // Stream video
   streamVideo: (videoId: number) => 
-    apiClient.get(`/api/videos/stream/${videoId}`),
+    apiClient.get(`/api/videos/${videoId}/stream`),
 
   // Get video stream URL (returns string for direct use in video src attribute)
   // Note: This method returns a string URL, not a Promise like other methods
   getVideoStreamUrl: (videoId: number): string => 
-    `/api/videos/stream/${videoId}`,
+    `/api/videos/${videoId}/stream`,
 
   // Get video metadata
   getMetadata: (videoId: number) => 

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -231,12 +231,12 @@ export const videoApi = {
 
   // Stream video
   streamVideo: (videoId: number) => 
-    apiClient.get(`/api/videos/${videoId}/stream`),
+    apiClient.get(`/api/videos/stream/${videoId}`),
 
   // Get video stream URL (returns string for direct use in video src attribute)
   // Note: This method returns a string URL, not a Promise like other methods
   getVideoStreamUrl: (videoId: number): string => 
-    `/api/videos/${videoId}/stream`,
+    `/api/videos/stream/${videoId}`,
 
   // Get video metadata
   getMetadata: (videoId: number) => 

--- a/app/routes/streamers.py
+++ b/app/routes/streamers.py
@@ -787,7 +787,7 @@ async def get_stream_chapters(
                 video_path = Path(stream.recording_path)
                 if video_path.exists():
                     # Use the stream ID for direct video streaming
-                    video_url = f"/api/videos/stream/{stream.id}"
+                    video_url = f"/api/videos/{stream.id}/stream"
                 else:
                     logger.warning(f"Video file not found: {video_path}")
             except Exception as e:

--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -127,7 +127,7 @@ def get_video_thumbnail_url(stream_id: int, recording_path: str) -> Optional[str
         for thumbnail_path in thumbnail_candidates:
             if thumbnail_path.exists() and thumbnail_path.is_file():
                 # Return relative URL for API access
-                return f"/api/videos/thumbnail/{stream_id}"
+                return f"/api/videos/{stream_id}/thumbnail"
         
         return None
     except Exception as e:
@@ -378,7 +378,7 @@ async def debug_video_access(stream_id: int, request: Request, db: Session = Dep
         # Don't expose internal error details to users
         return {"error": "Internal error occurred", "success": False}
 
-@router.get("/videos/thumbnail/{stream_id}")
+@router.get("/videos/{stream_id}/thumbnail")
 async def get_video_thumbnail(stream_id: int, request: Request, db: Session = Depends(get_db)):
     """Serve video thumbnail image"""
     try:
@@ -542,7 +542,7 @@ async def stream_video_public(stream_id: int, token: str = Query(...), request: 
         logger.error(f"Error streaming public video {stream_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
-@router.get("/videos/stream/{stream_id}")
+@router.get("/videos/{stream_id}/stream")
 async def stream_video_by_id(stream_id: int, request: Request, db: Session = Depends(get_db)):
     """Stream a video file by stream ID with range request support"""
     try:


### PR DESCRIPTION
This pull request updates the API endpoint structure for video streaming in the `videoApi` object. The changes ensure consistency in the URL format across methods.

### API endpoint updates:

* [`app/frontend/src/services/api.ts`](diffhunk://#diff-9a43d33c3a9bbc761e66ef2cc6b7b50e0d7036c52310486a0978da5c9068504eL234-R239): Updated the `streamVideo` and `getVideoStreamUrl` methods to use the new endpoint structure `/api/videos/stream/:videoId` instead of `/api/videos/:videoId/stream`.