### PR TITLE
fix(ci): install pytest in docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          
+          pip install pytest pytest-asyncio httpx
+
       - name: Run pytest
         run: |
           pytest tests/ -v --tb=short


### PR DESCRIPTION
- Add pytest, pytest-asyncio, httpx to pip install
- Fixes 'pytest: command not found' error in CI