### PR TITLE
Develop

### DIFF
--- a/app/events/handler_registry.py
+++ b/app/events/handler_registry.py
@@ -6,6 +6,7 @@ from typing import Dict, Callable, Awaitable, Any, Optional
 from datetime import datetime, timezone, timedelta
 
 from app.database import SessionLocal
+from sqlalchemy.exc import SQLAlchemyError
 from app.services.communication.websocket_manager import ConnectionManager
 from app.services.notification_service import NotificationService
 from app.services.recording.recording_service import RecordingService
@@ -262,6 +263,8 @@ class EventHandlerRegistry:
                     else:
                         logger.info(f"🎬 RECORDING_DISABLED: Not starting recording for streamer={streamer.username} (ID: {streamer.id}) - recording is disabled for this streamer")
             
+        except SQLAlchemyError as e:
+            logger.error(f"Database error handling stream online event: {e}")
         except Exception as e:
             logger.error(f"Error handling stream online event: {e}", exc_info=True)
             
@@ -344,6 +347,8 @@ class EventHandlerRegistry:
                         stream_id_info = stream.id if stream else "None"
                         logger.warning(f"🎬 NO_ACTIVE_RECORDING_FOUND: streamer_id={streamer.id}, stream_id={stream_id_info}")
             
+        except SQLAlchemyError as e:
+            logger.error(f"Database error handling stream offline event: {e}")
         except Exception as e:
             logger.error(f"Error handling stream offline event: {e}", exc_info=True)
             
@@ -508,6 +513,8 @@ class EventHandlerRegistry:
                                             "twitch_login": data['broadcaster_user_login']
                                         }
                                     )
+        except SQLAlchemyError as e:
+            logger.error(f"Database error handling stream update event: {e}")
         except Exception as e:
             logger.error(f"Error handling stream update event: {e}", exc_info=True)
                         

--- a/app/events/handler_registry.py
+++ b/app/events/handler_registry.py
@@ -391,6 +391,17 @@ class EventHandlerRegistry:
                         .first()
                 
                 if stream:
+                    # Also update the active stream with the latest title/category/language
+                    try:
+                        if data.get("title"):
+                            stream.title = data.get("title")
+                        if effective_category_name:
+                            stream.category_name = effective_category_name
+                        if data.get("language"):
+                            stream.language = data.get("language")
+                    except Exception as e:
+                        logger.debug(f"Could not update active stream fields from channel.update: {e}")
+
                     stream_event = StreamEvent(
                         stream_id=stream.id,
                         event_type="channel.update",

--- a/app/services/recording/recording_lifecycle_manager.py
+++ b/app/services/recording/recording_lifecycle_manager.py
@@ -8,6 +8,7 @@ Handles recording start, stop, monitoring, and lifecycle events.
 import logging
 import asyncio
 from typing import Dict, Any, Optional
+import re
 from datetime import datetime
 from pathlib import Path
 from app.utils.path_utils import generate_filename, update_episode_number
@@ -511,14 +512,13 @@ class RecordingLifecycleManager:
             # Try to persist the month-episode number we just used into the Stream
             try:
                 # Extract E## from the generated filename pattern SYYYYMME##
-                import re
                 m = re.search(r"S(\d{6})E(\d{2})", filename)
                 if m:
                     episode_num = int(m.group(2))
                     # Persist on Stream for later consumers (NFO, APIs)
                     await update_episode_number(stream.id, episode_num)
             except Exception:
-                pass
+                logger.exception("Failed to update episode number for stream %s", stream.id)
             
             # Clean up filename and add .ts extension
             # Remove any existing video extensions from the filename (case-insensitive)

--- a/app/services/recording/recording_lifecycle_manager.py
+++ b/app/services/recording/recording_lifecycle_manager.py
@@ -10,7 +10,7 @@ import asyncio
 from typing import Dict, Any, Optional
 from datetime import datetime
 from pathlib import Path
-from app.utils.path_utils import generate_filename
+from app.utils.path_utils import generate_filename, update_episode_number
 from app.services.api.twitch_api import twitch_api
 try:
     from app.utils.cache import app_cache
@@ -68,7 +68,13 @@ class RecordingLifecycleManager:
             
             # Check capacity
             if not self.state_manager.can_start_new_recording():
-                logger.warning("🎬 CAPACITY_BLOCK: Cannot start recording: at maximum capacity")
+                # Provide richer capacity info for diagnostics
+                try:
+                    active = self.state_manager.get_active_recording_count()
+                    limit = self.state_manager.max_concurrent_recordings
+                    logger.warning(f"🎬 CAPACITY_BLOCK: Cannot start recording: at maximum capacity ({active}/{limit})")
+                except Exception:
+                    logger.warning("🎬 CAPACITY_BLOCK: Cannot start recording: at maximum capacity")
                 return None
             
             # Generate file path
@@ -501,6 +507,18 @@ class RecordingLifecycleManager:
                 stream_data=stream_data,
                 template=template
             )
+
+            # Try to persist the month-episode number we just used into the Stream
+            try:
+                # Extract E## from the generated filename pattern SYYYYMME##
+                import re
+                m = re.search(r"S(\d{6})E(\d{2})", filename)
+                if m:
+                    episode_num = int(m.group(2))
+                    # Persist on Stream for later consumers (NFO, APIs)
+                    await update_episode_number(stream.id, episode_num)
+            except Exception:
+                pass
             
             # Clean up filename and add .ts extension
             # Remove any existing video extensions from the filename (case-insensitive)


### PR DESCRIPTION
This pull request introduces several improvements to how stream metadata is managed, recorded, and exposed, focusing on consistency in episode numbering, configurability of recording limits, and robustness in stream updates. The most significant changes are grouped below by theme.

**Recording Capacity and Configuration:**

* Added support for overriding the maximum number of concurrent recordings via the `STREAMVAULT_MAX_CONCURRENT_RECORDINGS` environment variable, with a fallback to database/global settings and a safe default. This makes the system more flexible for different deployment environments.
* Enhanced diagnostics when the recording capacity limit is reached by logging the current and maximum number of active recordings, aiding in troubleshooting and monitoring.

**Episode Numbering and Metadata Consistency:**

* Improved NFO file generation to prefer a consistent, scanner-friendly episode title format when the filename includes a formatted prefix, and to use the database-stored episode number if available for month-based episode numbering. This helps external tools and users keep metadata consistent.
* When generating a recording path, the system now extracts the episode number from the generated filename and persists it on the `Stream` model for later consumers such as NFO generation and APIs.
* Imported the new `update_episode_number` utility in the recording lifecycle manager to support episode number persistence.

**Stream Metadata Updates:**

* Ensured that when a stream update event is received, the active stream's title, category, and language fields are updated with the latest information, improving metadata accuracy for downstream consumers.

**Miscellaneous:**

* Added a missing import for `os` in `config_manager.py` to support environment variable reading.