### PR TITLE
feat: enhance metadata normalization by adding directory validation and adjusting paths for streamer seasons

### DIFF
--- a/app/services/media/metadata_service.py
+++ b/app/services/media/metadata_service.py
@@ -109,6 +109,15 @@ class MetadataService:
             return parent_res == child_res or parent_res in child_res.parents
         except Exception:
             return False
+
+    # Public wrappers (avoid external use of private helpers elsewhere)
+    def find_recordings_root(self, start_dir: Path) -> Optional[Path]:  # noqa: D401
+        """Public wrapper for locating recordings root (directory containing .media)."""
+        return self._find_recordings_root(start_dir)
+
+    def is_within(self, child: Path, parent: Path) -> bool:  # noqa: D401
+        """Public wrapper for safe path containment check."""
+        return self._is_within(child, parent)
     
     async def generate_metadata_for_stream(
         self, 


### PR DESCRIPTION
This pull request improves the reliability and correctness of metadata file generation during post-processing tasks by introducing a normalization step for file paths and filenames. The main focus is to ensure that metadata files are always generated in the correct streamer and season directories, even if the inputs are inconsistent or outdated.

**Metadata Path Normalization Enhancements:**

* Added a new `_normalize_metadata_args` method to the `PostProcessingTasks` service. This method checks and adjusts the `base_path` and `base_filename` to ensure they point to the correct streamer season directory, rebasing them if necessary. It uses current database data and validates directory containment.
* Updated `handle_video_conversion` and `handle_metadata_generation` to use the normalization method before generating metadata, ensuring correct file placement even if the initial arguments are stale or incorrect. [[1]](diffhunk://#diff-36cf59c33d4bc726e6976cdff6828306726ca4097d877919be0f3fdee7c8531bR119-R127) [[2]](diffhunk://#diff-36cf59c33d4bc726e6976cdff6828306726ca4097d877919be0f3fdee7c8531bR216-R224)

**Dependency Injection and Imports:**

* Modified the import from `metadata_service` to include the singleton `metadata_service` instance, enabling internal calls to helper methods for path validation.