### PR TITLE
fix(ci): use ghcr.io for Trivy DB instead of mirror.gcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db:2'
+          TRIVY_JAVA_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-java-db:1'
         with:
           image-ref: ${{ steps.image_name.outputs.full_ref }}
           format: 'sarif'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -185,6 +185,9 @@ jobs:
       - name: Run Trivy vulnerability scanner (SARIF)
         if: steps.docker-build.outcome == 'success'
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db:2'
+          TRIVY_JAVA_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-java-db:1'
         with:
           image-ref: 'streamvault:scan'
           format: 'sarif'
@@ -203,6 +206,9 @@ jobs:
       - name: Run Trivy (table output for logs)
         if: steps.docker-build.outcome == 'success'
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db:2'
+          TRIVY_JAVA_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-java-db:1'
         with:
           image-ref: 'streamvault:scan'
           format: 'table'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,9 @@ jobs:
           docker run -d --name streamvault-test \
             -p 7000:7000 \
             -e DATABASE_URL=sqlite:///./test.db \
+            -e TWITCH_APP_ID=ci_test_placeholder \
+            -e TWITCH_APP_SECRET=ci_test_placeholder \
+            -e BASE_URL=http://localhost:7000 \
             streamvault:test
 
           # Wait for container to be healthy with retries
@@ -230,6 +233,9 @@ jobs:
 
       - name: Run Trivy filesystem scanner
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db:2'
+          TRIVY_JAVA_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-java-db:1'
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
mirror.gcr.io returns 404 when downloading the Trivy vulnerability DB, causing CI scans to fail with:
  FATAL: failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2

Set TRIVY_DB_REPOSITORY and TRIVY_JAVA_DB_REPOSITORY env vars to use the official ghcr.io registry (ghcr.io/aquasecurity/trivy-db:2) in all workflows: security-scan.yml, release.yml, test.yml.