### PR TITLE
fix(ci): use continuous versioning across main and develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,38 +66,53 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          # Base version from latest stable tag
-          LATEST_STABLE_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | grep -v -E "dev" | head -n1 || echo "")
-          if [ -z "$LATEST_STABLE_TAG" ]; then
-            LATEST_STABLE_TAG="v1.0.0"
-          fi
-
-          STABLE_VERSION=${LATEST_STABLE_TAG#v}
-          IFS='.' read -ra VERSION_PARTS <<< "$STABLE_VERSION"
-          MAJOR=${VERSION_PARTS[0]:-1}
-          MINOR=${VERSION_PARTS[1]:-0}
-          PATCH=${VERSION_PARTS[2]:-0}
-
-          # Find the latest dev tag (format: vdev.X.Y.Z) using numeric sort
-          LATEST_DEV_TAG=$(git tag -l "vdev.[0-9]*.[0-9]*.[0-9]*" | sort -t. -k2,2n -k3,3n -k4,4n | tail -n1 || echo "")
+          # =============================================================
+          # Version Calculation Strategy:
+          # - Single continuous version number across main and develop
+          # - develop: vdev.X.Y.Z (pre-release)
+          # - main: vX.Y.Z (stable release)
+          # - Both branches increment from the HIGHEST existing version
+          # =============================================================
           
-          # Extract version parts from dev tag if it exists
-          if [ -n "$LATEST_DEV_TAG" ]; then
-            # vdev.2.0.26 -> 2.0.26
-            DEV_VERSION=${LATEST_DEV_TAG#vdev.}
-            IFS='.' read -ra DEV_PARTS <<< "$DEV_VERSION"
-            DEV_MAJOR=${DEV_PARTS[0]:-2}
-            DEV_MINOR=${DEV_PARTS[1]:-0}
-            DEV_PATCH=${DEV_PARTS[2]:-0}
-            NEXT_PATCH=$((DEV_PATCH + 1))
-            echo "Found latest dev tag: $LATEST_DEV_TAG (next patch: $NEXT_PATCH)"
+          # Find latest stable tag (v2.0.29 format, exclude vdev.*)
+          LATEST_STABLE_TAG=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" | grep -v "vdev" | \
+            sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1 || echo "")
+          if [ -n "$LATEST_STABLE_TAG" ]; then
+            STABLE_PATCH=$(echo "$LATEST_STABLE_TAG" | cut -d. -f3)
+            echo "Latest stable tag: v${LATEST_STABLE_TAG} (patch: ${STABLE_PATCH})"
           else
-            # Fallback if no dev tags exist
-            DEV_MAJOR=$MAJOR
-            DEV_MINOR=$MINOR
-            NEXT_PATCH=$((PATCH + 1))
-            echo "No dev tags found, using stable version as base"
+            STABLE_PATCH=0
+            echo "No stable tags found"
           fi
+          
+          # Find latest dev tag (vdev.2.0.27 format)
+          LATEST_DEV_TAG=$(git tag -l "vdev.[0-9]*.[0-9]*.[0-9]*" | \
+            sed 's/^vdev\.//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1 || echo "")
+          if [ -n "$LATEST_DEV_TAG" ]; then
+            DEV_PATCH=$(echo "$LATEST_DEV_TAG" | cut -d. -f3)
+            echo "Latest dev tag: vdev.${LATEST_DEV_TAG} (patch: ${DEV_PATCH})"
+          else
+            DEV_PATCH=0
+            echo "No dev tags found"
+          fi
+          
+          # Use the HIGHER patch number as base (continuous versioning)
+          if [ "$STABLE_PATCH" -gt "$DEV_PATCH" ]; then
+            CURRENT_PATCH=$STABLE_PATCH
+            echo "Using stable patch as base: ${CURRENT_PATCH}"
+          else
+            CURRENT_PATCH=$DEV_PATCH
+            echo "Using dev patch as base: ${CURRENT_PATCH}"
+          fi
+          
+          # Next version is always current + 1
+          NEXT_PATCH=$((CURRENT_PATCH + 1))
+          
+          # Major.Minor is fixed at 2.0 for now (change when needed)
+          MAJOR=2
+          MINOR=0
+          
+          echo "Next patch version: ${NEXT_PATCH}"
 
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             # Manual tag push - use the tag as-is
@@ -112,28 +127,30 @@ jobs:
               RELEASE_TAG=${GITHUB_REF#refs/tags/}
             fi
           elif [[ "${{ github.ref }}" == refs/heads/main ]]; then
-            # Main branch: stable release, increment from latest dev tag
-            VERSION="${DEV_MAJOR}.${DEV_MINOR}.${NEXT_PATCH}"
+            # Main branch: stable release
+            VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
             IS_PRERELEASE=false
             RELEASE_TAG="v${VERSION}"
             echo "Main branch release: ${VERSION}"
           elif [[ "${{ github.ref }}" == refs/heads/develop ]]; then
-            # Develop branch: dev release, increment from latest dev tag
-            VERSION="dev.${DEV_MAJOR}.${DEV_MINOR}.${NEXT_PATCH}"
+            # Develop branch: pre-release
+            VERSION="dev.${MAJOR}.${MINOR}.${NEXT_PATCH}"
             IS_PRERELEASE=true
-            RELEASE_TAG="vdev.${DEV_MAJOR}.${DEV_MINOR}.${NEXT_PATCH}"
+            RELEASE_TAG="vdev.${MAJOR}.${MINOR}.${NEXT_PATCH}"
             echo "Develop branch release: ${VERSION}"
           else
             # Other branches - shouldn't happen with current trigger config
-            VERSION="dev.${DEV_MAJOR}.${DEV_MINOR}.${NEXT_PATCH}"
+            VERSION="dev.${MAJOR}.${MINOR}.${NEXT_PATCH}"
             IS_PRERELEASE=true
-            RELEASE_TAG="vdev.${DEV_MAJOR}.${DEV_MINOR}.${NEXT_PATCH}"
+            RELEASE_TAG="vdev.${MAJOR}.${MINOR}.${NEXT_PATCH}"
           fi
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "is_prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
           echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
-          echo "Version: ${VERSION}, Prerelease: ${IS_PRERELEASE}, Tag: ${RELEASE_TAG}"
+          echo "=========================================="
+          echo "Final: Version=${VERSION}, Prerelease=${IS_PRERELEASE}, Tag=${RELEASE_TAG}"
+          echo "=========================================="
 
       - name: Docker metadata
         id: docker_meta


### PR DESCRIPTION
Version calculation now finds the HIGHEST version from both:
- Stable tags: v2.0.X
- Dev tags: vdev.2.0.X

This ensures a single continuous version sequence:
- develop: vdev.2.0.27 → vdev.2.0.28
- main: (after merge) → v2.0.29
- develop: (after main release) → vdev.2.0.30

No more version conflicts between branches.

Example flow:
1. develop push: MAX(26, 7) = 26 → vdev.2.0.27
2. develop push: MAX(27, 7) = 27 → vdev.2.0.28
3. main merge:   MAX(28, 7) = 28 → v2.0.29
4. develop push: MAX(28, 29) = 29 → vdev.2.0.30