### PR TITLE
Feature/upgrade postgres 18

### DIFF
--- a/.github/agents/modernization.agent.md
+++ b/.github/agents/modernization.agent.md
@@ -1,19 +1,7 @@
 ---
 description: 'Human-in-the-loop modernization assistant for analyzing, documenting, and planning complete project modernization with architectural recommendations.'
-model: 'GPT-5'
 tools:
-   - search
-   - read
-   - edit
-   - execute
-   - agent
-   - todo
-   - read/problems
-   - execute/runTask
-   - execute/runInTerminal
-   - execute/createAndRunTask
-   - execute/getTaskOutput
-   - web/fetch
+   ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'copilot-container-tools/*', 'github/*', 'agent', 'pylance-mcp-server/*', 'ms-python.python/getPythonEnvironmentInfo', 'ms-python.python/getPythonExecutableCommand', 'ms-python.python/installPythonPackage', 'ms-python.python/configurePythonEnvironment', 'todo']
 ---
 
 This agent runs directly in VS Code with read/write access to your workspace. It guides you through complete project modernization with a structured, stac

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -67,7 +67,7 @@ services:
       - streamvault_network
 
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: streamvault_db_dev
     
     # Development database resource limits

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     networks:
       - streamvault_network
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: streamvault_db
     
     # Database resource limits


### PR DESCRIPTION
This pull request updates the development and production Docker configurations to use a newer version of PostgreSQL, and also modifies the configuration for the modernization agent to refine its toolset and model specification.

**Docker configuration updates:**

* Upgraded the PostgreSQL image from `postgres:16-alpine` to `postgres:18-alpine` in both `docker/docker-compose.yml` and `docker/docker-compose.dev.yml` to ensure compatibility with newer features and improved security. [[1]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L66-R66) [[2]](diffhunk://#diff-740e0cdeda40047aeb493482ba2b352edbacdc0107a84491d149bcd219dd95ffL70-R70)

**Modernization agent configuration:**

* Updated `.github/agents/modernization.agent.md` to remove the explicit `model` field and consolidate the tools list into a single array, streamlining the agent's capabilities and configuration.