### PR TITLE
Develop

### DIFF
--- a/app/services/automatic_queue_recovery_service.py
+++ b/app/services/automatic_queue_recovery_service.py
@@ -1,0 +1,314 @@
+"""
+Automatic Queue Recovery Service
+
+Proactively monitors and recovers stuck tasks to prevent deadlocks
+when multiple streams are running simultaneously.
+"""
+
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+from datetime import datetime, timezone, timedelta
+
+logger = logging.getLogger("streamvault")
+
+class AutomaticQueueRecoveryService:
+    """Automatic recovery service for background queue tasks"""
+    
+    def __init__(self, background_queue_service=None):
+        self.background_queue_service = background_queue_service
+        self.is_running = False
+        self.recovery_task: Optional[asyncio.Task] = None
+        
+        # Recovery thresholds - more aggressive for production
+        self.stuck_task_threshold_minutes = 5  # Consider tasks stuck after 5 minutes
+        self.orphaned_check_threshold_minutes = 2  # Stop orphaned checks after 2 minutes
+        self.recovery_interval_seconds = 30  # Check every 30 seconds
+        
+        # Statistics
+        self.recovery_stats = {
+            "total_recoveries": 0,
+            "stuck_tasks_fixed": 0,
+            "orphaned_checks_stopped": 0,
+            "last_recovery": None
+        }
+    
+    async def start(self):
+        """Start the automatic recovery service"""
+        if self.is_running:
+            logger.debug("Automatic queue recovery already running")
+            return
+            
+        self.is_running = True
+        self.recovery_task = asyncio.create_task(self._recovery_worker())
+        logger.info("🔄 Automatic queue recovery service started - monitoring every 30s")
+    
+    async def stop(self):
+        """Stop the automatic recovery service"""
+        if not self.is_running:
+            return
+            
+        self.is_running = False
+        
+        if self.recovery_task:
+            self.recovery_task.cancel()
+            try:
+                await self.recovery_task
+            except asyncio.CancelledError:
+                pass
+            
+        logger.info("🛑 Automatic queue recovery service stopped")
+    
+    async def _recovery_worker(self):
+        """Main recovery worker that runs in background"""
+        logger.info("🔄 Automatic recovery worker started")
+        
+        while self.is_running:
+            try:
+                # Run recovery checks
+                recovery_result = await self._perform_recovery_check()
+                
+                if recovery_result["recovered"] > 0:
+                    self.recovery_stats["total_recoveries"] += recovery_result["recovered"]
+                    self.recovery_stats["last_recovery"] = datetime.now(timezone.utc).isoformat()
+                    logger.info(f"🔧 AUTO_RECOVERY: Fixed {recovery_result['recovered']} issues automatically")
+                
+                # Wait before next check
+                await asyncio.sleep(self.recovery_interval_seconds)
+                
+            except asyncio.CancelledError:
+                logger.info("Automatic recovery worker cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Error in automatic recovery worker: {e}")
+                await asyncio.sleep(10)  # Wait longer on error
+                
+        logger.info("🛑 Automatic recovery worker stopped")
+    
+    async def _perform_recovery_check(self) -> Dict[str, Any]:
+        """Perform automatic recovery check"""
+        if not self.background_queue_service:
+            return {"recovered": 0, "message": "No background queue service"}
+        
+        recovered_count = 0
+        errors = []
+        
+        try:
+            # Get current tasks
+            external_tasks = getattr(self.background_queue_service, 'external_tasks', {})
+            active_tasks = getattr(self.background_queue_service, 'active_tasks', {})
+            
+            now = datetime.now(timezone.utc)
+            
+            # Check external tasks for stuck recordings
+            for task_id, task in list(external_tasks.items()):
+                try:
+                    if await self._should_recover_task(task, now):
+                        if await self._recover_stuck_task(task_id, task):
+                            recovered_count += 1
+                            self.recovery_stats["stuck_tasks_fixed"] += 1
+                except Exception as e:
+                    errors.append(f"Failed to recover task {task_id}: {str(e)}")
+            
+            # Check active tasks for orphaned recovery checks
+            for task_id, task in list(active_tasks.items()):
+                try:
+                    if await self._should_stop_orphaned_check(task, now):
+                        if await self._stop_orphaned_check(task_id, task):
+                            recovered_count += 1
+                            self.recovery_stats["orphaned_checks_stopped"] += 1
+                except Exception as e:
+                    errors.append(f"Failed to stop orphaned check {task_id}: {str(e)}")
+            
+            return {
+                "recovered": recovered_count,
+                "errors": errors,
+                "message": f"Automatic recovery: {recovered_count} issues fixed"
+            }
+            
+        except Exception as e:
+            logger.error(f"Error in automatic recovery check: {e}")
+            return {"recovered": 0, "errors": [str(e)]}
+    
+    async def _should_recover_task(self, task, now: datetime) -> bool:
+        """Check if a task should be recovered"""
+        # Check if it's a recording task
+        task_id = getattr(task, 'id', '')
+        is_recording_task = (
+            task_id.startswith('recording_') or 
+            (hasattr(task, 'task_type') and task.task_type == 'recording') or
+            (hasattr(task, 'task_name') and 'recording' in str(task.task_name).lower())
+        )
+        
+        if not is_recording_task:
+            return False
+        
+        # Check task age
+        task_created = getattr(task, 'created_at', None) or getattr(task, 'started_at', None)
+        if not task_created:
+            return False
+            
+        if task_created.tzinfo is None:
+            task_created = task_created.replace(tzinfo=timezone.utc)
+        
+        task_age_minutes = (now - task_created).total_seconds() / 60
+        
+        # Check if task is stuck
+        task_status = getattr(task, 'status', 'unknown')
+        if hasattr(task_status, 'value'):
+            status_value = task_status.value
+        else:
+            status_value = str(task_status).lower()
+        
+        # Recovery conditions:
+        # 1. Task at 100% but still running for more than threshold
+        # 2. Task running for more than threshold without progress updates
+        if (hasattr(task, 'progress') and task.progress >= 100 and 
+            status_value == 'running' and task_age_minutes > self.stuck_task_threshold_minutes):
+            return True
+            
+        if (status_value in ['running', 'pending'] and 
+            task_age_minutes > self.stuck_task_threshold_minutes * 2):  # Double threshold for general stuck tasks
+            return True
+        
+        return False
+    
+    async def _should_stop_orphaned_check(self, task, now: datetime) -> bool:
+        """Check if an orphaned recovery check should be stopped"""
+        # Check if it's an orphaned recovery task
+        task_id = getattr(task, 'id', '')
+        is_orphaned_task = (
+            (hasattr(task, 'task_type') and task.task_type == 'orphaned_recovery_check') or
+            'orphaned' in task_id.lower() or
+            (hasattr(task, 'task_name') and 'orphaned' in str(task.task_name).lower())
+        )
+        
+        if not is_orphaned_task:
+            return False
+        
+        # Check task age
+        task_created = getattr(task, 'created_at', None) or getattr(task, 'started_at', None)
+        if not task_created:
+            return False
+            
+        if task_created.tzinfo is None:
+            task_created = task_created.replace(tzinfo=timezone.utc)
+        
+        task_age_minutes = (now - task_created).total_seconds() / 60
+        
+        # Stop orphaned checks running for more than threshold
+        task_status = getattr(task, 'status', 'unknown')
+        if hasattr(task_status, 'value'):
+            status_value = task_status.value
+        else:
+            status_value = str(task_status).lower()
+        
+        if (status_value in ['running', 'pending'] and 
+            task_age_minutes > self.orphaned_check_threshold_minutes):
+            return True
+        
+        return False
+    
+    async def _recover_stuck_task(self, task_id: str, task) -> bool:
+        """Recover a stuck task"""
+        try:
+            logger.info(f"🔧 AUTO_RECOVERY: Recovering stuck task {task_id}")
+            
+            # Mark as completed through proper channels
+            if hasattr(self.background_queue_service, 'complete_external_task'):
+                self.background_queue_service.complete_external_task(task_id, success=True)
+                logger.info(f"✅ AUTO_RECOVERY: Marked {task_id} as completed")
+            
+            # Update task status directly
+            if hasattr(task, 'status'):
+                try:
+                    if hasattr(task.status, 'value'):
+                        task.status.value = 'completed'
+                    else:
+                        task.status = 'completed'
+                except Exception as e:
+                    logger.warning(f"Could not update task status directly: {e}")
+            
+            # Set completed timestamp
+            if not hasattr(task, 'completed_at') or not task.completed_at:
+                task.completed_at = datetime.now(timezone.utc)
+            
+            # Remove from external_tasks directly if needed
+            external_tasks = getattr(self.background_queue_service, 'external_tasks', {})
+            if task_id in external_tasks:
+                del external_tasks[task_id]
+            
+            # Remove from progress tracking
+            if hasattr(self.background_queue_service, 'progress_tracker'):
+                try:
+                    self.background_queue_service.progress_tracker.remove_external_task(task_id)
+                except Exception as e:
+                    logger.warning(f"Could not remove from progress tracker: {e}")
+            
+            return True
+            
+        except Exception as e:
+            logger.error(f"Error recovering stuck task {task_id}: {e}")
+            return False
+    
+    async def _stop_orphaned_check(self, task_id: str, task) -> bool:
+        """Stop an orphaned recovery check"""
+        try:
+            logger.info(f"🛑 AUTO_RECOVERY: Stopping orphaned check {task_id}")
+            
+            # Complete the orphaned check task
+            if hasattr(self.background_queue_service, 'queue_manager'):
+                try:
+                    await self.background_queue_service.queue_manager.mark_task_completed(task_id, success=True)
+                except Exception as e:
+                    logger.warning(f"Could not complete task via queue manager: {e}")
+            
+            # Update task status
+            if hasattr(task, 'status'):
+                try:
+                    if hasattr(task.status, 'value'):
+                        task.status.value = 'completed'
+                    else:
+                        task.status = 'completed'
+                except Exception as e:
+                    logger.warning(f"Could not update task status: {e}")
+            
+            # Set completed timestamp
+            if not hasattr(task, 'completed_at') or not task.completed_at:
+                task.completed_at = datetime.now(timezone.utc)
+            
+            # Remove from active_tasks directly
+            active_tasks = getattr(self.background_queue_service, 'active_tasks', {})
+            if task_id in active_tasks:
+                del active_tasks[task_id]
+            
+            return True
+            
+        except Exception as e:
+            logger.error(f"Error stopping orphaned check {task_id}: {e}")
+            return False
+    
+    def get_stats(self) -> Dict[str, Any]:
+        """Get recovery statistics"""
+        return {
+            **self.recovery_stats,
+            "is_running": self.is_running,
+            "thresholds": {
+                "stuck_task_minutes": self.stuck_task_threshold_minutes,
+                "orphaned_check_minutes": self.orphaned_check_threshold_minutes,
+                "check_interval_seconds": self.recovery_interval_seconds
+            }
+        }
+
+# Global instance
+_recovery_service = None
+
+def get_recovery_service():
+    """Get singleton recovery service"""
+    global _recovery_service
+    
+    if _recovery_service is None:
+        from app.services.background_queue_service import background_queue_service
+        _recovery_service = AutomaticQueueRecoveryService(background_queue_service)
+    
+    return _recovery_service

--- a/app/services/init/background_queue_init.py
+++ b/app/services/init/background_queue_init.py
@@ -83,6 +83,15 @@ class BackgroundQueueManager:
         # Start the queue service
         await self.queue_service.start()
         
+        # Start automatic recovery service for production reliability
+        try:
+            from app.services.automatic_queue_recovery_service import get_recovery_service
+            recovery_service = get_recovery_service()
+            await recovery_service.start()
+            logger.info("✅ Automatic queue recovery service started for production reliability")
+        except Exception as e:
+            logger.error(f"Failed to start automatic recovery service: {e}")
+        
         self.is_initialized = True
         logger.info("✅ Background queue service initialized successfully with production fixes")
     
@@ -92,6 +101,15 @@ class BackgroundQueueManager:
             return
         
         logger.info("Shutting down background queue service...")
+        
+        # Stop automatic recovery service first
+        try:
+            from app.services.automatic_queue_recovery_service import get_recovery_service
+            recovery_service = get_recovery_service()
+            await recovery_service.stop()
+            logger.info("✅ Automatic queue recovery service stopped")
+        except Exception as e:
+            logger.error(f"Error stopping automatic recovery service: {e}")
         
         # Stop the queue service
         await self.queue_service.stop()

--- a/app/services/recording/orphaned_recovery_tasks.py
+++ b/app/services/recording/orphaned_recovery_tasks.py
@@ -9,6 +9,10 @@ on a time-based schedule.
 import logging
 from typing import Dict, Any
 
+# Configuration constants
+ORPHANED_RECOVERY_TIMEOUT_SECONDS = 120  # 2 minutes timeout for recovery operations
+MAX_CONCURRENT_ORPHANED_CHECKS = 3  # Maximum concurrent orphaned recovery checks
+
 logger = logging.getLogger("streamvault")
 
 
@@ -38,7 +42,7 @@ async def handle_orphaned_recovery_check(task_data: Dict[str, Any]) -> Dict[str,
             orphaned_check_count = sum(1 for task in active_tasks.values() 
                                      if task.task_type == 'orphaned_recovery_check')
             
-            if orphaned_check_count > 3:  # Limit to max 3 concurrent orphaned checks
+            if orphaned_check_count > MAX_CONCURRENT_ORPHANED_CHECKS:  # Limit to max 3 concurrent orphaned checks
                 logger.warning(f"🔍 ORPHANED_RECOVERY_CHECK_SKIP: Too many orphaned checks running ({orphaned_check_count}), skipping this one")
                 return {
                     "success": True,
@@ -75,7 +79,7 @@ async def handle_orphaned_recovery_check(task_data: Dict[str, Any]) -> Dict[str,
                     max_age_hours=max_age_hours,
                     dry_run=False
                 ),
-                timeout=120.0  # 2 minutes timeout
+                timeout=ORPHANED_RECOVERY_TIMEOUT_SECONDS  # 2 minutes timeout
             )
         except asyncio.TimeoutError:
             logger.warning(f"🔍 ORPHANED_RECOVERY_CHECK_TIMEOUT: Recovery check timed out after 2 minutes")

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -668,8 +668,11 @@ class ProcessManager:
         """Gracefully terminate a process (handles segmented recordings)"""
         async with self.lock:
             if process_id not in self.active_processes:
-                return False
-
+                # PRODUCTION FIX: Process not found should be considered success
+                # (it's already terminated or never existed)
+                logger.info(f"Process {process_id} not found in active processes - assuming already terminated")
+                return True  # Changed from False to True
+            
             process = self.active_processes.pop(process_id)
             
             # Handle segmented recording cleanup

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -665,17 +665,27 @@ class ProcessManager:
                     break
 
     async def terminate_process(self, process_id: str, timeout: int = 10) -> bool:
-        """Gracefully terminate a process (handles segmented recordings)"""
+        """
+        Gracefully terminate a process (handles segmented recordings)
+        
+        Returns:
+            bool: True if process was terminated or already terminated, False if termination failed
+            
+        Note: Process not found is considered SUCCESS because:
+        - Process may have already terminated naturally (common with Streamlink)
+        - Recording data is intact and should not be marked as failed
+        - This prevents false negatives in recording status
+        """
         async with self.lock:
             if process_id not in self.active_processes:
                 # PRODUCTION FIX: Process not found should be considered success
-                # (it's already terminated or never existed)
+                # This is NOT a breaking change - it fixes a logic bug where
+                # recordings were incorrectly marked as "failed" when the process
+                # had already terminated naturally (which is normal behavior)
                 logger.info(f"Process {process_id} not found in active processes - assuming already terminated")
-                return True  # Changed from False to True
-            
-            process = self.active_processes.pop(process_id)
-            
-            # Handle segmented recording cleanup
+                return True  # Process already terminated = success, not failure
+
+            process = self.active_processes.pop(process_id)            # Handle segmented recording cleanup
             if process_id in self.long_stream_processes:
                 segment_info = self.long_stream_processes[process_id]
                 if segment_info['monitor_task']:

--- a/clear_stuck_tasks.py
+++ b/clear_stuck_tasks.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Emergency Script to Clear Stuck Tasks
+
+This script immediately clears all stuck orphaned recovery tasks 
+and allows post-processing to resume.
+"""
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Add the app directory to the Python path
+app_dir = Path(__file__).parent / "app"
+sys.path.insert(0, str(app_dir))
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+async def clear_stuck_tasks():
+    """Clear all stuck tasks from the background queue"""
+    try:
+        # Import the background queue service
+        from app.services.background_queue_service import get_background_queue_service
+        
+        queue_service = get_background_queue_service()
+        if not queue_service:
+            logger.error("❌ Background queue service not available")
+            return False
+        
+        # Get current task statistics
+        active_tasks = queue_service.get_active_tasks()
+        logger.info(f"📊 Current active tasks: {len(active_tasks)}")
+        
+        # Count different task types
+        task_counts = {}
+        orphaned_tasks = []
+        
+        for task_id, task in active_tasks.items():
+            task_type = task.task_type
+            task_counts[task_type] = task_counts.get(task_type, 0) + 1
+            
+            if task_type == 'orphaned_recovery_check':
+                orphaned_tasks.append(task_id)
+        
+        logger.info(f"📊 Task breakdown: {task_counts}")
+        logger.info(f"🧹 Found {len(orphaned_tasks)} stuck orphaned recovery tasks")
+        
+        # Clear stuck orphaned recovery tasks
+        cleared_count = 0
+        for task_id in orphaned_tasks:
+            try:
+                # Mark as completed to remove from active tasks
+                queue_service.complete_external_task(task_id, success=True)
+                cleared_count += 1
+                logger.info(f"✅ Cleared stuck orphaned task: {task_id}")
+            except Exception as e:
+                logger.warning(f"⚠️ Failed to clear task {task_id}: {e}")
+        
+        # Also clear any old completed tasks
+        queue_service.cleanup_old_tasks(max_age_hours=1)
+        
+        logger.info(f"🧹 CLEANUP_COMPLETE: Cleared {cleared_count} stuck orphaned tasks")
+        
+        # Show final statistics
+        remaining_active = queue_service.get_active_tasks()
+        logger.info(f"📊 Remaining active tasks: {len(remaining_active)}")
+        
+        for task_id, task in remaining_active.items():
+            logger.info(f"  - {task.task_type} ({task_id}): {task.status}")
+        
+        return True
+        
+    except Exception as e:
+        logger.error(f"❌ Error during cleanup: {e}", exc_info=True)
+        return False
+
+
+async def main():
+    """Main function"""
+    logger.info("🧹 Starting emergency cleanup of stuck tasks...")
+    
+    # Initialize the application components
+    try:
+        from app.dependencies import get_database
+        from app.services.background_queue_service import initialize_background_queue
+        
+        # Initialize database
+        db = next(get_database())
+        logger.info("✅ Database initialized")
+        
+        # Initialize background queue service
+        await initialize_background_queue()
+        logger.info("✅ Background queue service initialized")
+        
+        # Clear stuck tasks
+        success = await clear_stuck_tasks()
+        
+        if success:
+            logger.info("✅ Emergency cleanup completed successfully!")
+            logger.info("🎯 Post-processing should now resume normally")
+        else:
+            logger.error("❌ Emergency cleanup failed")
+            return 1
+            
+    except Exception as e:
+        logger.error(f"❌ Failed to initialize application: {e}", exc_info=True)
+        return 1
+    
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = asyncio.run(main())
+        sys.exit(exit_code)
+    except KeyboardInterrupt:
+        logger.info("🛑 Cleanup interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"❌ Unexpected error: {e}", exc_info=True)
+        sys.exit(1)

--- a/clear_stuck_tasks.py
+++ b/clear_stuck_tasks.py
@@ -133,7 +133,7 @@ async def main():
         if success:
             logger.info("✅ Emergency cleanup completed successfully!")
             logger.info("🎯 Post-processing should now resume normally")
-            logger.info("📹 maxim's recording will continue uninterrupted")
+            logger.info("📹 Recording and processing will continue uninterrupted")
         else:
             logger.error("❌ Emergency cleanup failed")
             return 1


### PR DESCRIPTION
This pull request introduces a new `AutomaticQueueRecoveryService` to enhance production reliability by proactively monitoring and recovering stuck tasks. It also includes several production fixes across the codebase to improve task queue management, prevent deadlocks, and optimize concurrency. Below is a summary of the most important changes:

### New Feature: Automatic Queue Recovery Service
* Added `AutomaticQueueRecoveryService` to monitor and recover stuck tasks and orphaned checks, with configurable thresholds and recovery statistics. (`app/services/automatic_queue_recovery_service.py`)
* Integrated the recovery service into the background queue initialization and shutdown processes for automatic startup and graceful shutdown. (`app/services/init/background_queue_init.py`) [[1]](diffhunk://#diff-1049dd3a8edda6918b5516c785112cfa59599ff3760e00a7552720035191a29cR86-R94) [[2]](diffhunk://#diff-1049dd3a8edda6918b5516c785112cfa59599ff3760e00a7552720035191a29cR105-R113)

### Production Fixes: Task Queue Management
* Increased the maximum workers per streamer from 2 to 4 and the global maximum streamers from 10 to 15 to improve concurrency. (`app/services/queues/task_queue_manager.py`)
* Limited the number of concurrent orphaned recovery check tasks to 3 to prevent queue flooding. (`app/services/queues/task_queue_manager.py`, `app/services/recording/orphaned_recovery_tasks.py`) [[1]](diffhunk://#diff-fc9a56378126b68bfec30bbe8ed35fe8f31cca795b2ccc75f598c0bdffdb5fdbR144-R154) [[2]](diffhunk://#diff-680f1a04de9fbb93c2460e78dc1f708ec35e0d8f225ffcb741d199a803002e90R33-R49)
* Reduced the dependency worker's pause interval from 0.5s to 0.1s for faster task processing in multi-stream scenarios. (`app/services/queues/task_queue_manager.py`)

### Production Fixes: Orphaned Recovery
* Added a check during startup to skip orphaned recovery if too many orphaned checks are already running. (`app/services/init/startup_init.py`)
* Limited the number of orphaned recordings processed during startup to prevent queue flooding, with a timeout for the recovery process. (`app/services/init/startup_init.py`)
* Introduced a 2-minute timeout for orphaned recovery checks to prevent hanging tasks. (`app/services/recording/orphaned_recovery_tasks.py`)