### PR TITLE
fix(recording): fix permanent DB session failure breaking all recordings

### DIFF
--- a/app/utils/retry_decorator.py
+++ b/app/utils/retry_decorator.py
@@ -189,11 +189,10 @@ def database_retry(func: Callable) -> Callable:
         retry_on=[
             ConnectionError,
             OSError,
-            # Add specific database error types as needed
+            RetryableError,
         ],
         stop_on=[
             NonRetryableError,
-            # Add database-specific non-retryable errors
         ],
         log_attempts=True,
     )(func)


### PR DESCRIPTION
Root cause: Database session entered invalid transaction state on Feb 14 and never recovered because:

1. Read-only methods (get_stream_by_id, get_streamer_by_id, etc.) had no rollback() in their except blocks, so a broken transaction was never cleared
2. _ensure_db_session() only checked if session existed, not if it was healthy - so a broken session persisted forever
3. database_retry decorator didn't include RetryableError in retry_on list, so DB errors were never retried

Fixes:
- Add rollback() to ALL database methods in except blocks
- _ensure_db_session() now tests session health with SELECT 1 and recreates session if transaction is invalid
- Add RetryableError to database_retry's retry_on list
- Add try/except to get_recording() which had none at all