### PR TITLE
fix: implement adaptive rate limiting middleware with token-bucket strategy

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -294,11 +294,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"❌ Error stopping image sync service: {e}")
     
-    # Stop recording auto-fix service
+    # Stop recording auto-fix service (optional component; ignore if not present)
     try:
-        from app.services.recording.recording_auto_fix_service import recording_auto_fix_service
-        await recording_auto_fix_service.stop()
-        logger.info("✅ Recording auto-fix service stopped")
+        try:
+            from app.services.recording.recording_auto_fix_service import recording_auto_fix_service  # type: ignore
+        except ModuleNotFoundError:
+            recording_auto_fix_service = None  # type: ignore
+        if recording_auto_fix_service and hasattr(recording_auto_fix_service, 'stop'):
+            await recording_auto_fix_service.stop()
+            logger.info("✅ Recording auto-fix service stopped")
+        else:
+            logger.debug("Recording auto-fix service not available; skipping")
     except Exception as e:
         logger.error(f"❌ Error stopping recording auto-fix service: {e}")
     

--- a/app/services/recording/recording_orchestrator.py
+++ b/app/services/recording/recording_orchestrator.py
@@ -213,12 +213,16 @@ class RecordingOrchestrator:
 
     # Shutdown methods
 
-    async def graceful_shutdown(self) -> None:
-        """Gracefully shutdown all recording operations"""
+    async def graceful_shutdown(self, timeout: int | None = None) -> None:
+        """Gracefully shutdown all recording operations
+        
+        Args:
+            timeout: Optional timeout hint (seconds) for terminating subprocesses.
+        """
         logger.info("Starting graceful shutdown of recording orchestrator")
         
         # Shutdown lifecycle manager (handles active recordings)
-        await self.lifecycle_manager.graceful_shutdown()
+        await self.lifecycle_manager.graceful_shutdown(timeout=timeout)
         
         # Save state to persistence
         await self.state_manager.save_state_to_persistence()

--- a/app/services/recording/recording_service.py
+++ b/app/services/recording/recording_service.py
@@ -127,10 +127,15 @@ class RecordingService:
 
     # Shutdown methods (delegate to orchestrator)
 
-    async def graceful_shutdown(self) -> None:
-        """Gracefully shutdown all recording operations"""
+    async def graceful_shutdown(self, timeout: int | None = None) -> None:
+        """Gracefully shutdown all recording operations
+        
+        Args:
+            timeout: Optional timeout hint (seconds) for underlying process termination.
+        """
         self._is_shutting_down = True
-        await self.orchestrator.graceful_shutdown()
+        # Propagate optional timeout to orchestrator (ignored by components that don't use it)
+        await self.orchestrator.graceful_shutdown(timeout=timeout)
 
     def is_shutting_down(self) -> bool:
         """Check if shutting down"""


### PR DESCRIPTION
This pull request introduces a significant upgrade to the rate limiting middleware by replacing the previous basic implementation with an adaptive, token-bucket-based limiter that supports per-route and per-user configuration. It also adds backward-compatible static file serving to handle legacy path requirements and removes a duplicate endpoint for serving service worker registration files. The most important changes are grouped below:

**Rate Limiting Improvements:**

* Replaced the basic rate limiting middleware with a new adaptive token-bucket implementation (`_AdaptiveLimiter` and `_TokenBucket`), supporting per-route and per-user limits, soft-waiting to reduce 429 errors, and dynamic configuration via environment variables. The limiter now distinguishes between authenticated users and IP addresses, and exposes more accurate rate limit headers.
* Updated the list of paths excluded from rate limiting, including support for `/recordings/.media/` to avoid limiting cached image file requests.

**Static File Serving Enhancements:**

* Added a new static file mount at `/recordings/.media` to provide backward compatibility for services that reference this path, ensuring legacy database entries remain valid.

**Endpoint Cleanup:**

* Removed a duplicate `/registerSW.js` endpoint to prevent conflicts and ensure only the secured version is active.