### PR TITLE
fix(frontend): replace window.location.href with router.push to prevent reload loop

### DIFF
--- a/app/frontend/src/composables/useAuth.ts
+++ b/app/frontend/src/composables/useAuth.ts
@@ -3,6 +3,10 @@
  * Handles persistent sessions for standalone apps
  */
 import { ref, computed } from 'vue'
+import router from '@/router'
+
+// Guard against concurrent auth redirects
+let isAuthRedirecting = false
 
 const isAuthenticated = ref(false)
 const sessionToken = ref<string | null>(null)
@@ -39,7 +43,10 @@ export function useAuth() {
           // If authenticated but got false from server, redirect
           if (!data.authenticated && !isAuthPage) {
             console.warn('Session invalid, redirecting to login...')
-            window.location.href = '/auth/login'
+            if (!isAuthRedirecting) {
+              isAuthRedirecting = true
+              router.push('/auth/login').finally(() => { isAuthRedirecting = false })
+            }
             return
           }
         } else {
@@ -47,7 +54,10 @@ export function useAuth() {
           clearAuth()
           if (!isAuthPage) {
             console.warn('Auth check failed (non-OK response), redirecting to login...')
-            window.location.href = '/auth/login'
+            if (!isAuthRedirecting) {
+              isAuthRedirecting = true
+              router.push('/auth/login').finally(() => { isAuthRedirecting = false })
+            }
           }
         }
       } catch (error) {
@@ -59,7 +69,10 @@ export function useAuth() {
       // No stored token and on protected page - redirect to login
       if (!isAuthPage) {
         console.warn('No session token found, redirecting to login...')
-        window.location.href = '/auth/login'
+        if (!isAuthRedirecting) {
+          isAuthRedirecting = true
+          router.push('/auth/login').finally(() => { isAuthRedirecting = false })
+        }
       }
     }
   }
@@ -110,8 +123,8 @@ export function useAuth() {
     
     clearAuth()
     
-    // Force redirect to login for ALL scenarios
-    window.location.href = '/auth/login'
+    // Soft redirect to login for ALL scenarios
+    router.push('/auth/login')
   }
   
   const clearAuth = () => {

--- a/app/frontend/src/composables/useWebSocket.ts
+++ b/app/frontend/src/composables/useWebSocket.ts
@@ -1,6 +1,7 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import type { Ref } from 'vue'
 import { logDebug, logWebSocket } from '@/utils/logger'
+import router from '@/router'
 
 interface WebSocketMessage {
   type: string
@@ -17,6 +18,7 @@ class WebSocketManager {
   private maxReconnectAttempts = 10
   private wsUrl: string
   private connectionId: string | null = null
+  private isRedirecting = false
   
   // Reactive state shared across all components
   public messages: Ref<WebSocketMessage[]> = ref([])
@@ -77,6 +79,13 @@ class WebSocketManager {
   }
 
   private connect() {
+    // Don't connect on auth pages — there's no valid session
+    const path = window.location.pathname
+    if (path.startsWith('/auth/')) {
+      console.log('⏭️ Skipping WebSocket connection on auth page')
+      return
+    }
+
     // Prevent multiple connections
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       console.log('⚠️ WebSocket already connected, skipping')
@@ -136,7 +145,14 @@ class WebSocketManager {
       if (event.code === 4001 || event.code === 4003) {
         console.warn('🔒 WebSocket auth failed — session invalid or expired')
         this.connectionStatus.value = 'auth_failed'
-        window.location.href = '/auth/login'
+        // Use Vue Router (soft navigation) instead of window.location.href
+        // to prevent full page reload → reconnect → auth fail → reload loop
+        if (!this.isRedirecting) {
+          this.isRedirecting = true
+          router.push('/auth/login').finally(() => {
+            this.isRedirecting = false
+          })
+        }
         return
       }
       

--- a/app/frontend/src/services/api-real.ts
+++ b/app/frontend/src/services/api-real.ts
@@ -1,6 +1,11 @@
 // API client for StreamVault - REAL BACKEND IMPLEMENTATION
 // This file is imported by api.ts when NOT in mock mode
 
+import router from '@/router'
+
+// Global redirect guard to prevent concurrent redirects
+let isAuthRedirecting = false
+
 interface RequestConfig {
   headers?: Record<string, string>
   body?: any
@@ -48,9 +53,15 @@ class ApiClient {
           // Clear any stored auth data
           localStorage.removeItem('streamvault_session')
           sessionStorage.clear()
-          // Force redirect to login page
-          window.location.href = '/auth/login'
-          return
+          // Use Vue Router (soft navigation) to prevent reload loops
+          if (!isAuthRedirecting) {
+            isAuthRedirecting = true
+            router.push('/auth/login').finally(() => {
+              isAuthRedirecting = false
+            })
+          }
+          // Throw to abort the caller so it doesn't continue processing
+          throw new Error('Session expired - redirecting to login')
         }
         throw new Error(`HTTP error! status: ${response.status}`)
       }


### PR DESCRIPTION
When unauthenticated, WebSocket onclose, API 401 handler, and useAuth all used window.location.href = /auth/login which triggers a full page reload. This remounts all components, reconnects WebSocket, which fails auth again, causing another reload — infinite flickering loop.

Fixes:
- useWebSocket.ts: import router, use router.push with isRedirecting guard, skip WebSocket connection entirely on /auth/ pages
- api-real.ts: import router, use router.push on 401 with guard, throw error to abort caller instead of silent return
- useAuth.ts: import router, replace all window.location.href redirects to login with router.push and isRedirecting guards