### PR TITLE
Develop

### DIFF
--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -29,6 +29,11 @@ class ApiClient {
       ...options,
     }
 
+    // Ensure cookies (session) are always sent with API requests (fix für fehlende Persistenz)
+    if (!('credentials' in config)) {
+      ;(config as any).credentials = 'include'
+    }
+
     if (config.body && typeof config.body === 'object') {
       config.body = JSON.stringify(config.body)
     }

--- a/app/services/media/metadata_service.py
+++ b/app/services/media/metadata_service.py
@@ -407,12 +407,12 @@ class MetadataService:
                 try:
                     recordings_root = self._find_recordings_root(streamer_dir) or streamer_dir.parent
                     central_art = recordings_root / ".media" / "artwork" / safe_username
-                    local_targets = {
-                        "poster.jpg": None,
-                        "banner.jpg": None,
-                        "fanart.jpg": None,
-                    }
-                    for fname in list(local_targets.keys()):
+                    local_targets = [
+                        "poster.jpg",
+                        "banner.jpg",
+                        "fanart.jpg",
+                    ]
+                    for fname in local_targets:
                         src = central_art / fname
                         dst = streamer_dir / fname
                         if src.exists() and not dst.exists():
@@ -484,8 +484,8 @@ class MetadataService:
                             central_art = recordings_root / ".media" / "artwork" / safe_username / "poster.jpg"
                             if central_art.exists():
                                 shutil.copy2(central_art, local_season_poster)
-                        except Exception:
-                            pass
+                        except Exception as ce_season:
+                            logger.exception("Failed to copy central season poster to local season directory: %s", ce_season)
                     ET.SubElement(season_root, "thumb").text = "poster.jpg"
                     
                 # Write XML


### PR DESCRIPTION
This pull request improves the compatibility of generated NFO metadata files with media servers by ensuring that artwork image files are always present locally within the relevant directories and by updating the XML references to use simple local filenames. The changes eliminate reliance on relative paths and external references, which can cause issues with some server configurations.

**Artwork management improvements:**

* Ensures that artwork files (`poster.jpg`, `banner.jpg`, `fanart.jpg`) are copied locally into the `streamer_dir` and, if applicable, season-level artwork into the `season_dir`, falling back gracefully if copying fails. This avoids issues with servers that block references outside the library directory or do not support relative paths.
* Adds logic to copy a global poster image to the season directory if a season-specific poster is not present, ensuring that every season directory has a `poster.jpg` for maximum compatibility.

**NFO XML generation improvements:**

* Updates the XML elements in the generated NFO files to reference artwork using simple local filenames (e.g., `"poster.jpg"`, `"banner.jpg"`, `"fanart.jpg"`) instead of relative paths, further improving compatibility with a wider range of media servers. [[1]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L406-R443) [[2]](diffhunk://#diff-0ba5a795ff5985fce10c018951911a8ce5195e288b03176b7ddf02ae7631fbe2L455-R489)