### PR TITLE
fix: add optional progress callback to segment concatenation handler

### DIFF
--- a/app/api/failed_recovery_endpoints.py
+++ b/app/api/failed_recovery_endpoints.py
@@ -1,0 +1,147 @@
+"""
+Failed Recording Recovery API Endpoints
+
+Provides API endpoints for managing and triggering failed recording recovery.
+"""
+
+from fastapi import APIRouter, HTTPException, Query, BackgroundTasks
+from typing import Dict, Any
+import logging
+
+logger = logging.getLogger("streamvault")
+
+router = APIRouter(prefix="/api/admin/failed-recovery", tags=["Failed Recording Recovery"])
+
+
+@router.get("/stats")
+async def get_failed_recovery_stats() -> Dict[str, Any]:
+    """Get statistics about failed recordings that can be recovered"""
+    try:
+        from app.services.recording.failed_recording_recovery_service import get_failed_recovery_service
+        
+        recovery_service = await get_failed_recovery_service()
+        result = await recovery_service.scan_and_recover_failed_recordings(dry_run=True)
+        
+        return {
+            "success": True,
+            "stats": {
+                "failed_recordings": result["failed_found"],
+                "recoverable_recordings": result["recoverable_found"],
+                "pending_recovery": result["recovery_triggered"]
+            },
+            "details": result["details"]
+        }
+        
+    except Exception as e:
+        logger.error(f"Failed to get failed recovery stats: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get stats: {str(e)}")
+
+
+@router.post("/scan")
+async def scan_failed_recordings(
+    dry_run: bool = Query(False, description="If true, only show what would be recovered"),
+    background_tasks: BackgroundTasks = None
+) -> Dict[str, Any]:
+    """Scan for failed recordings and optionally trigger recovery"""
+    try:
+        from app.services.recording.failed_recovery_recovery_service import get_failed_recovery_service
+        
+        recovery_service = await get_failed_recovery_service()
+        
+        if dry_run:
+            # Synchronous dry run
+            result = await recovery_service.scan_and_recover_failed_recordings(dry_run=True)
+            
+            return {
+                "success": True,
+                "message": "Dry run completed",
+                "data": result
+            }
+        else:
+            # Asynchronous recovery in background
+            if background_tasks:
+                background_tasks.add_task(
+                    _background_failed_recovery,
+                    recovery_service
+                )
+            else:
+                # Run synchronously if no background tasks available
+                result = await recovery_service.scan_and_recover_failed_recordings(dry_run=False)
+                return {
+                    "success": True,
+                    "message": "Recovery completed",
+                    "data": result
+                }
+            
+            return {
+                "success": True,
+                "message": "Failed recording recovery started in background",
+                "data": {
+                    "background": True
+                }
+            }
+        
+    except Exception as e:
+        logger.error(f"Failed to scan failed recordings: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to scan: {str(e)}")
+
+
+@router.post("/recover/{recording_id}")
+async def recover_specific_recording(recording_id: int) -> Dict[str, Any]:
+    """Manually trigger recovery for a specific failed recording"""
+    try:
+        from app.services.recording.failed_recording_recovery_service import get_failed_recovery_service
+        
+        recovery_service = await get_failed_recovery_service()
+        result = await recovery_service.recover_specific_recording(recording_id)
+        
+        if result["success"]:
+            return {
+                "success": True,
+                "message": result["message"],
+                "data": {
+                    "recording_id": recording_id,
+                    "segments_found": result.get("segments_found", 0),
+                    "segments_dir": result.get("segments_dir")
+                }
+            }
+        else:
+            return {
+                "success": False,
+                "message": result["error"]
+            }
+        
+    except Exception as e:
+        logger.error(f"Failed to recover recording {recording_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to recover recording: {str(e)}")
+
+
+async def _background_failed_recovery(recovery_service):
+    """Background task for failed recording recovery"""
+    try:
+        logger.info("🔧 Starting background failed recording recovery...")
+        
+        result = await recovery_service.scan_and_recover_failed_recordings(dry_run=False)
+        
+        logger.info(f"🔧 Background failed recovery completed: "
+                   f"triggered={result['recovery_triggered']}, "
+                   f"failed={result['recovery_failed']}")
+        
+        # Send WebSocket notification if available
+        try:
+            from app.services.websocket.websocket_service import websocket_service
+            if websocket_service and result["recovery_triggered"] > 0:
+                await websocket_service.send_system_notification({
+                    "type": "failed_recovery_completed",
+                    "message": f"Failed recording recovery completed: {result['recovery_triggered']} recordings processed",
+                    "data": {
+                        "recovery_triggered": result["recovery_triggered"],
+                        "recovery_failed": result["recovery_failed"],
+                        "total_recoverable": result["recoverable_found"]
+                    }
+                })
+        except Exception as e:
+            logger.debug(f"Could not send WebSocket notification: {e}")
+        
+    except Exception as e:
+        logger.error(f"Background failed recording recovery failed: {e}", exc_info=True)

--- a/app/main.py
+++ b/app/main.py
@@ -716,6 +716,10 @@ app.include_router(status.router, prefix="/api")  # Status API routes - independ
 from app.api import orphaned_recovery_endpoints
 app.include_router(orphaned_recovery_endpoints.router)
 
+# Failed recording recovery routes
+from app.api import failed_recovery_endpoints
+app.include_router(failed_recovery_endpoints.router)
+
 # Push notification routes
 from app.routes import push as push_router
 app.include_router(push_router.router)

--- a/app/services/init/startup_init.py
+++ b/app/services/init/startup_init.py
@@ -111,6 +111,9 @@ async def initialize_background_services():
         # Recover orphaned recordings (unfinished post-processing jobs)
         await recover_orphaned_recordings()
         
+        # Initialize failed recording recovery service
+        await initialize_failed_recording_recovery()
+        
         # Start automatic recording database fix service
         await start_recording_auto_fix_service()
         
@@ -200,6 +203,23 @@ async def recover_orphaned_recordings():
         
     except Exception as e:
         logger.error(f"Failed to recover orphaned recordings: {e}", exc_info=True)
+        # Don't raise - this is not critical for startup
+
+
+async def initialize_failed_recording_recovery():
+    """Initialize automatic failed recording recovery service"""
+    try:
+        logger.info("🔧 Initializing failed recording recovery service...")
+        
+        from app.services.recording.failed_recording_recovery_service import get_failed_recovery_service
+        
+        # Start the failed recording recovery service
+        recovery_service = await get_failed_recovery_service()
+        
+        logger.info("🔧 Failed recording recovery service initialized successfully")
+        
+    except Exception as e:
+        logger.error(f"Failed to initialize failed recording recovery service: {e}", exc_info=True)
         # Don't raise - this is not critical for startup
 
 

--- a/app/services/recording/failed_recording_recovery_service.py
+++ b/app/services/recording/failed_recording_recovery_service.py
@@ -1,0 +1,322 @@
+"""
+Failed Recording Recovery Service
+
+Automatically detects and recovers failed recordings by finding their segment files
+and triggering segment concatenation.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Dict, Any, List
+from datetime import datetime, timedelta
+
+from app.database import SessionLocal
+from app.models import Recording, Stream, Streamer
+
+logger = logging.getLogger("streamvault")
+
+
+class FailedRecordingRecoveryService:
+    """Service for automatically recovering failed recordings"""
+    
+    def __init__(self):
+        self.check_interval_minutes = 30  # Check every 30 minutes
+        self.max_age_hours = 48  # Only process recordings younger than 48 hours
+        self.is_running = False
+        self.background_task = None
+    
+    async def start(self):
+        """Start the automatic recovery service"""
+        if self.is_running:
+            logger.debug("Failed recording recovery service already running")
+            return
+            
+        logger.info("🔧 Starting failed recording recovery service...")
+        self.is_running = True
+        
+        # Run initial recovery on startup
+        await self.scan_and_recover_failed_recordings()
+        
+        # Start background task
+        self.background_task = asyncio.create_task(self._background_loop())
+        logger.info("🔧 Failed recording recovery service started successfully")
+    
+    async def stop(self):
+        """Stop the automatic recovery service"""
+        if not self.is_running:
+            return
+            
+        logger.info("🔧 Stopping failed recording recovery service...")
+        self.is_running = False
+        
+        if self.background_task:
+            self.background_task.cancel()
+            try:
+                await self.background_task
+            except asyncio.CancelledError:
+                pass
+            self.background_task = None
+        
+        logger.info("🔧 Failed recording recovery service stopped")
+    
+    async def _background_loop(self):
+        """Background loop for periodic recovery checks"""
+        try:
+            while self.is_running:
+                try:
+                    await asyncio.sleep(self.check_interval_minutes * 60)
+                    
+                    if not self.is_running:
+                        break
+                    
+                    logger.debug("🔧 Running periodic failed recording recovery check...")
+                    await self.scan_and_recover_failed_recordings()
+                    
+                except Exception as e:
+                    logger.error(f"Error in failed recording recovery loop: {e}", exc_info=True)
+                    # Wait a bit before retrying
+                    await asyncio.sleep(60)
+                    
+        except asyncio.CancelledError:
+            logger.debug("🔧 Failed recording recovery background loop cancelled")
+        except Exception as e:
+            logger.error(f"Unexpected error in failed recording recovery loop: {e}", exc_info=True)
+    
+    async def scan_and_recover_failed_recordings(self, dry_run: bool = False) -> Dict[str, Any]:
+        """
+        Scan for failed recordings and attempt recovery
+        
+        Args:
+            dry_run: If True, only return what would be recovered without doing it
+        
+        Returns:
+            Dictionary with recovery statistics
+        """
+        logger.info(f"🔧 FAILED_RECOVERY_SCAN_START: dry_run={dry_run}")
+        
+        result = {
+            "scanned_recordings": 0,
+            "failed_found": 0,
+            "recoverable_found": 0,
+            "recovery_triggered": 0,
+            "recovery_failed": 0,
+            "skipped_no_segments": 0,
+            "details": [],
+            "errors": []
+        }
+        
+        try:
+            with SessionLocal() as db:
+                # Find failed recordings from the last 48 hours
+                cutoff = datetime.utcnow() - timedelta(hours=self.max_age_hours)
+                
+                failed_recordings = (
+                    db.query(Recording)
+                    .join(Stream)
+                    .join(Streamer)
+                    .filter(Recording.status == 'failed')
+                    .filter(Recording.created_at >= cutoff)
+                    .all()
+                )
+                
+                result["scanned_recordings"] = len(failed_recordings)
+                logger.info(f"🔧 Found {len(failed_recordings)} failed recordings to check")
+                
+                for recording in failed_recordings:
+                    try:
+                        result["failed_found"] += 1
+                        
+                        # Look for segment files
+                        segment_info = await self._find_segment_files(recording)
+                        
+                        recovery_info = {
+                            "recording_id": recording.id,
+                            "streamer_name": recording.stream.streamer.username if recording.stream and recording.stream.streamer else "Unknown",
+                            "original_path": recording.path,
+                            "segments_found": len(segment_info["segments"]),
+                            "segments_dir": segment_info["segments_dir"],
+                            "recovery_triggered": False,
+                            "error": None
+                        }
+                        
+                        if not segment_info["segments"]:
+                            result["skipped_no_segments"] += 1
+                            recovery_info["error"] = "No segment files found"
+                            logger.debug(f"🔧 No segments found for recording {recording.id}")
+                        else:
+                            result["recoverable_found"] += 1
+                            logger.info(f"🔧 Found {len(segment_info['segments'])} segments for recording {recording.id}")
+                            
+                            if not dry_run:
+                                # Trigger segment concatenation
+                                success = await self._trigger_segment_concatenation(recording, segment_info, db)
+                                
+                                if success:
+                                    result["recovery_triggered"] += 1
+                                    recovery_info["recovery_triggered"] = True
+                                    logger.info(f"✅ Recovery triggered for recording {recording.id}")
+                                else:
+                                    result["recovery_failed"] += 1
+                                    recovery_info["error"] = "Failed to trigger segment concatenation"
+                                    logger.error(f"❌ Failed to trigger recovery for recording {recording.id}")
+                            else:
+                                # Dry run - count as triggered
+                                result["recovery_triggered"] += 1
+                                recovery_info["recovery_triggered"] = True
+                        
+                        result["details"].append(recovery_info)
+                        
+                    except Exception as e:
+                        result["recovery_failed"] += 1
+                        result["errors"].append(f"Recording {recording.id}: {str(e)}")
+                        logger.error(f"Error processing failed recording {recording.id}: {e}", exc_info=True)
+        
+        except Exception as e:
+            result["errors"].append(f"Scan failed: {str(e)}")
+            logger.error(f"Failed recording recovery scan failed: {e}", exc_info=True)
+        
+        logger.info(f"🔧 FAILED_RECOVERY_SCAN_COMPLETE: triggered={result['recovery_triggered']}, failed={result['recovery_failed']}")
+        return result
+    
+    async def _find_segment_files(self, recording: Recording) -> Dict[str, Any]:
+        """Find segment files for a failed recording"""
+        segments = []
+        segments_dir = None
+        
+        if not recording.path:
+            return {"segments": segments, "segments_dir": segments_dir}
+        
+        # Construct expected segment directory path
+        original_path = Path(recording.path)
+        expected_segments_dir = original_path.parent / f"{original_path.stem}_segments"
+        
+        if expected_segments_dir.exists() and expected_segments_dir.is_dir():
+            segments_dir = str(expected_segments_dir)
+            
+            # Find all .ts files in the segment directory
+            for segment_file in expected_segments_dir.glob("*.ts"):
+                if segment_file.is_file() and segment_file.stat().st_size > 0:
+                    segments.append(str(segment_file))
+            
+            # Sort segments to maintain order
+            segments.sort()
+        
+        return {"segments": segments, "segments_dir": segments_dir}
+    
+    async def _trigger_segment_concatenation(self, recording: Recording, segment_info: Dict[str, Any], db) -> bool:
+        """Trigger segment concatenation for a failed recording"""
+        try:
+            from app.services.background_queue_service import background_queue_service
+            
+            # Update recording status to prevent double-processing
+            recording.status = 'post_processing'
+            recording.updated_at = datetime.utcnow()
+            db.commit()
+            
+            # Prepare task data for segment concatenation
+            output_path = recording.path  # Use original recording path as output
+            
+            task_data = {
+                "recording_id": recording.id,
+                "segment_files": segment_info["segments"],
+                "output_path": output_path,
+                "streamer_name": recording.stream.streamer.username if recording.stream and recording.stream.streamer else "Unknown",
+                "stream_id": recording.stream_id,
+                "started_at": recording.created_at.isoformat() if recording.created_at else datetime.utcnow().isoformat()
+            }
+            
+            # Enqueue segment concatenation task
+            task_id = await background_queue_service.enqueue_task(
+                task_type="segment_concatenation",
+                task_data=task_data,
+                streamer_name=task_data["streamer_name"],
+                priority="HIGH"
+            )
+            
+            logger.info(f"🔧 SEGMENT_CONCATENATION_QUEUED: task_id={task_id}, recording_id={recording.id}")
+            return True
+            
+        except Exception as e:
+            # Revert status on error
+            try:
+                recording.status = 'failed'
+                db.commit()
+            except:
+                pass
+            
+            logger.error(f"Failed to trigger segment concatenation for recording {recording.id}: {e}")
+            return False
+    
+    async def recover_specific_recording(self, recording_id: int) -> Dict[str, Any]:
+        """Manually trigger recovery for a specific recording"""
+        try:
+            with SessionLocal() as db:
+                recording = db.query(Recording).filter(Recording.id == recording_id).first()
+                if not recording:
+                    return {
+                        "success": False,
+                        "error": f"Recording {recording_id} not found"
+                    }
+                
+                if recording.status != 'failed':
+                    return {
+                        "success": False,
+                        "error": f"Recording {recording_id} is not in failed status (current: {recording.status})"
+                    }
+                
+                # Find segments
+                segment_info = await self._find_segment_files(recording)
+                
+                if not segment_info["segments"]:
+                    return {
+                        "success": False,
+                        "error": "No segment files found for this recording"
+                    }
+                
+                # Trigger recovery
+                success = await self._trigger_segment_concatenation(recording, segment_info, db)
+                
+                if success:
+                    return {
+                        "success": True,
+                        "message": f"Recovery triggered for recording {recording_id}",
+                        "segments_found": len(segment_info["segments"]),
+                        "segments_dir": segment_info["segments_dir"]
+                    }
+                else:
+                    return {
+                        "success": False,
+                        "error": "Failed to trigger segment concatenation"
+                    }
+                    
+        except Exception as e:
+            logger.error(f"Error recovering recording {recording_id}: {e}", exc_info=True)
+            return {
+                "success": False,
+                "error": str(e)
+            }
+
+
+# Global service instance
+_failed_recovery_service = None
+
+
+async def get_failed_recovery_service() -> FailedRecordingRecoveryService:
+    """Get or create the failed recovery service instance"""
+    global _failed_recovery_service
+    
+    if _failed_recovery_service is None:
+        _failed_recovery_service = FailedRecordingRecoveryService()
+        await _failed_recovery_service.start()
+    
+    return _failed_recovery_service
+
+
+async def stop_failed_recovery_service():
+    """Stop the failed recovery service"""
+    global _failed_recovery_service
+    
+    if _failed_recovery_service:
+        await _failed_recovery_service.stop()
+        _failed_recovery_service = None

--- a/app/services/recording/segment_concatenation_task.py
+++ b/app/services/recording/segment_concatenation_task.py
@@ -8,12 +8,12 @@ that were split into multiple parts.
 import asyncio
 import logging
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Callable
 
 logger = logging.getLogger("streamvault")
 
 
-async def handle_segment_concatenation(task_data: Dict[str, Any], progress_callback=None) -> Dict[str, Any]:
+async def handle_segment_concatenation(task_data: Dict[str, Any], progress_callback: Optional[Callable[[float], None]] = None) -> Dict[str, Any]:
     """
     Handle segment concatenation task
     
@@ -24,7 +24,10 @@ async def handle_segment_concatenation(task_data: Dict[str, Any], progress_callb
             - output_path: str - Output path for concatenated file
             - streamer_name: str - Streamer name
             - stream_id: int - Stream ID
-        progress_callback: Optional callback for progress updates
+        progress_callback: Optional[Callable[[float], None]]
+            A callback function for progress updates. The callback should accept a single argument:
+                - progress (float): A value between 0.0 and 1.0 indicating the percentage of completion.
+            The callback will be called periodically during the concatenation process to report progress.
     
     Returns:
         Dict with concatenation result

--- a/app/services/recording/segment_concatenation_task.py
+++ b/app/services/recording/segment_concatenation_task.py
@@ -13,7 +13,7 @@ from typing import Dict, Any
 logger = logging.getLogger("streamvault")
 
 
-async def handle_segment_concatenation(task_data: Dict[str, Any]) -> Dict[str, Any]:
+async def handle_segment_concatenation(task_data: Dict[str, Any], progress_callback=None) -> Dict[str, Any]:
     """
     Handle segment concatenation task
     
@@ -24,6 +24,7 @@ async def handle_segment_concatenation(task_data: Dict[str, Any]) -> Dict[str, A
             - output_path: str - Output path for concatenated file
             - streamer_name: str - Streamer name
             - stream_id: int - Stream ID
+        progress_callback: Optional callback for progress updates
     
     Returns:
         Dict with concatenation result


### PR DESCRIPTION
This pull request introduces a minor update to the `handle_segment_concatenation` function in `segment_concatenation_task.py`, allowing an optional `progress_callback` parameter to be passed in. This enables callers to receive progress updates during segment concatenation.

- Function signature update:
  * Added an optional `progress_callback` parameter to the `handle_segment_concatenation` function to support progress reporting. [[1]](diffhunk://#diff-63135985f5489642a0cf1ab8e8fe33f6cade94fd22c2e36e96450f93ec617287L16-R16) [[2]](diffhunk://#diff-63135985f5489642a0cf1ab8e8fe33f6cade94fd22c2e36e96450f93ec617287R27)