### PR TITLE
ci: add Trivy SARIF upload to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -117,6 +117,7 @@ jobs:
           file: docker/Dockerfile
           platforms: linux/amd64
           push: false
+          load: true
           tags: streamvault:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,6 +73,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
     
@@ -119,6 +120,23 @@ jobs:
           tags: streamvault:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'streamvault:pr-${{ github.event.pull_request.number }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-secure'
+        continue-on-error: true
           
   # Security scanning on requirements
   security:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Build Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
ci: add Trivy SARIF upload to docker-build workflow (trivy-secure category) and fix buildx setup