### PR TITLE
feat: enhance category handling by implementing category history and improving image preloading

### DIFF
--- a/app/frontend/src/components/StreamList.vue
+++ b/app/frontend/src/components/StreamList.vue
@@ -264,64 +264,38 @@
                   <i class="fas fa-tags"></i> Categories
                 </h4>
                 <div class="categories-container">
-                  <!-- Current/Main Category -->
-                  <div v-if="stream.category_name" class="category-item main-category">
-                    <div class="category-image-wrapper">
-                      <template v-if="getCategoryImageSrc(stream.category_name).startsWith('icon:')">
-                        <div class="category-icon-small">
-                          <i :class="`fas ${getCategoryImageSrc(stream.category_name).replace('icon:', '')}`"></i>
-                        </div>
-                      </template>
-                      <template v-else>
-                        <img 
-                          :src="getCategoryImageSrc(stream.category_name)"
-                          :alt="stream.category_name" 
-                          @error="handleImageError($event, stream.category_name)"
-                          loading="lazy"
-                          class="category-image-small"
-                        />
-                      </template>
-                    </div>
-                    <div class="category-info">
-                      <span class="category-name">{{ stream.category_name }}</span>
-                      <span class="category-type">Main Category</span>
-                    </div>
-                  </div>
-                  
-                  <!-- Additional Categories (if available from database) -->
-                  <div v-if="(stream as ExtendedStream).categories && (stream as ExtendedStream).categories!.length > 1" class="additional-categories">
-                    <div 
-                      v-for="category in (stream as ExtendedStream).categories!.slice(1)" 
-                      :key="category.name"
+          <template v-if="getCategoryHistory(stream).length > 0">
+                    <div
+                      v-for="(cat, idx) in getCategoryHistory(stream)"
+                      :key="`${cat.timestamp}-${idx}`"
                       class="category-item"
+            :class="{}"
                     >
                       <div class="category-image-wrapper">
-                        <template v-if="getCategoryImageSrc(category.name).startsWith('icon:')">
+                        <template v-if="getCategoryImageSrc(cat.name).startsWith('icon:')">
                           <div class="category-icon-small">
-                            <i :class="`fas ${getCategoryImageSrc(category.name).replace('icon:', '')}`"></i>
+                            <i :class="`fas ${getCategoryImageSrc(cat.name).replace('icon:', '')}`"></i>
                           </div>
                         </template>
                         <template v-else>
-                          <img 
-                            :src="getCategoryImageSrc(category.name)"
-                            :alt="category.name" 
-                            @error="handleImageError($event, category.name)"
+                          <img
+                            :src="getCategoryImageSrc(cat.name)"
+                            :alt="cat.name"
+                            @error="handleImageError($event, cat.name)"
                             loading="lazy"
                             class="category-image-small"
                           />
                         </template>
                       </div>
                       <div class="category-info">
-                        <span class="category-name">{{ category.name }}</span>
-                        <span v-if="category.duration" class="category-duration">
-                          {{ formatDuration(category.duration) }}
+                        <span class="category-name">{{ cat.name }}</span>
+                        <span v-if="cat.duration" class="category-duration">
+                          {{ formatDuration(cat.duration) }}
                         </span>
                       </div>
                     </div>
-                  </div>
-                  
-                  <!-- Fallback if no categories -->
-                  <div v-if="!stream.category_name" class="no-categories">
+                  </template>
+                  <div v-else class="no-categories">
                     <i class="fas fa-question-circle"></i>
                     <span>No category information available</span>
                   </div>
@@ -667,6 +641,45 @@ const handleImageError = (event: Event, categoryName: string) => {
   }
 }
 
+// Build a category history list from stream events with durations
+type CategoryHistoryItem = { name: string; timestamp?: string; duration?: number }
+const getCategoryHistory = (s: Stream): CategoryHistoryItem[] => {
+  const events = ((s as any).events || []) as Array<{ event_type?: string; category_name?: string | null; timestamp?: string | null }>
+  const relevant = events
+    .filter(e => !!e && (e.event_type === 'channel.update' || e.event_type === 'stream.online') && e.category_name)
+    .sort((a, b) => {
+      const at = a.timestamp ? new Date(a.timestamp).getTime() : 0
+      const bt = b.timestamp ? new Date(b.timestamp).getTime() : 0
+      return at - bt
+    })
+
+  if (relevant.length === 0) {
+    return s.category_name ? [{ name: s.category_name }] : []
+  }
+
+  // Deduplicate consecutive same categories
+  const items: CategoryHistoryItem[] = []
+  for (const ev of relevant) {
+    const name = ev.category_name as string
+    if (items.length === 0 || items[items.length - 1].name !== name) {
+      items.push({ name, timestamp: ev.timestamp || undefined })
+    }
+  }
+
+  // Compute durations between changes (ms)
+  for (let i = 0; i < items.length; i++) {
+    const curr = items[i]
+    const next = items[i + 1]
+    const startMs = curr.timestamp ? new Date(curr.timestamp).getTime() : (s.started_at ? new Date(s.started_at).getTime() : NaN)
+    const endMs = next?.timestamp ? new Date(next.timestamp!).getTime() : (s.ended_at ? new Date(s.ended_at).getTime() : Date.now())
+    if (!Number.isNaN(startMs) && !Number.isNaN(endMs) && endMs >= startMs) {
+      curr.duration = endMs - startMs
+    }
+  }
+
+  return items
+}
+
 const formatDate = (dateString: string | null): string => {
   if (!dateString) return 'Unknown'
   const date = new Date(dateString)
@@ -876,9 +889,14 @@ onMounted(async () => {
   if (streamerId.value) {
     await fetchStreams(Number(streamerId.value))
     
-    // Preload category images
-    const categories = [...new Set(streams.value.map((s: any) => s.category_name).filter(Boolean))] as string[]
-    await preloadCategoryImages(categories)
+    // Preload category images (main + from event history)
+    const categories = new Set<string>()
+    streams.value.forEach((s: any) => {
+      if (s.category_name) categories.add(s.category_name)
+      const evs = (s.events || []) as Array<{ category_name?: string | null }>
+      evs.forEach(e => { if (e && e.category_name) categories.add(e.category_name) })
+    })
+    await preloadCategoryImages(Array.from(categories))
   }
 })
 
@@ -892,9 +910,14 @@ watch(streamerId, async (newVal: string | undefined, oldVal: string | undefined)
 
     await fetchStreams(Number(newVal))
 
-    // Preload category images for the new set
-    const categories = [...new Set(streams.value.map((s: any) => s.category_name).filter(Boolean))] as string[]
-    await preloadCategoryImages(categories)
+    // Preload category images for the new set (main + history)
+    const categories = new Set<string>()
+    streams.value.forEach((s: any) => {
+      if (s.category_name) categories.add(s.category_name)
+      const evs = (s.events || []) as Array<{ category_name?: string | null }>
+      evs.forEach(e => { if (e && e.category_name) categories.add(e.category_name) })
+    })
+    await preloadCategoryImages(Array.from(categories))
   }
 })
 </script>


### PR DESCRIPTION
This pull request updates the `StreamList.vue` component to display a full history of stream categories (with durations), rather than just the current and additional categories. It also improves category image preloading to ensure all relevant images are loaded, including those from historical events.

**Category history improvements:**
* Added a new `getCategoryHistory` function to build a chronological list of category changes for each stream, deduplicating consecutive repeats and calculating how long each category was active. This enables displaying a timeline of categories with durations for each stream.
* Updated the template to render all categories from the stream's history using `getCategoryHistory`, showing their names and durations. The previous logic for "main" and "additional" categories was removed in favor of this unified approach.

**Category image preloading enhancements:**
* Modified the logic in both `onMounted` and the `streamerId` watcher to preload images for all categories that appear in the stream's history, not just the main category. This ensures category icons/images are available for the entire timeline. [[1]](diffhunk://#diff-dc8da8a9109f343ac4ab7f2d125674d933dad2d8330bb46160771bea205313b5L879-R899) [[2]](diffhunk://#diff-dc8da8a9109f343ac4ab7f2d125674d933dad2d8330bb46160771bea205313b5L895-R920)