### PR TITLE
feat: update queue readiness verification to use background queue service for direct access

### DIFF
--- a/app/services/background_queue_service.py
+++ b/app/services/background_queue_service.py
@@ -209,6 +209,24 @@ class BackgroundQueueService:
         """Check if handler is registered for task type"""
         return self.queue_manager.has_handler(task_type)
     
+    def has_queue_manager(self) -> bool:
+        """Check if queue manager is available"""
+        return hasattr(self, 'queue_manager') and self.queue_manager is not None
+    
+    def is_queue_manager_running(self) -> bool:
+        """Check if the queue manager is running"""
+        return self.has_queue_manager() and self.queue_manager.is_running
+    
+    def get_queue_status(self) -> Optional[Dict[str, Any]]:
+        """Get queue status with proper abstraction"""
+        if not self.has_queue_manager():
+            return None
+        try:
+            return self.queue_manager.get_status()
+        except Exception as e:
+            logger.error(f"Error getting queue status: {e}")
+            return None
+    
     async def enqueue_recording_post_processing(self, **kwargs):
         """Enqueue a complete post-processing chain for a recording"""
         return await self.queue_manager.enqueue_recording_post_processing(**kwargs)

--- a/app/services/init/startup_init.py
+++ b/app/services/init/startup_init.py
@@ -140,22 +140,22 @@ async def verify_queue_readiness() -> bool:
         max_attempts = 3
         for attempt in range(max_attempts):
             try:
-                # Get the background queue service and access its queue manager
+                # Get the background queue service and check its status
                 queue_service = get_background_queue_service()
                 
                 if not queue_service:
                     logger.debug(f"⚠️ Queue service not found on attempt {attempt + 1}")
                 elif not queue_service.is_running:
                     logger.debug(f"⚠️ Queue service not running on attempt {attempt + 1}")
-                elif not hasattr(queue_service, 'queue_manager') or not queue_service.queue_manager:
+                elif not queue_service.has_queue_manager():
                     logger.debug(f"⚠️ Queue manager not available on attempt {attempt + 1}")
-                elif not queue_service.queue_manager.is_running:
+                elif not queue_service.is_queue_manager_running():
                     logger.debug(f"⚠️ Queue manager not running on attempt {attempt + 1}")
                 else:
-                    # Check if we have at least one queue and it's active
-                    status = queue_service.queue_manager.get_status()
+                    # Check if we have at least one queue and it's active using proper abstraction
+                    status = queue_service.get_queue_status()
                     if status and 'queues' in status and len(status['queues']) > 0:
-                        logger.info(f"✅ Queue readiness verified on attempt {attempt + 1} - Direct access to queue manager")
+                        logger.info(f"✅ Queue readiness verified on attempt {attempt + 1}")
                         return True
                     else:
                         logger.debug(f"⚠️ Queue manager running but no active queues on attempt {attempt + 1}")

--- a/app/services/init/startup_init.py
+++ b/app/services/init/startup_init.py
@@ -134,22 +134,26 @@ async def initialize_background_services():
 async def verify_queue_readiness() -> bool:
     """Verify that the background queue is fully ready to accept tasks"""
     try:
-        # Direct access to the queue manager instead of HTTP API call
-        from app.services.init.background_queue_init import get_task_queue_manager
+        # Direct access to the queue manager through background queue service
+        from app.services.init.background_queue_init import get_background_queue_service
         
         max_attempts = 3
         for attempt in range(max_attempts):
             try:
-                # Get the queue manager directly
-                queue_manager = get_task_queue_manager()
+                # Get the background queue service and access its queue manager
+                queue_service = get_background_queue_service()
                 
-                if not queue_manager:
-                    logger.debug(f"⚠️ Queue manager not found on attempt {attempt + 1}")
-                elif not queue_manager.is_running:
+                if not queue_service:
+                    logger.debug(f"⚠️ Queue service not found on attempt {attempt + 1}")
+                elif not queue_service.is_running:
+                    logger.debug(f"⚠️ Queue service not running on attempt {attempt + 1}")
+                elif not hasattr(queue_service, 'queue_manager') or not queue_service.queue_manager:
+                    logger.debug(f"⚠️ Queue manager not available on attempt {attempt + 1}")
+                elif not queue_service.queue_manager.is_running:
                     logger.debug(f"⚠️ Queue manager not running on attempt {attempt + 1}")
                 else:
                     # Check if we have at least one queue and it's active
-                    status = queue_manager.get_status()
+                    status = queue_service.queue_manager.get_status()
                     if status and 'queues' in status and len(status['queues']) > 0:
                         logger.info(f"✅ Queue readiness verified on attempt {attempt + 1} - Direct access to queue manager")
                         return True


### PR DESCRIPTION
This pull request updates the queue readiness verification logic in the `initialize_background_services` process to use the background queue service abstraction instead of directly accessing the queue manager. This makes the code more robust and better aligned with the application's service-oriented architecture.

**Improvements to background queue initialization:**

* Replaced direct import and use of `get_task_queue_manager` with `get_background_queue_service`, updating the readiness checks to operate through the background queue service abstraction. This includes enhanced checks for service and manager availability and running status.