### PR TITLE
fix: update variable names for clarity in create_simple_recovery_tasks function

### DIFF
--- a/app/services/simple_recovery_service.py
+++ b/app/services/simple_recovery_service.py
@@ -101,17 +101,17 @@ async def create_simple_recovery_tasks() -> int:
         try:
             # SQL Query to find recordings where TS exists but MP4 is missing
             recordings = db.query(Recording).join(Stream).join(Streamer).filter(
-                Recording.recording_path.isnot(None),
+                Recording.path.isnot(None),
                 ~Stream.is_active  # Only inactive streams
             ).all()
             
             for recording in recordings:
                 try:
-                    if not recording.recording_path:
+                    if not recording.path:
                         continue
                         
                     # Check if TS exists but MP4 is missing
-                    recording_path = Path(recording.recording_path)
+                    recording_path = Path(recording.path)
                     if not recording_path.exists():
                         continue
                         
@@ -124,8 +124,8 @@ async def create_simple_recovery_tasks() -> int:
                     payload = {
                         'recording_id': recording.id,
                         'stream_id': recording.stream_id,
-                        'streamer_name': recording.stream.streamer.name,
-                        'recording_path': str(recording.recording_path),
+                        'streamer_name': recording.stream.streamer.username,
+                        'recording_path': str(recording.path),
                         'simple_recovery': True,
                         'recovery_timestamp': datetime.now(timezone.utc).isoformat()
                     }


### PR DESCRIPTION
This pull request updates the `create_simple_recovery_tasks` function in `simple_recovery_service.py` to align field names and payload structure with recent model changes. The most important changes are:

Field renaming and consistency:

* Replaced usage of the outdated `recording.recording_path` field with the correct `recording.path` field throughout the function to match the current `Recording` model.

Payload improvements:

* Updated the recovery task payload to use `streamer.username` instead of `streamer.name`, and to reference the correct `recording.path` for the `recording_path` key.