### PR TITLE
fix: update vite version to 6.3.6 for improved compatibility

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "sass": "^1.83.4",
         "sass-loader": "^16.0.4",
         "typescript": "~5.6.3",
-        "vite": "^6.2.7",
+        "vite": "^6.3.6",
         "vite-plugin-pwa": "^0.21.1",
         "vite-plugin-vue-devtools": "^7.6.5",
         "vue-tsc": "^2.2.12"
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -41,7 +41,7 @@
     "sass": "^1.83.4",
     "sass-loader": "^16.0.4",
     "typescript": "~5.6.3",
-    "vite": "^6.2.7",
+    "vite": "^6.3.6",
     "vite-plugin-pwa": "^0.21.1",
     "vite-plugin-vue-devtools": "^7.6.5",
     "vue-tsc": "^2.2.12"


### PR DESCRIPTION
This pull request updates the version of the `vite` dependency in the frontend package to keep the build tooling up to date.

Dependency updates:

* Upgraded `vite` from version `6.2.7` to `6.3.6` in `app/frontend/package.json` to ensure compatibility with the latest features and bug fixes.