### PR TITLE
fix(docker): update volume path for PostgreSQL 18 compatibility

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -93,7 +93,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
     
     restart: unless-stopped
     

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
     
     restart: unless-stopped
     


### PR DESCRIPTION
PostgreSQL 18+ requires mounting at /var/lib/postgresql instead of /var/lib/postgresql/data to support pg_upgrade --link.

See: https://github.com/docker-library/postgres/pull/1259

BREAKING CHANGE: Existing PostgreSQL 16 volumes must be backed up and recreated when upgrading. Run:
  docker compose exec db sh -c 'pg_dump -U $POSTGRES_USER $POSTGRES_DB' > backup.sql
  docker compose down
  docker volume rm <volume_name>
  docker compose up -d
  docker compose exec -T db sh -c 'psql -U $POSTGRES_USER $POSTGRES_DB' < backup.sql