### PR TITLE
fix: enhance image downloading to support local file paths and improve error handling

### DIFF
--- a/app/services/media/artwork_service.py
+++ b/app/services/media/artwork_service.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import logging
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any
@@ -215,14 +216,13 @@ class ArtworkService:
                 return True
             
             # Check if URL is actually a local file path
-            if url.startswith('/') or url.startswith('\\') or (len(url) > 2 and url[1] == ':'):
+            if Path(url).is_absolute():
                 # This is a local file path, not a URL
                 logger.debug(f"Detected local file path instead of URL: {url}")
                 source_path = Path(url)
                 if source_path.exists():
                     # Copy the local file
                     target_path.parent.mkdir(parents=True, exist_ok=True)
-                    import shutil
                     shutil.copy2(source_path, target_path)
                     logger.debug(f"Copied local image: {source_path} -> {target_path}")
                     return True

--- a/app/services/media/artwork_service.py
+++ b/app/services/media/artwork_service.py
@@ -204,7 +204,7 @@ class ArtworkService:
             logger.error(f"Error creating season.nfo: {e}", exc_info=True)
     
     async def _download_image(self, url: str, target_path: Path) -> bool:
-        """Download an image from a URL to a target path
+        """Download an image from a URL or copy from local path to a target path
         
         Returns:
             bool: True on success, False on error
@@ -214,7 +214,23 @@ class ArtworkService:
                 logger.debug(f"Image already exists: {target_path}")
                 return True
             
-            # Use unified_image_service for download
+            # Check if URL is actually a local file path
+            if url.startswith('/') or url.startswith('\\') or (len(url) > 2 and url[1] == ':'):
+                # This is a local file path, not a URL
+                logger.debug(f"Detected local file path instead of URL: {url}")
+                source_path = Path(url)
+                if source_path.exists():
+                    # Copy the local file
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    import shutil
+                    shutil.copy2(source_path, target_path)
+                    logger.debug(f"Copied local image: {source_path} -> {target_path}")
+                    return True
+                else:
+                    logger.warning(f"Local image file does not exist: {source_path}")
+                    return False
+            
+            # URL is a proper HTTP/HTTPS URL - download it
             session = await unified_image_service._get_session()
             async with session.get(url) as response:
                 if response.status == 200:


### PR DESCRIPTION
This pull request updates the image handling logic in the `ArtworkService` to support both downloading images from URLs and copying images from local file paths. The main changes are focused on improving the flexibility of the `_download_image` method.

Image download and copy improvements:

* Updated the `_download_image` method in `app/services/media/artwork_service.py` to detect if the provided `url` parameter is actually a local file path. If so, the method now copies the file to the target location instead of attempting to download it.
* Updated the docstring for `_download_image` to clarify that it now supports both downloading from URLs and copying from local paths.