### PR TITLE
feat: enhance share link functionality with improved copy feedback and error handling

### DIFF
--- a/app/frontend/src/components/VideoModal.vue
+++ b/app/frontend/src/components/VideoModal.vue
@@ -83,9 +83,10 @@
             @click="$event.target.select()"
           />
           <button class="copy-btn" @click="copyShareLink" :disabled="shareCopied">
-            {{ shareCopied ? '✔ Kopiert' : 'Copy' }}
+            {{ shareCopied ? '✔ Copied' : 'Copy' }}
           </button>
-          <span v-if="shareCopied" class="copied-hint">Link kopiert – in VLC: Medien → Netzwerkstream öffnen</span>
+          <span v-if="shareCopied" class="copied-hint">Link copied – In VLC: Media → Open Network Stream</span>
+          <span v-else-if="copyError" class="copy-error-hint">Could not copy automatically – select manually and press Ctrl+C</span>
         </div>
         
         <!-- Chapter Navigation -->
@@ -137,6 +138,7 @@ const showChapters = ref(false)
 const currentChapter = ref(-1)
 const shareLink = ref('')
 const shareCopied = ref(false)
+const copyError = ref(false)
 
 const videoUrl = computed(() => {
   // Use the stream ID based endpoint
@@ -256,7 +258,16 @@ const copyShareLink = async () => {
     shareCopied.value = true
     setTimeout(() => (shareCopied.value = false), 4000)
   } catch (e) {
-    // ignore
+    copyError.value = true
+    // Attempt to select the input so user can press Ctrl+C
+    requestAnimationFrame(() => {
+  const el = document.querySelector('.share-link-input')
+      if (el) {
+        el.focus()
+        el.select()
+      }
+    })
+    setTimeout(() => (copyError.value = false), 5000)
   }
 }
 

--- a/app/frontend/src/components/VideoModal.vue
+++ b/app/frontend/src/components/VideoModal.vue
@@ -76,6 +76,7 @@
         <!-- Share Link Box -->
         <div v-if="shareLink" class="share-link-box">
           <input
+            ref="shareLinkInput"
             class="share-link-input"
             :value="shareLink"
             readonly
@@ -86,7 +87,7 @@
             {{ shareCopied ? '✔ Copied' : 'Copy' }}
           </button>
           <span v-if="shareCopied" class="copied-hint">Link copied – In VLC: Media → Open Network Stream</span>
-          <span v-else-if="copyError" class="copy-error-hint">Could not copy automatically – select manually and press Ctrl+C</span>
+          <span v-else-if="copyError" class="copy-error-hint">Could not copy automatically – select the field and press {{ copyShortcut }}</span>
         </div>
         
         <!-- Chapter Navigation -->
@@ -139,6 +140,12 @@ const currentChapter = ref(-1)
 const shareLink = ref('')
 const shareCopied = ref(false)
 const copyError = ref(false)
+const shareLinkInput = ref(null)
+const copyShortcut = computed(() => {
+  // Basic platform detection for shortcut hint
+  const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.platform)
+  return isMac ? 'Cmd+C' : 'Ctrl+C'
+})
 
 const videoUrl = computed(() => {
   // Use the stream ID based endpoint
@@ -261,10 +268,9 @@ const copyShareLink = async () => {
     copyError.value = true
     // Attempt to select the input so user can press Ctrl+C
     requestAnimationFrame(() => {
-  const el = document.querySelector('.share-link-input')
-      if (el) {
-        el.focus()
-        el.select()
+      if (shareLinkInput.value) {
+        shareLinkInput.value.focus()
+        shareLinkInput.value.select()
       }
     })
     setTimeout(() => (copyError.value = false), 5000)


### PR DESCRIPTION
This pull request improves the user experience when copying the share link in the `VideoModal.vue` component by providing clearer feedback and handling copy errors more gracefully. The main changes include updating messages for clarity and adding logic to help users manually copy the link if automatic copying fails.

User feedback improvements:

* Updated button and hint text to use English and provide clearer instructions, including guidance for using VLC.
* Added a new error message that appears if copying fails, instructing users to manually select and copy the link.

Copy error handling:

* Introduced a new `copyError` state to track copy failures.
* Enhanced the `copyShareLink` function to set `copyError` on failure, focus and select the input for easy manual copying, and reset the error message after a timeout.