### PR TITLE
Optimize workflow

### DIFF
--- a/app/services/images/stream_artwork_service.py
+++ b/app/services/images/stream_artwork_service.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, Optional, List
 from sqlalchemy.orm import Session, selectinload
 from app.database import SessionLocal
-from app.models import Stream, Streamer
+from app.models import Stream, Streamer, StreamMetadata
 from .image_download_service import ImageDownloadService
 
 logger = logging.getLogger("streamvault")
@@ -106,10 +106,8 @@ class StreamArtworkService:
                 if cached_path:
                     # Ensure stream has metadata
                     if not stream.stream_metadata:
-                        from app.models import StreamMetadata
                         metadata = StreamMetadata(stream_id=stream_id)
                         db.add(metadata)
-                        db.flush()  # Get the ID
                         stream.stream_metadata = metadata
                     
                     # Update metadata with cached path

--- a/app/utils/async_db_utils.py
+++ b/app/utils/async_db_utils.py
@@ -31,8 +31,10 @@ async def get_recent_streams(limit: int = 10) -> List[Stream]:
     async with async_session() as session:
         try:
             # Get recent completed streams (those with recording_path or ended_at)
+            # Also load the stream_metadata relationship for thumbnail_url access
             result = await session.execute(
                 select(Stream)
+                .options(selectinload(Stream.stream_metadata))
                 .filter(
                     (Stream.ended_at.isnot(None)) | 
                     (Stream.recording_path.isnot(None))


### PR DESCRIPTION
This pull request refactors how stream artwork is handled by introducing and utilizing a `stream_metadata` relationship for storing and accessing thumbnail URLs. The changes improve the structure and maintainability of the code by centralizing thumbnail URL management in the `stream_metadata` model. Key updates include modifying queries, ensuring metadata creation when missing, and updating logic for downloading and caching artwork.

### Refactoring for `stream_metadata` usage:

* `app/services/images/image_refresh_service.py`:
  - Updated `_refresh_missing_stream_artwork` to check and use `stream_metadata.thumbnail_url` instead of `stream.thumbnail_url`. Added logic to handle cases where metadata or thumbnail URL is missing. [[1]](diffhunk://#diff-74f654e5783fe91f689f4a27dfeacb74bfc737e5e2d74ed59979aff1568bcfbbL191-R196) [[2]](diffhunk://#diff-74f654e5783fe91f689f4a27dfeacb74bfc737e5e2d74ed59979aff1568bcfbbR221-R233)

* `app/services/images/stream_artwork_service.py`:
  - Modified `update_stream_artwork` to ensure `stream_metadata` exists before updating the cached thumbnail URL. Added logic to create `stream_metadata` if missing.
  - Updated `sync_stream_artwork` to preload `stream_metadata` using `selectinload` and use `stream_metadata.thumbnail_url` for artwork synchronization.

### Query optimization:

* `app/services/images/stream_artwork_service.py`:
  - Added `selectinload(Stream.stream_metadata)` to the query in `sync_stream_artwork` for efficient loading of related metadata.

* `app/utils/async_db_utils.py`:
  - Updated `get_recent_streams` to load `stream_metadata` relationship for easier access to `thumbnail_url`.

### Dependency updates:

* `app/services/images/stream_artwork_service.py`:
  - Imported `selectinload` from `sqlalchemy.orm` to support preloading of related metadata.