### PR TITLE
Develop

### DIFF
--- a/app/services/images/profile_image_service.py
+++ b/app/services/images/profile_image_service.py
@@ -107,12 +107,12 @@ class ProfileImageService:
                     try:
                         internal_id = self._get_internal_id_for_extracted_id(extracted_id)
                         if internal_id:
-                            relative_path = f"/data/images/profiles/{image_file.name}"
+                            relative_path = f"/recordings/.media/profiles/{image_file.name}"
                             self._profile_cache[str(internal_id)] = relative_path
                     except Exception as db_error:
                         # Database not ready, use extracted_id as fallback key
                         logger.debug(f"Using extracted ID {extracted_id} as cache key due to DB error: {db_error}")
-                        relative_path = f"/data/images/profiles/{image_file.name}"
+                        relative_path = f"/recordings/.media/profiles/{image_file.name}"
                         self._profile_cache[str(extracted_id)] = relative_path
             
             logger.info(f"Loaded profile image cache: {len(self._profile_cache)} profiles")
@@ -183,7 +183,7 @@ class ProfileImageService:
             
             success = await self.download_service.download_image(profile_image_url, file_path)
             if success:
-                relative_path = f"/data/images/profiles/{filename}"
+                relative_path = f"/recordings/.media/profiles/{filename}"
                 self._profile_cache[streamer_id_str] = relative_path
                 logger.info(f"Successfully cached profile image for streamer {streamer_id}")
                 return relative_path

--- a/app/services/init/startup_init.py
+++ b/app/services/init/startup_init.py
@@ -11,6 +11,12 @@ logger = logging.getLogger("streamvault")
 async def initialize_background_queue_with_fixes():
     """Initialize background queue with production concurrency and auth fixes"""
     try:
+        # Check if already initialized to prevent double initialization
+        from app.services.init.background_queue_init import background_queue_manager
+        if background_queue_manager.is_initialized:
+            logger.info("✅ Background queue already initialized, skipping duplicate initialization")
+            return
+            
         logger.info("Initializing background queue with production fixes...")
         
         # Check if we're in production environment (multiple streamers)

--- a/app/services/media/artwork_service.py
+++ b/app/services/media/artwork_service.py
@@ -228,6 +228,14 @@ class ArtworkService:
                 # This is a local file path, not a URL
                 logger.debug(f"Detected local file path instead of URL: {url}")
                 source_path = Path(url)
+                
+                # Handle legacy path migration: /data/images/profiles/ -> /recordings/.media/profiles/
+                if url.startswith('/data/images/profiles/'):
+                    # Map old path to new structure
+                    filename = url.split('/')[-1]  # Extract just the filename
+                    source_path = self.recordings_dir / ".media" / "profiles" / filename
+                    logger.debug(f"Mapped legacy path {url} to {source_path}")
+                
                 if source_path.exists():
                     # Copy the local file
                     target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/services/notifications/external_notification_service.py
+++ b/app/services/notifications/external_notification_service.py
@@ -128,7 +128,7 @@ class ExternalNotificationService:
                     base_url = settings.notification_url or settings.BASE_URL
                     if base_url:
                         # Remove /recordings from the path and make it publicly accessible
-                        public_path = streamer.profile_image_url.replace('/data/', '/')
+                        public_path = streamer.profile_image_url.replace('/recordings', '')
                         profile_image_url = f"{base_url.rstrip('/')}{public_path}"
                         logger.debug(f"Converted local cache to public URL: {profile_image_url}")
                 

--- a/app/services/notifications/external_notification_service.py
+++ b/app/services/notifications/external_notification_service.py
@@ -123,11 +123,11 @@ class ExternalNotificationService:
                     logger.debug(f"Using profile URL from streamer: {profile_image_url}")
                 
                 # Priority 3: If we have a local cached path, convert to BASE_URL
-                elif streamer.profile_image_url and streamer.profile_image_url.startswith('/data/images/profiles/'):
+                elif streamer.profile_image_url and streamer.profile_image_url.startswith('/recordings/.media/profiles/'):
                     # Convert local path to public URL using BASE_URL from settings
                     base_url = settings.notification_url or settings.BASE_URL
                     if base_url:
-                        # Remove /data from the path and make it publicly accessible
+                        # Remove /recordings from the path and make it publicly accessible
                         public_path = streamer.profile_image_url.replace('/data/', '/')
                         profile_image_url = f"{base_url.rstrip('/')}{public_path}"
                         logger.debug(f"Converted local cache to public URL: {profile_image_url}")

--- a/app/services/streamers/streamer_image_service.py
+++ b/app/services/streamers/streamer_image_service.py
@@ -100,7 +100,7 @@ class StreamerImageService:
 
     def is_cached_image(self, image_url: str) -> bool:
         """Check if an image URL is a cached local path"""
-        return image_url and image_url.startswith('/data/images/profiles/')
+        return image_url and image_url.startswith('/recordings/.media/profiles/')
 
     def get_original_url_from_cached(self, cached_path: str) -> Optional[str]:
         """Extract original URL info from cached path (limited functionality)"""


### PR DESCRIPTION
This pull request focuses on migrating the storage and reference paths for cached profile images from the old `/data/images/profiles/` directory to the new `/recordings/.media/profiles/` directory. It also introduces a safeguard to prevent duplicate initialization of the background queue. The main changes ensure consistent path usage throughout the codebase and provide backward compatibility for legacy image paths.

**Profile image path migration and consistency:**

* Updated all references to cached profile image paths from `/data/images/profiles/` to `/recordings/.media/profiles/` in `profile_image_service.py`, `streamer_image_service.py`, and `external_notification_service.py`, ensuring consistent usage of the new storage location. [[1]](diffhunk://#diff-81a08549823803db481bfcc04f6b85ca2328ba69fdd82a5f7503c87bf90cb920L110-R115) [[2]](diffhunk://#diff-81a08549823803db481bfcc04f6b85ca2328ba69fdd82a5f7503c87bf90cb920L186-R186) [[3]](diffhunk://#diff-addbc9cce3040f03b59a81c5ebe55cd3ec74a4f9861eaceaf8ff712962910254L103-R103) [[4]](diffhunk://#diff-66babf8fe6b40cf909b70f09d95183f9ea9dd55381b482266c3e5a8dffb9c91bL126-R130)
* Added logic in `artwork_service.py` to detect and migrate legacy image paths from `/data/images/profiles/` to the new `/recordings/.media/profiles/` structure, maintaining compatibility with previously cached images.

**Background queue initialization:**

* Added a check in `startup_init.py` to prevent duplicate initialization of the background queue by verifying if it has already been initialized.