### PR TITLE
fix: update import path for websocket_manager to improve module organization

### DIFF
--- a/app/services/processing/post_processing_task_handlers.py
+++ b/app/services/processing/post_processing_task_handlers.py
@@ -13,7 +13,7 @@ from app.database import SessionLocal
 from app.models import Stream, Recording, StreamMetadata, Streamer
 from app.services.media.metadata_service import MetadataService
 from app.services.media.thumbnail_service import ThumbnailService
-from app.services.websocket_manager import websocket_manager
+from app.services.communication.websocket_manager import websocket_manager
 from app.utils import ffmpeg_utils
 from app.utils.structured_logging import log_with_context
 


### PR DESCRIPTION
This pull request makes a small change to the import path for the `websocket_manager` in the `post_processing_task_handlers.py` service, updating it to reflect its new location in the codebase. This helps keep the imports organized and consistent with the project's structure.