### PR TITLE
fix: remove redundant task execution logging in TaskQueueManager

### DIFF
--- a/app/services/queues/task_queue_manager.py
+++ b/app/services/queues/task_queue_manager.py
@@ -8,19 +8,7 @@ Handles task enqueueing, dependency management, and queue coordination.
 import asyncio
 import logging
 import uuid
-from                    try:
-                        # Execute the task using the worker manager
-                        await self.worker_manager._execute_task(task, worker_name)
-                        
-                        # Mark task as completed successfully
-                        if self.progress_tracker:
-                            self.progress_tracker.update_task_status(task.id, TaskStatus.COMPLETED)
-                            self.progress_tracker.update_task_progress(task.id, 100.0)
-                        
-                        # Notify completion callback
-                        await self.mark_task_completed(task.id, success=True)
-                        
-                        logger.info(f"✅ Streamer {streamer_name} completed task {task.id} - success: True")rt datetime, timezone
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 from collections import defaultdict
 from pathlib import Path


### PR DESCRIPTION
This pull request includes a minor fix to the import statements in `app/services/queues/task_queue_manager.py`, correcting the import of `datetime` and `timezone` to resolve a syntax error.

* Fixed a malformed import statement by replacing an accidental code paste with the correct import of `datetime` and `timezone` from the `datetime` module.