### PR TITLE
refactor: defer background queue and recovery service initialization to improve startup sequence

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -153,10 +153,6 @@ async def lifespan(app: FastAPI):
         # Automated recovery service will be handled by initialize_background_services()
         try:
             logger.info("✅ Startup recovery check scheduled (runs once after 2 minutes)")
-                    
-                    recoveries = result.get('total_recoveries', 0)
-                    if recoveries > 0:
-                        logger.info(f"✅ STARTUP_RECOVERY: {recoveries} recovery tasks created automatically")
             
         except Exception as e:
             logger.error(f"❌ Failed to start startup recovery check: {e}")


### PR DESCRIPTION
This pull request refactors the initialization process for several background services in `app/main.py`. The main change is to defer the initialization of the background queue service, its auto-cleanup, and the automated recovery service to a new or existing function called `initialize_background_services`, instead of starting them directly in `safe_image_refresh`. This helps centralize and simplify service startup logic.

Key changes:

**Background queue service:**

* Deferred the initialization of the background queue service and its auto-cleanup from `safe_image_refresh` to `initialize_background_services`, replacing direct initialization with log messages indicating the deferral.

**Automated recovery service:**

* Deferred the startup of the automated recovery service for failed recordings, removing the direct scheduling and replacing it with a log message that the service will be handled later.