### PR TITLE
Develop

### DIFF
--- a/app/frontend/public/push-sw.js
+++ b/app/frontend/public/push-sw.js
@@ -1,0 +1,80 @@
+// Custom push and notification click handlers for the generated Workbox SW
+// This file is imported by the generated service worker via workbox.importScripts
+
+/* eslint-disable no-restricted-globals */
+
+self.addEventListener('push', (event) => {
+  try {
+    if (!event || !event.data) return;
+
+    let payload = {};
+    try {
+      payload = event.data.json();
+    } catch (_e) {
+      // Fallback for non-JSON payloads
+      payload = { title: 'Notification', body: event.data.text() };
+    }
+
+    const title = payload.title || 'StreamVault';
+    const options = {
+      body: payload.body || '',
+      icon: payload.icon || '/android-icon-192x192.png',
+      badge: payload.badge || '/android-icon-96x96.png',
+      tag: payload.tag || undefined,
+      data: payload.data || {},
+      actions: payload.actions || [],
+      requireInteraction: !!payload.requireInteraction,
+      // Optional: vibrate pattern for attention
+      vibrate: payload.vibrate || [100, 50, 100],
+    };
+
+    event.waitUntil(self.registration.showNotification(title, options));
+  } catch (err) {
+    // Swallow errors to avoid crashing the SW
+    // eslint-disable-next-line no-console
+    console.error('SW push handler error:', err);
+  }
+});
+
+self.addEventListener('notificationclick', (event) => {
+  const notification = event.notification;
+  const action = event.action;
+  const data = notification && notification.data ? notification.data : {};
+
+  const internalUrl = data.internal_url || data.url || '/';
+
+  const openOrFocus = async (url) => {
+    const allClients = await clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const root = new URL('/', self.location.origin).href;
+    const targetUrl = new URL(internalUrl, self.location.origin).href;
+
+    // Try focus an existing tab on same origin
+    for (const client of allClients) {
+      try {
+        const clientUrl = client.url || root;
+        if (clientUrl.startsWith(self.location.origin)) {
+          await client.focus();
+          // If router-based SPA, navigate within the app
+          // Note: postMessage can be handled by app to navigate
+          client.postMessage({ type: 'navigate', url: targetUrl });
+          return;
+        }
+      } catch (_) { /* ignore */ }
+    }
+
+    // Otherwise open a new window
+    await clients.openWindow(targetUrl);
+  };
+
+  event.waitUntil((async () => {
+    try {
+      if (action && action !== 'dismiss') {
+        await openOrFocus(internalUrl);
+      } else if (!action) {
+        await openOrFocus(internalUrl);
+      }
+    } finally {
+      notification.close();
+    }
+  })());
+});

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -29,9 +29,25 @@ class AuthMiddleware:
             "/auth/setup", 
             "/auth/check",
             "/auth/logout",
+            "/auth/keepalive",
             "/eventsub",
             "/static/",
-            "/assets/"
+            "/assets/",
+            "/registerSW.js",
+            "/sw.js",
+            "/pwa",
+            "/pwa-helper.js",
+            "/workbox-",
+            "/manifest.json",
+            "/manifest.webmanifest",
+            "/favicon",
+            "/android-icon-",
+            "/apple-icon",
+            "/ms-icon-",
+            "/recordings/.media/",
+            "/api/media/",
+            "/data/images/",
+            "/data/"
         ]
 
         if any(request.url.path.startswith(path) for path in public_paths):


### PR DESCRIPTION
This pull request improves the handling of NFO metadata and artwork paths for media libraries, with a focus on generating correct relative paths, robust directory detection, and better fallback logic for artwork files. The changes ensure that NFO files and artwork references are more accurate and compatible with different media server setups, and that artwork is reliably available even in edge cases.

**NFO and Artwork Path Handling Improvements:**

* Added `_relative_artwork_path` and `_find_recordings_root` helper methods to robustly compute relative paths to artwork from NFO directories and to locate the recordings root containing the `.media` folder. This ensures artwork references in NFO files are accurate regardless of directory structure.
* Updated NFO generation logic to use these new helpers, ensuring that artwork paths in `tvshow.nfo`, `season.nfo`, and actor entries are always correct relative paths, improving compatibility with media scanners. [[1]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L264-R350) [[2]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L285-R364) [[3]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L307-R389)

**Directory Structure and Fallback Logic:**

* Refactored the logic for determining streamer and season directories, making it more robust and defensive to avoid misplacement of NFO files and to handle edge cases where directory names do not match expected patterns. [[1]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L233-R318) [[2]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L295-R373)
* Improved fallback mechanisms for artwork: if a thumbnail is missing, the service now attempts to copy the global poster from the artwork cache into the local folder, ensuring artwork is always present for media servers.

**Media Server Compatibility Enhancements:**

* Enhanced the creation of season poster images: season-specific posters are now created in both the season directory and as `poster.jpg`, ensuring compatibility with various media servers and their folder structure expectations.
* Updated metadata database handling to only save the season NFO path if it was actually created, with defensive checks for backward compatibility with older database schemas.