### PR TITLE
Develop

### DIFF
--- a/app/services/processing/post_processing_task_handlers.py
+++ b/app/services/processing/post_processing_task_handlers.py
@@ -55,10 +55,7 @@ class PostProcessingTaskHandlers:
             with SessionLocal() as db:
                 rec_id = local_payload.get('recording_id')
                 if rec_id:
-                    state = self._get_or_create_state(db, rec_id, stream_id)
-                    if state:
-                        state.metadata_status = 'running'
-                        db.commit()
+                    self._set_status(db, rec_id, stream_id, 'metadata_generation', 'running')
         except Exception as e:
             logger.debug(f"metadata_generation: failed to mark running state: {e}")
 
@@ -148,10 +145,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.metadata_status = 'completed'
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'metadata_generation', 'completed')
             except Exception as persist_err:
                 logger.debug(f"Could not persist metadata status: {persist_err}")
 
@@ -178,11 +172,7 @@ class PostProcessingTaskHandlers:
                     rec_id = payload.get('recording_id')
                     stream_id = payload.get('stream_id')
                     if rec_id and stream_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.metadata_status = 'failed'
-                            state.last_error = str(e)
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'metadata_generation', 'failed', str(e))
             except Exception as persist_err:
                 logger.debug(f"Could not persist metadata failed status: {persist_err}")
     
@@ -202,10 +192,7 @@ class PostProcessingTaskHandlers:
             with SessionLocal() as db:
                 rec_id = payload.get('recording_id')
                 if rec_id:
-                    state = self._get_or_create_state(db, rec_id, stream_id)
-                    if state:
-                        state.chapters_status = 'running'
-                        db.commit()
+                    self._set_status(db, rec_id, stream_id, 'chapters_generation', 'running')
         except Exception as e:
             logger.debug(f"chapters_generation: failed to mark running: {e}")
         
@@ -233,10 +220,7 @@ class PostProcessingTaskHandlers:
                     rec_id = payload.get('recording_id')
                     stream_id = payload.get('stream_id')
                     if rec_id and stream_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.chapters_status = 'completed'
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'chapters_generation', 'completed')
             except Exception as persist_err:
                 logger.debug(f"Could not persist chapters status: {persist_err}")
             
@@ -255,11 +239,7 @@ class PostProcessingTaskHandlers:
                     rec_id = payload.get('recording_id')
                     stream_id = payload.get('stream_id')
                     if rec_id and stream_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.chapters_status = 'failed'
-                            state.last_error = str(e)
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'chapters_generation', 'failed', str(e))
             except Exception as persist_err:
                 logger.debug(f"Could not persist chapters failed status: {persist_err}")
             raise
@@ -285,10 +265,7 @@ class PostProcessingTaskHandlers:
             with SessionLocal() as db:
                 rec_id = payload.get('recording_id')
                 if rec_id:
-                    state = self._get_or_create_state(db, rec_id, stream_id)
-                    if state:
-                        state.mp4_remux_status = 'running'
-                        db.commit()
+                    self._set_status(db, rec_id, stream_id, 'mp4_remux', 'running')
         except Exception as e:
             logger.debug(f"mp4_remux: failed to mark running: {e}")
         
@@ -430,10 +407,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.mp4_remux_status = 'completed'
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'mp4_remux', 'completed')
             except Exception as persist_err:
                 logger.debug(f"Could not persist mp4_remux status: {persist_err}")
             
@@ -450,11 +424,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.mp4_remux_status = 'failed'
-                            state.last_error = str(e)
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'mp4_remux', 'failed', str(e))
             except Exception as persist_err:
                 logger.debug(f"Could not persist mp4_remux failed status: {persist_err}")
             raise
@@ -477,10 +447,7 @@ class PostProcessingTaskHandlers:
             with SessionLocal() as db:
                 rec_id = payload.get('recording_id')
                 if rec_id:
-                    state = self._get_or_create_state(db, rec_id, stream_id)
-                    if state:
-                        state.thumbnail_status = 'running'
-                        db.commit()
+                    self._set_status(db, rec_id, stream_id, 'thumbnail_generation', 'running')
         except Exception as e:
             logger.debug(f"thumbnail_generation: failed to mark running: {e}")
         
@@ -507,10 +474,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.thumbnail_status = 'completed'
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'thumbnail_generation', 'completed')
             except Exception as persist_err:
                 logger.debug(f"Could not persist thumbnail status: {persist_err}")
             
@@ -527,11 +491,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.thumbnail_status = 'failed'
-                            state.last_error = str(e)
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'thumbnail_generation', 'failed', str(e))
             except Exception as persist_err:
                 logger.debug(f"Could not persist thumbnail failed status: {persist_err}")
             raise
@@ -556,10 +516,7 @@ class PostProcessingTaskHandlers:
             with SessionLocal() as db:
                 rec_id = payload.get('recording_id')
                 if rec_id:
-                    state = self._get_or_create_state(db, rec_id, stream_id)
-                    if state:
-                        state.mp4_validation_status = 'running'
-                        db.commit()
+                    self._set_status(db, rec_id, stream_id, 'mp4_validation', 'running')
         except Exception as e:
             logger.debug(f"mp4_validation: failed to mark running: {e}")
         
@@ -604,10 +561,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.mp4_validation_status = 'completed'
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'mp4_validation', 'completed')
             except Exception as persist_err:
                 logger.debug(f"Could not persist mp4_validation status: {persist_err}")
             
@@ -624,11 +578,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.mp4_validation_status = 'failed'
-                            state.last_error = str(e)
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'mp4_validation', 'failed', str(e))
             except Exception as persist_err:
                 logger.debug(f"Could not persist mp4_validation failed status: {persist_err}")
             raise
@@ -684,10 +634,7 @@ class PostProcessingTaskHandlers:
                 with SessionLocal() as db:
                     rec_id = payload.get('recording_id')
                     if rec_id:
-                        state = self._get_or_create_state(db, rec_id, stream_id)
-                        if state:
-                            state.cleanup_status = 'running'
-                            db.commit()
+                        self._set_status(db, rec_id, stream_id, 'cleanup', 'running')
         except Exception as e:
             logger.debug(f"cleanup: failed to mark running: {e}")
         
@@ -746,10 +693,7 @@ class PostProcessingTaskHandlers:
                     with SessionLocal() as db:
                         rec_id = payload.get('recording_id')
                         if rec_id:
-                            state = self._get_or_create_state(db, rec_id, stream_id)
-                            if state:
-                                state.cleanup_status = 'completed'
-                                db.commit()
+                            self._set_status(db, rec_id, stream_id, 'cleanup', 'completed')
             except Exception as persist_err:
                 logger.debug(f"Could not persist cleanup status: {persist_err}")
             
@@ -778,11 +722,7 @@ class PostProcessingTaskHandlers:
                     with SessionLocal() as db:
                         rec_id = payload.get('recording_id')
                         if rec_id:
-                            state = self._get_or_create_state(db, rec_id, stream_id)
-                            if state:
-                                state.cleanup_status = 'failed'
-                                state.last_error = str(e)
-                                db.commit()
+                            self._set_status(db, rec_id, stream_id, 'cleanup', 'failed', str(e))
             except Exception as persist_err:
                 logger.debug(f"Could not persist cleanup failed status: {persist_err}")
             raise
@@ -838,6 +778,37 @@ class PostProcessingTaskHandlers:
         except Exception as e:
             logger.debug(f"_get_or_create_state failed: {e}")
             return None
+
+    def _set_status(self, db, recording_id: int, stream_id: int, step: str, status: str, last_error: str | None = None):
+        """Set a specific step status with minimal duplication.
+        step can be one of: metadata_generation|metadata, chapters_generation|chapters, mp4_remux,
+        mp4_validation, thumbnail_generation|thumbnail, cleanup
+        """
+        try:
+            state = self._get_or_create_state(db, recording_id, stream_id)
+            if not state:
+                return
+            step_map = {
+                'metadata_generation': 'metadata_status',
+                'metadata': 'metadata_status',
+                'chapters_generation': 'chapters_status',
+                'chapters': 'chapters_status',
+                'mp4_remux': 'mp4_remux_status',
+                'mp4_validation': 'mp4_validation_status',
+                'thumbnail_generation': 'thumbnail_status',
+                'thumbnail': 'thumbnail_status',
+                'cleanup': 'cleanup_status',
+            }
+            attr = step_map.get(step)
+            if not attr:
+                logger.debug(f"_set_status: unknown step '{step}' for recording {recording_id}")
+                return
+            setattr(state, attr, status)
+            if last_error is not None:
+                state.last_error = last_error
+            db.commit()
+        except Exception as e:
+            logger.debug(f"_set_status failed for recording {recording_id}, step {step}: {e}")
 
 # Global instance
 post_processing_task_handlers = PostProcessingTaskHandlers()

--- a/app/services/processing/recording_task_factory.py
+++ b/app/services/processing/recording_task_factory.py
@@ -61,14 +61,24 @@ class RecordingTaskFactory:
                         completed.add('cleanup')
                 else:
                     # Prime a state row so we can keep progress even if app restarts mid-chain
-                    # Use provided streamer_name to resolve streamer_id if possible
                     try:
                         stream = db.query(Stream).get(stream_id)
-                        st = RecordingProcessingState(recording_id=recording_id, stream_id=stream_id, streamer_id=stream.streamer_id if stream else 0)
-                        db.add(st)
-                        db.commit()
-                    except Exception:
-                        pass
+                        if stream:
+                            st = RecordingProcessingState(
+                                recording_id=recording_id,
+                                stream_id=stream_id,
+                                streamer_id=stream.streamer_id
+                            )
+                            db.add(st)
+                            db.commit()
+                        else:
+                            logger.debug(
+                                "Skip creating RecordingProcessingState: stream %s not found for recording %s",
+                                stream_id,
+                                recording_id,
+                            )
+                    except Exception as e:
+                        logger.debug(f"Could not prime processing state for recording {recording_id}: {e}")
         except Exception:
             pass
         

--- a/app/services/processing/recording_task_factory.py
+++ b/app/services/processing/recording_task_factory.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 
 from app.services.processing.task_dependency_manager import Task, TaskStatus
+from app.database import SessionLocal
+from app.models import RecordingProcessingState, Stream
 
 logger = logging.getLogger("streamvault")
 
@@ -39,6 +41,36 @@ class RecordingTaskFactory:
             List of tasks with proper dependencies
         """
         tasks = []
+        # Load persisted state to skip completed steps
+        completed = set()
+        try:
+            with SessionLocal() as db:
+                state = db.query(RecordingProcessingState).filter(RecordingProcessingState.recording_id == recording_id).first()
+                if state:
+                    if state.metadata_status == 'completed':
+                        completed.add('metadata_generation')
+                    if state.chapters_status == 'completed':
+                        completed.add('chapters_generation')
+                    if state.mp4_remux_status == 'completed':
+                        completed.add('mp4_remux')
+                    if state.mp4_validation_status == 'completed':
+                        completed.add('mp4_validation')
+                    if state.thumbnail_status == 'completed':
+                        completed.add('thumbnail_generation')
+                    if state.cleanup_status == 'completed':
+                        completed.add('cleanup')
+                else:
+                    # Prime a state row so we can keep progress even if app restarts mid-chain
+                    # Use provided streamer_name to resolve streamer_id if possible
+                    try:
+                        stream = db.query(Stream).get(stream_id)
+                        st = RecordingProcessingState(recording_id=recording_id, stream_id=stream_id, streamer_id=stream.streamer_id if stream else 0)
+                        db.add(st)
+                        db.commit()
+                    except Exception:
+                        pass
+        except Exception:
+            pass
         
         # Base task IDs
         base_id = f"stream_{stream_id}_recording_{recording_id}"
@@ -65,7 +97,8 @@ class RecordingTaskFactory:
         mp4_path = str(ts_path.with_suffix('.mp4'))
         
         # 1. Metadata Generation Task (no dependencies)
-        metadata_task = Task(
+        if 'metadata_generation' not in completed:
+            metadata_task = Task(
             id=metadata_task_id,
             type='metadata_generation',
             payload={
@@ -75,11 +108,12 @@ class RecordingTaskFactory:
             },
             dependencies=set(),
             priority=1  # High priority
-        )
-        tasks.append(metadata_task)
+            )
+            tasks.append(metadata_task)
         
         # 2. Chapters Generation Task (no dependencies)
-        chapters_task = Task(
+        if 'chapters_generation' not in completed:
+            chapters_task = Task(
             id=chapters_task_id,
             type='chapters_generation',
             payload={
@@ -87,13 +121,14 @@ class RecordingTaskFactory:
                 'mp4_path': mp4_path,
                 'base_filename': ts_path.stem
             },
-            dependencies=set(),
+            dependencies={metadata_task_id} if any(t.id == metadata_task_id for t in tasks) else set(),
             priority=1  # High priority
-        )
-        tasks.append(chapters_task)
+            )
+            tasks.append(chapters_task)
         
         # 3. MP4 Remux Task (depends on metadata and chapters)
-        mp4_remux_task = Task(
+        if 'mp4_remux' not in completed:
+            mp4_remux_task = Task(
             id=mp4_remux_task_id,
             type='mp4_remux',
             payload={
@@ -103,14 +138,15 @@ class RecordingTaskFactory:
                 'include_metadata': True,
                 'include_chapters': True
             },
-            dependencies={metadata_task_id, chapters_task_id},
+            dependencies={dep for dep in {metadata_task_id, chapters_task_id} if dep and dep in [t.id for t in tasks]},
             priority=2  # Medium priority
-        )
-        tasks.append(mp4_remux_task)
+            )
+            tasks.append(mp4_remux_task)
         
         # 4. MP4 Validation Task (depends on MP4 remux)
         mp4_validation_task_id = f"{base_id}_mp4_validation"
-        mp4_validation_task = Task(
+        if 'mp4_validation' not in completed:
+            mp4_validation_task = Task(
             id=mp4_validation_task_id,
             type='mp4_validation',
             payload={
@@ -120,13 +156,14 @@ class RecordingTaskFactory:
                 'validate_size_ratio': True,
                 'min_size_mb': 1  # Minimum 1MB
             },
-            dependencies={mp4_remux_task_id},
+            dependencies={mp4_remux_task_id} if any(t.id == mp4_remux_task_id for t in tasks) else set(),
             priority=2  # High priority - validation is critical
-        )
-        tasks.append(mp4_validation_task)
+            )
+            tasks.append(mp4_validation_task)
         
         # 5. Thumbnail Generation Task (depends on MP4 validation)
-        thumbnail_task = Task(
+        if 'thumbnail_generation' not in completed:
+            thumbnail_task = Task(
             id=thumbnail_task_id,
             type='thumbnail_generation',
             payload={
@@ -134,13 +171,13 @@ class RecordingTaskFactory:
                 'mp4_path': mp4_path,
                 'fallback_to_video_extraction': True
             },
-            dependencies={mp4_validation_task_id},
+            dependencies={mp4_validation_task_id} if any(t.id == mp4_validation_task_id for t in tasks) else set(),
             priority=3  # Lower priority
-        )
-        tasks.append(thumbnail_task)
+            )
+            tasks.append(thumbnail_task)
         
         # 6. Cleanup Task (depends on MP4 validation, only if cleanup_ts_file is True)
-        if cleanup_ts_file:
+        if cleanup_ts_file and 'cleanup' not in completed:
             # Prepare files to remove: .ts file and potential segments directory
             files_to_remove = [ts_file_path]
             
@@ -162,7 +199,7 @@ class RecordingTaskFactory:
                     'intelligent_cleanup': True,
                     'max_wait_time': 300  # 5 minutes max wait for processes
                 },
-                dependencies={mp4_validation_task_id},  # Depends on validation, not thumbnail
+                dependencies={mp4_validation_task_id} if any(t.id == mp4_validation_task_id for t in tasks) else set(),  # Depends on validation, not thumbnail
                 priority=4  # Lowest priority
             )
             tasks.append(cleanup_task)

--- a/app/services/queues/task_queue_manager.py
+++ b/app/services/queues/task_queue_manager.py
@@ -385,6 +385,30 @@ class TaskQueueManager:
                         ",".join([t.id for t in ready_tasks])
                     )
                 for dep_task in ready_tasks:
+                    # Skip tasks already completed in persistent state
+                    try:
+                        from app.database import SessionLocal
+                        from app.models import RecordingProcessingState
+                        with SessionLocal() as db:
+                            rec_id = dep_task.payload.get('recording_id')
+                            if rec_id:
+                                state = db.query(RecordingProcessingState).filter(RecordingProcessingState.recording_id == rec_id).first()
+                                if state:
+                                    step = dep_task.type
+                                    status_map = {
+                                        'metadata_generation': state.metadata_status,
+                                        'chapters_generation': state.chapters_status,
+                                        'mp4_remux': state.mp4_remux_status,
+                                        'mp4_validation': state.mp4_validation_status,
+                                        'thumbnail_generation': state.thumbnail_status,
+                                        'cleanup': state.cleanup_status,
+                                    }
+                                    if status_map.get(step) == 'completed':
+                                        logger.info(f"⏭️ Skipping already-completed task {dep_task.id} ({step}) for recording {rec_id}")
+                                        await self.dependency_manager.mark_task_completed(dep_task.id)
+                                        continue
+                    except Exception:
+                        pass
                     # Find corresponding queue task
                     queue_task = self.progress_tracker.get_task(dep_task.id)
                     if queue_task:
@@ -651,6 +675,17 @@ class TaskQueueManager:
             started_at=started_at,
             cleanup_ts_file=cleanup_ts_file
         )
+        # Persist created task IDs for the recording
+        try:
+            from app.database import SessionLocal
+            from app.models import RecordingProcessingState
+            with SessionLocal() as db:
+                state = db.query(RecordingProcessingState).filter(RecordingProcessingState.recording_id == recording_id).first()
+                if state:
+                    state.set_task_ids({t.type: t.id for t in tasks})
+                    db.commit()
+        except Exception:
+            pass
         
         # Add tasks to dependency manager and create corresponding queue tasks for tracking
         for task in tasks:

--- a/app/services/queues/task_queue_manager.py
+++ b/app/services/queues/task_queue_manager.py
@@ -407,8 +407,13 @@ class TaskQueueManager:
                                         logger.info(f"⏭️ Skipping already-completed task {dep_task.id} ({step}) for recording {rec_id}")
                                         await self.dependency_manager.mark_task_completed(dep_task.id)
                                         continue
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(
+                            "Exception while checking completed state for dep_task %s: %s",
+                            getattr(dep_task, 'id', None),
+                            e,
+                            exc_info=True,
+                        )
                     # Find corresponding queue task
                     queue_task = self.progress_tracker.get_task(dep_task.id)
                     if queue_task:

--- a/migrations/022_add_recording_processing_state.py
+++ b/migrations/022_add_recording_processing_state.py
@@ -30,6 +30,13 @@ CREATE TABLE IF NOT EXISTS recording_processing_state (
 CREATE UNIQUE INDEX IF NOT EXISTS ix_rps_recording_id ON recording_processing_state(recording_id);
 CREATE INDEX IF NOT EXISTS ix_rps_stream_id ON recording_processing_state(stream_id);
 CREATE INDEX IF NOT EXISTS ix_rps_updated_at ON recording_processing_state(updated_at);
+
+-- Ensure updated_at is maintained at DB level
+DROP TRIGGER IF EXISTS update_recording_processing_state_updated_at ON recording_processing_state;
+CREATE TRIGGER update_recording_processing_state_updated_at
+    BEFORE UPDATE ON recording_processing_state
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
 """
 
 SQL_DROP = """

--- a/migrations/022_add_recording_processing_state.py
+++ b/migrations/022_add_recording_processing_state.py
@@ -1,0 +1,46 @@
+"""
+Migration: 022_add_recording_processing_state
+Creates table recording_processing_state to persist per-recording post-processing step status.
+"""
+
+from sqlalchemy import text
+from app.database import engine
+
+SCRIPT_NAME = __name__.split('.')[-1] + '.py'
+
+SQL_CREATE = """
+CREATE TABLE IF NOT EXISTS recording_processing_state (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recording_id INTEGER NOT NULL UNIQUE,
+    stream_id INTEGER NOT NULL,
+    streamer_id INTEGER NOT NULL,
+    metadata_status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    chapters_status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    mp4_remux_status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    mp4_validation_status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    thumbnail_status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    cleanup_status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    last_error TEXT NULL,
+    task_ids_json TEXT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS ix_rps_recording_id ON recording_processing_state(recording_id);
+CREATE INDEX IF NOT EXISTS ix_rps_stream_id ON recording_processing_state(stream_id);
+CREATE INDEX IF NOT EXISTS ix_rps_updated_at ON recording_processing_state(updated_at);
+"""
+
+SQL_DROP = """
+DROP TABLE IF EXISTS recording_processing_state;
+"""
+
+
+def upgrade():
+    with engine.begin() as conn:
+        conn.execute(text(SQL_CREATE))
+
+
+def downgrade():
+    with engine.begin() as conn:
+        conn.execute(text(SQL_DROP))

--- a/migrations/022_add_recording_processing_state.py
+++ b/migrations/022_add_recording_processing_state.py
@@ -10,8 +10,8 @@ SCRIPT_NAME = __name__.split('.')[-1] + '.py'
 
 SQL_CREATE = """
 CREATE TABLE IF NOT EXISTS recording_processing_state (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    recording_id INTEGER NOT NULL UNIQUE,
+    id SERIAL PRIMARY KEY,
+    recording_id INTEGER NOT NULL,
     stream_id INTEGER NOT NULL,
     streamer_id INTEGER NOT NULL,
     metadata_status VARCHAR(20) NOT NULL DEFAULT 'pending',
@@ -20,13 +20,14 @@ CREATE TABLE IF NOT EXISTS recording_processing_state (
     mp4_validation_status VARCHAR(20) NOT NULL DEFAULT 'pending',
     thumbnail_status VARCHAR(20) NOT NULL DEFAULT 'pending',
     cleanup_status VARCHAR(20) NOT NULL DEFAULT 'pending',
-    last_error TEXT NULL,
-    task_ids_json TEXT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    last_error TEXT,
+    task_ids_json TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS ix_rps_recording_id ON recording_processing_state(recording_id);
+-- Align with model index naming; keep unique index on recording_id
+CREATE UNIQUE INDEX IF NOT EXISTS ix_rps_recording_id ON recording_processing_state(recording_id);
 CREATE INDEX IF NOT EXISTS ix_rps_stream_id ON recording_processing_state(stream_id);
 CREATE INDEX IF NOT EXISTS ix_rps_updated_at ON recording_processing_state(updated_at);
 """


### PR DESCRIPTION
This pull request introduces persistent tracking of post-processing steps for recordings, enabling better idempotency and visibility into the status of each processing stage. The main change is the addition of a new `RecordingProcessingState` model, which records the status of each post-processing step (such as metadata generation, chapter extraction, MP4 remuxing, validation, thumbnail generation, and cleanup) for each recording. The code has been updated so that each processing handler updates this state in the database as steps start, complete, or fail.

**Persistent post-processing state tracking:**

* Added a new `RecordingProcessingState` SQLAlchemy model in `app/models.py` to persist the status of each post-processing step per recording, including fields for each step's status, error messages, and task IDs.
* Updated all post-processing handlers in `app/services/processing/post_processing_task_handlers.py` (metadata, chapters, MP4 remux, thumbnail, MP4 validation) to create or update the corresponding `RecordingProcessingState` record as each step starts, completes, or fails, including error handling and minimal record creation if missing. [[1]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R53-R66) [[2]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R149-R167) [[3]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R186-R200) [[4]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R214-R226) [[5]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R246-R260) [[6]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R271-R286) [[7]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R306-R318) [[8]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R453-R466) [[9]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R477-R490) [[10]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R507-R519) [[11]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R539-R552) [[12]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R563-R576) [[13]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R595-R607) [[14]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R646-R658) [[15]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2R669-R682)

**Supporting changes:**

* Imported the new model where needed and made minor imports for future extensibility (e.g., JSON/JSONB types, though not yet used). [[1]](diffhunk://#diff-90c680eba43456b516da8b4c2573d467ae17d1b0ed4373549f2a593ced3616d5R10-R11) [[2]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2L13-R13)

With these changes, the system can now reliably track and recover the state of post-processing pipelines for each recording, improving reliability and observability.