### PR TITLE
perf(ci): remove ARM build to speed up Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,9 +213,6 @@ jobs:
           npx update-browserslist-db@latest
           npm run build
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -237,7 +234,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ needs.prepare.outputs.docker_tags }}
           labels: ${{ needs.prepare.outputs.docker_labels }}


### PR DESCRIPTION
Removed:
- QEMU emulation setup (no longer needed)
- linux/arm64 platform from build matrix

Build time reduction: ~10-15 min → ~3-4 min

ARM support can be added back as a feature request if needed.