### PR TITLE
Develop

### DIFF
--- a/app/services/media/metadata_service.py
+++ b/app/services/media/metadata_service.py
@@ -235,7 +235,7 @@ class MetadataService:
                             if not self._is_within(base_path_obj, expected_streamer_dir):
                                 # CRITICAL FIX: Before rebasing, validate that the output_dir actually contains wrong streamer content
                                 # This prevents cross-contamination when the wrong streamer context is passed
-                                output_dir_str = str(output_dir) if output_dir else ""
+                                output_dir_str = str(base_path_obj) if base_path_obj else ""
                                 base_path_str = str(base_path_obj)
                                 
                                 # Check if the current path actually belongs to a different streamer
@@ -243,7 +243,7 @@ class MetadataService:
                                 if output_dir_str and streamer.username.lower() not in output_dir_str.lower():
                                     # The output_dir doesn't contain current streamer name, this might be cross-contamination
                                     logger.error(
-                                        f"CRITICAL: Stream belongs to {streamer.username} but output_dir is {output_dir}. "
+                                        f"CRITICAL: Stream belongs to {streamer.username} but base_path is {base_path_obj}. "
                                         f"This indicates wrong stream-to-recording mapping. Refusing to rebase to prevent cross-contamination."
                                     )
                                     # Instead of rebasing, keep the original path and log the error for investigation

--- a/app/services/processing/post_processing_task_handlers.py
+++ b/app/services/processing/post_processing_task_handlers.py
@@ -413,7 +413,7 @@ class PostProcessingTaskHandlers:
                             # Send recording available notification
                             import asyncio
                             async def send_notification():
-                                await websocket_manager.send_message_to_all({
+                                await websocket_manager.send_notification({
                                     "type": "recording_available",
                                     "data": {
                                         "stream_id": stream_id,
@@ -552,13 +552,6 @@ class PostProcessingTaskHandlers:
         validate_size_ratio = payload.get('validate_size_ratio', True)
         min_size_mb = payload.get('min_size_mb', 1)
         
-        log_with_context(
-            logger, 'info',
-            f"Starting MP4 validation for stream {stream_id}",
-            task_id=payload.get('task_id'),
-            stream_id=stream_id,
-            mp4_path=mp4_path,
-            operation='mp4_validation_start'
         log_with_context(
             logger, 'info',
             f"Starting MP4 validation for stream {stream_id}",
@@ -932,7 +925,7 @@ class PostProcessingTaskHandlers:
             if rec_id is None:
                 # No debounce key; send immediately
                 async def send_once():
-                    await websocket_manager.send_message_to_all(snapshot)
+                    await websocket_manager.send_notification(snapshot)
                 try:
                     loop = asyncio.get_running_loop()
                     asyncio.create_task(send_once())
@@ -947,7 +940,7 @@ class PostProcessingTaskHandlers:
                 snap = self._broadcast_debounce.get(recording_id)
                 if snap:
                     try:
-                        await websocket_manager.send_message_to_all(snap)
+                        await websocket_manager.send_notification(snap)
                     finally:
                         # Clear after send
                         self._broadcast_debounce.pop(recording_id, None)
@@ -957,7 +950,7 @@ class PostProcessingTaskHandlers:
             except RuntimeError:
                 # No running loop; skip debounce
                 async def send_fallback():
-                    await websocket_manager.send_message_to_all(snapshot)
+                    await websocket_manager.send_notification(snapshot)
                 try:
                     loop = asyncio.get_running_loop()
                     asyncio.create_task(send_fallback())

--- a/app/services/recording/recording_lifecycle_manager.py
+++ b/app/services/recording/recording_lifecycle_manager.py
@@ -648,7 +648,7 @@ class RecordingLifecycleManager:
                     logger.info(f"🎬 QUEUING_SEGMENT_CONCATENATION: {len(segment_files)} files for recording {recording_id}")
                     
                     # Queue segment concatenation task first
-                    await self._queue_segment_concatenation_task(recording_id, segment_files, recording_path, streamer_data)
+                    await self._queue_segment_concatenation_task(recording_id, stream_data.id, segment_files, recording_path, streamer_data)
                     return  # Exit here - post-processing will continue after concatenation
                 else:
                     logger.warning(f"🎬 NO_SEGMENTS_FOUND: {segments_dir}")
@@ -754,7 +754,7 @@ class RecordingLifecycleManager:
         except Exception as e:
             logger.error(f"Error triggering post-processing for recording {recording_id}: {e}", exc_info=True)
 
-    async def _queue_segment_concatenation_task(self, recording_id: int, segment_files: list, recording_path: str, streamer_data):
+    async def _queue_segment_concatenation_task(self, recording_id: int, stream_id: int, segment_files: list, recording_path: str, streamer_data):
         """Queue segment concatenation as a background task to avoid blocking the stream offline handler"""
         try:
             from app.services.queues.task_progress_tracker import TaskPriority
@@ -765,7 +765,8 @@ class RecordingLifecycleManager:
                 'segment_files': [str(f) for f in segment_files],
                 'output_path': recording_path,
                 'streamer_name': streamer_data.username,
-                'stream_id': recording_id,  # Use recording_id as fallback for stream_id
+                # Real stream id to avoid mixing identifiers
+                'stream_id': stream_id,
             }
             
             # Enqueue segment concatenation task with high priority

--- a/app/services/recording/segment_concatenation_task.py
+++ b/app/services/recording/segment_concatenation_task.py
@@ -260,7 +260,8 @@ async def _queue_post_processing_tasks(recording_id: int, ts_file_path: str, tas
         
         # Create post-processing payload
         post_processing_payload = {
-            'stream_id': task_data.get('stream_id', recording_id),
+            # Prefer explicit stream_id from task_data; do NOT fall back to recording_id
+            'stream_id': task_data.get('stream_id'),
             'recording_id': recording_id,
             'ts_file_path': ts_file_path,
             'output_dir': str(Path(ts_file_path).parent),

--- a/app/services/recording/segment_concatenation_task.py
+++ b/app/services/recording/segment_concatenation_task.py
@@ -258,10 +258,15 @@ async def _queue_post_processing_tasks(recording_id: int, ts_file_path: str, tas
     try:
         from app.services.background_queue_service import background_queue_service
         
+        # Validate that stream_id is present
+        stream_id = task_data.get('stream_id')
+        if stream_id is None:
+            logger.error(f"stream_id is missing from task_data for recording {recording_id}, cannot queue post-processing")
+            return
+        
         # Create post-processing payload
         post_processing_payload = {
-            # Prefer explicit stream_id from task_data; do NOT fall back to recording_id
-            'stream_id': task_data.get('stream_id'),
+            'stream_id': stream_id,
             'recording_id': recording_id,
             'ts_file_path': ts_file_path,
             'output_dir': str(Path(ts_file_path).parent),


### PR DESCRIPTION
This pull request focuses on improving the accuracy and safety of stream processing and notification broadcasting in the media processing pipeline. The changes address critical issues around stream identification to prevent cross-contamination, update notification methods for consistency, and refine task payloads to ensure correct stream IDs are used throughout the system.

**Stream Identification and Safety**

* Updated a critical validation in `generate_metadata_for_stream` to use `base_path_obj` instead of `output_dir` for streamer context checks, ensuring more accurate detection of cross-contamination between streamers.
* Modified segment concatenation task queuing in `recording_lifecycle_manager.py` to always use the real `stream_id` instead of falling back to `recording_id`, preventing identifier mix-ups. This includes updating function signatures and payload construction. [[1]](diffhunk://#diff-69e1ea3a9312285e5a2d66a6397d3b9f60ed4a468a50f17d7966ed0bc0b2d936L651-R651) [[2]](diffhunk://#diff-69e1ea3a9312285e5a2d66a6397d3b9f60ed4a468a50f17d7966ed0bc0b2d936L757-R757) [[3]](diffhunk://#diff-69e1ea3a9312285e5a2d66a6397d3b9f60ed4a468a50f17d7966ed0bc0b2d936L768-R769)
* Adjusted post-processing payload creation in `segment_concatenation_task.py` to require an explicit `stream_id` from `task_data`, removing the fallback to `recording_id` for improved identifier integrity.

**Notification and WebSocket Handling**

* Standardized notification broadcasting by replacing `send_message_to_all` with `send_notification` in all relevant async notification calls, ensuring a unified notification interface. [[1]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2L416-R416) [[2]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2L935-R928) [[3]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2L950-R943) [[4]](diffhunk://#diff-b4676993457906a56569995765f9dfeff5c46015462ddf20f6b0dd870272c8f2L960-R953)

**Logging and Validation**

* Fixed a logging call in `handle_mp4_validation` to remove duplicate or erroneous log statements, streamlining the start of the MP4 validation process.