### PR TITLE
feat(metadata): improve Plex/Emby NFO cast, plot and genres

### DIFF
--- a/app/events/handler_registry.py
+++ b/app/events/handler_registry.py
@@ -214,6 +214,8 @@ class EventHandlerRegistry:
                 if streamer:
                     if user_info and user_info.get("profile_image_url"):
                         streamer.profile_image_url = user_info["profile_image_url"]
+                    if user_info and user_info.get("description"):
+                        streamer.description = user_info["description"]
 
                     stream = Stream(
                         streamer_id=streamer.id,

--- a/app/models.py
+++ b/app/models.py
@@ -79,6 +79,7 @@ class Streamer(Base):
     original_profile_image_url = Column(String)
     offline_image_url = Column(String)  # Twitch banner image (cached)
     original_offline_image_url = Column(String)  # Twitch banner (original URL)
+    description = Column(Text, nullable=True)  # Twitch "About" / bio text
     is_favorite = Column(Boolean, default=False, index=True)
     auto_record = Column(Boolean, default=False, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/services/media/metadata_service.py
+++ b/app/services/media/metadata_service.py
@@ -214,6 +214,130 @@ class MetadataService:
         """Public wrapper for safe path containment check."""
         return self._is_within(child, parent)
 
+    def _collect_streamer_genres(
+        self,
+        db: Session,
+        streamer: Streamer,
+        limit: int = 20,
+    ) -> List[str]:
+        """Return an ordered, de-duplicated list of genres (categories) for a streamer.
+
+        Pulls from the streamer's historical `Stream.category_name` values (most recent first)
+        and augments with current/last known category fields on the streamer so the list is
+        never empty as long as the streamer has ever been seen playing something.
+        """
+        genres: List[str] = []
+        seen: set = set()
+
+        def _add(value: Optional[str]) -> None:
+            if not value:
+                return
+            v = value.strip()
+            if not v or v.lower() in seen:
+                return
+            seen.add(v.lower())
+            genres.append(v)
+
+        try:
+            rows = (
+                db.query(Stream.category_name)
+                .filter(Stream.streamer_id == streamer.id)
+                .filter(Stream.category_name.isnot(None))
+                .filter(Stream.category_name != "")
+                .order_by(Stream.started_at.desc().nullslast())
+                .limit(max(limit * 2, limit))  # over-fetch to allow dedup
+                .all()
+            )
+            for (cat,) in rows:
+                _add(cat)
+                if len(genres) >= limit:
+                    break
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(
+                f"Failed to query historical categories for streamer {streamer.id}: {e}"
+            )
+
+        # Fallbacks from the streamer row itself (current + last known)
+        _add(getattr(streamer, "category_name", None))
+        _add(getattr(streamer, "last_stream_category_name", None))
+
+        return genres[:limit]
+
+    def _ensure_actor_folder_image(
+        self, streamer_dir: Path, streamer: Streamer, safe_username: str
+    ) -> None:
+        """Place a local actor portrait at ``<streamer_dir>/.Actors/<Name>/folder.jpg``.
+
+        Emby and Jellyfin look for cast portraits in a ``.Actors`` subfolder next to the
+        show. Plex' new NFO scanner primarily uses the ``<thumb>`` URL on the ``<actor>``
+        element (we set an HTTPS Twitch CDN URL for that), but keeping a local fallback
+        here makes the same NFO work offline on Emby/Jellyfin.
+
+        Silently ignores errors - this is a best-effort enrichment.
+        """
+        try:
+            streamer_dir = Path(streamer_dir)
+            actor_name = streamer.username or safe_username
+            actor_dir = streamer_dir / ".Actors" / actor_name
+            target = actor_dir / "folder.jpg"
+            if target.exists():
+                return
+
+            # Source: central artwork poster.jpg (downloaded by artwork_service)
+            root = self._find_recordings_root(streamer_dir)
+            if not root:
+                parent = streamer_dir.parent
+                if parent != streamer_dir and (parent / ".media").is_dir():
+                    root = parent
+            if not root:
+                return
+
+            source = root / ".media" / "artwork" / safe_username / "poster.jpg"
+            if not source.is_file():
+                return
+
+            actor_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        except Exception as e:
+            logger.debug(
+                f"Failed to create .Actors folder image for {safe_username}: {e}"
+            )
+
+    def _pick_actor_thumb_url(
+        self, streamer: Streamer, streamer_dir: Path, safe_username: str
+    ) -> Optional[str]:
+        """Return the best value for ``<actor><thumb>`` in NFO files.
+
+        Preference order:
+        1. ``streamer.original_profile_image_url`` if it is a plain HTTPS URL - this is
+           what Plex' newer NFO scanner handles most reliably.
+        2. ``streamer.profile_image_url`` if it points to an HTTPS URL.
+        3. Relative path to the cached ``poster.jpg`` under ``.media/artwork/<user>/``.
+        """
+        for candidate in (
+            getattr(streamer, "original_profile_image_url", None),
+            getattr(streamer, "profile_image_url", None),
+        ):
+            if (
+                isinstance(candidate, str)
+                and candidate.startswith("http")
+                and "://" in candidate
+            ):
+                return candidate
+
+        return self._relative_artwork_path(streamer_dir, safe_username, "poster.jpg")
+
+    def _series_plot_text(self, streamer: Streamer) -> str:
+        """Return the ``<plot>`` text for a streamer's ``tvshow.nfo``.
+
+        Prefers the streamer's Twitch "About" bio (column ``description``); falls
+        back to a generic placeholder when the bio is unset or empty.
+        """
+        bio = (getattr(streamer, "description", None) or "").strip()
+        if bio:
+            return bio
+        return f"Streams by {streamer.username} on Twitch."
+
     async def generate_metadata_for_stream(
         self, stream_id: int, base_path: str, base_filename: str
     ) -> bool:
@@ -586,9 +710,10 @@ class MetadataService:
 
             # Streamer information
             ET.SubElement(show_root, "studio").text = "Twitch"
-            ET.SubElement(
-                show_root, "plot"
-            ).text = f"Streams by {streamer.username} on Twitch."
+            # Prefer the streamer's Twitch "About" bio as the series plot so that
+            # Plex / Emby / Jellyfin show the real channel description instead of
+            # a generic placeholder. Fall back to the placeholder when unset.
+            ET.SubElement(show_root, "plot").text = self._series_plot_text(streamer)
 
             # Important for Plex: Store artwork in hidden .media directory
             if streamer.profile_image_url:
@@ -617,21 +742,36 @@ class MetadataService:
                 fanart = ET.SubElement(show_root, "fanart")
                 ET.SubElement(fanart, "thumb").text = "fanart.jpg"
 
-            # Genre/Category
-            if streamer.category_name:
-                ET.SubElement(show_root, "genre").text = streamer.category_name
+            # Genre/Category - emit one <genre> per unique historical category
+            # so Plex/Emby display the full range of games the streamer has played.
+            genres = self._collect_streamer_genres(db, streamer)
+            if genres:
+                for genre_name in genres:
+                    ET.SubElement(show_root, "genre").text = genre_name
             else:
                 ET.SubElement(show_root, "genre").text = "Livestream"
 
             # Streamer as "actor"
             actor = ET.SubElement(show_root, "actor")
             ET.SubElement(actor, "name").text = streamer.username
-            if streamer.profile_image_url:
-                # Actor image from .media directory with proper relative path
-                actor_thumb_rel = self._relative_artwork_path(
-                    streamer_dir, safe_username, "poster.jpg"
+            if streamer.profile_image_url or streamer.original_profile_image_url:
+                # Prefer an HTTPS URL (maximum compatibility with Plex' newer NFO
+                # scanner). Fall back to a relative path into the central .media
+                # artwork directory if no URL is available.
+                actor_thumb = self._pick_actor_thumb_url(
+                    streamer, streamer_dir, safe_username
                 )
-                ET.SubElement(actor, "thumb").text = actor_thumb_rel
+                if actor_thumb:
+                    ET.SubElement(actor, "thumb").text = actor_thumb
+                # Emby/Jellyfin offline fallback: local .Actors/<Name>/folder.jpg
+                try:
+                    self._ensure_actor_folder_image(
+                        streamer_dir, streamer, safe_username
+                    )
+                except Exception as e_actor:
+                    logger.debug(
+                        f"Actor folder image step failed (non-fatal): {e_actor}"
+                    )
 
             ET.SubElement(actor, "role").text = "Streamer"
 
@@ -786,11 +926,12 @@ class MetadataService:
             # Streamer as "actor"
             actor = ET.SubElement(episode_root, "actor")
             ET.SubElement(actor, "name").text = streamer.username
-            if streamer.profile_image_url:
-                # Actor image from .media directory
-                ET.SubElement(
-                    actor, "thumb"
-                ).text = f".media/artwork/{safe_username}/poster.jpg"
+            if streamer.profile_image_url or streamer.original_profile_image_url:
+                actor_thumb = self._pick_actor_thumb_url(
+                    streamer, streamer_dir, safe_username
+                )
+                if actor_thumb:
+                    ET.SubElement(actor, "thumb").text = actor_thumb
             ET.SubElement(actor, "role").text = "Streamer"
 
             # IMPORTANT: Thumbnails for the episode with different standard names

--- a/app/services/streamer_service.py
+++ b/app/services/streamer_service.py
@@ -246,14 +246,19 @@ class StreamerService:
                     )
 
             # Update streamer in database
-            self.repository.update_streamer(
-                streamer,
-                username=user_data.get("display_name", streamer.username),
-                profile_image_url=user_data.get(
+            update_fields = {
+                "username": user_data.get("display_name", streamer.username),
+                "profile_image_url": user_data.get(
                     "cached_profile_image", user_data.get("profile_image_url")
                 ),
-                original_profile_image_url=user_data.get("profile_image_url"),
-            )
+                "original_profile_image_url": user_data.get("profile_image_url"),
+            }
+            # Only update description if Twitch returned a non-empty value
+            twitch_description = user_data.get("description")
+            if twitch_description:
+                update_fields["description"] = twitch_description
+
+            self.repository.update_streamer(streamer, **update_fields)
 
             return True
 

--- a/app/services/streamers/streamer_repository.py
+++ b/app/services/streamers/streamer_repository.py
@@ -173,6 +173,7 @@ class StreamerRepository:
                 original_offline_image_url=user_data.get(
                     "offline_image_url"
                 ),  # NEW: Original Twitch banner URL
+                description=user_data.get("description") or None,
                 is_live=is_live,
                 title=current_title,
                 category_name=current_category,

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+"""Top-level conftest that makes the repository root importable.
+
+This ensures ``from app.xxx import ...`` works in tests regardless of how
+pytest is invoked (``pytest`` vs ``python -m pytest``) and independent of
+pytest's import-mode / rootdir heuristics.
+"""
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))

--- a/migrations/036_add_streamer_description.py
+++ b/migrations/036_add_streamer_description.py
@@ -1,0 +1,79 @@
+"""
+Migration 036: Add Streamer Description (Twitch Bio)
+
+Adds a `description` column to the streamers table which stores the streamer's
+Twitch "About" / bio text. This is used in NFO files (tvshow.nfo <plot>) so that
+Plex/Emby/Jellyfin show the real channel description instead of a generic
+"Streams by X on Twitch." placeholder.
+
+The Twitch Helix /users endpoint already returns this field as `description`;
+we simply persist it for NFO generation and frontend display.
+"""
+
+import logging
+from sqlalchemy import text
+from app.database import SessionLocal
+
+logger = logging.getLogger("streamvault")
+
+
+def run_migration():
+    """Add description column to streamers table (idempotent)."""
+
+    with SessionLocal() as session:
+        try:
+            logger.info("🔄 Running Migration 036: Add Streamer Description")
+
+            check_result = session.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_name = 'streamers'
+                      AND column_name = 'description'
+                    """
+                )
+            ).fetchone()
+
+            if check_result:
+                logger.info("✅ Column 'description' already exists, skipping")
+            else:
+                session.execute(
+                    text(
+                        """
+                        ALTER TABLE streamers
+                        ADD COLUMN description TEXT
+                        """
+                    )
+                )
+                logger.info("✅ Added 'description' column to streamers table")
+
+            session.commit()
+            logger.info("✅ Migration 036 completed successfully")
+
+        except Exception as e:
+            session.rollback()
+            logger.error(f"❌ Migration 036 failed: {e}")
+            raise
+
+
+def rollback_migration():
+    """Rollback migration 036"""
+    with SessionLocal() as session:
+        try:
+            logger.info("🔄 Rolling back Migration 036")
+            session.execute(
+                text(
+                    """
+                    ALTER TABLE streamers
+                    DROP COLUMN IF EXISTS description
+                    """
+                )
+            )
+            session.commit()
+            logger.info("✅ Migration 036 rollback completed")
+
+        except Exception as e:
+            session.rollback()
+            logger.error(f"❌ Migration 036 rollback failed: {e}")
+            raise

--- a/tests/test_metadata_nfo.py
+++ b/tests/test_metadata_nfo.py
@@ -1,0 +1,178 @@
+"""Tests for NFO metadata generation helpers in metadata_service.
+
+Covers:
+- Series plot prefers streamer bio, falls back to placeholder.
+- Actor thumb prefers HTTPS URL over local relative path.
+- Historical categories are collected, de-duplicated and ordered.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.media.metadata_service import MetadataService
+
+
+@pytest.fixture()
+def service() -> MetadataService:
+    return MetadataService()
+
+
+# ---------------------------------------------------------------------------
+# _series_plot_text
+# ---------------------------------------------------------------------------
+
+def test_series_plot_uses_streamer_bio(service: MetadataService) -> None:
+    streamer = SimpleNamespace(
+        username="gronkh",
+        description="Streams by GRONKH – Let's Plays, Talks und mehr.",
+    )
+    assert (
+        service._series_plot_text(streamer)
+        == "Streams by GRONKH – Let's Plays, Talks und mehr."
+    )
+
+
+def test_series_plot_falls_back_when_bio_empty(service: MetadataService) -> None:
+    streamer = SimpleNamespace(username="gronkh", description="")
+    assert service._series_plot_text(streamer) == "Streams by gronkh on Twitch."
+
+
+def test_series_plot_falls_back_when_bio_missing(service: MetadataService) -> None:
+    streamer = SimpleNamespace(username="gronkh")  # no description attribute
+    assert service._series_plot_text(streamer) == "Streams by gronkh on Twitch."
+
+
+def test_series_plot_strips_whitespace(service: MetadataService) -> None:
+    streamer = SimpleNamespace(username="g", description="   \n\t   ")
+    assert service._series_plot_text(streamer) == "Streams by g on Twitch."
+
+
+# ---------------------------------------------------------------------------
+# _pick_actor_thumb_url
+# ---------------------------------------------------------------------------
+
+def test_actor_thumb_prefers_original_https_url(service: MetadataService, tmp_path: Path) -> None:
+    streamer = SimpleNamespace(
+        username="gronkh",
+        profile_image_url="/recordings/.media/profiles/profile_avatar_1.jpg",
+        original_profile_image_url="https://static-cdn.jtvnw.net/jtv_user_pictures/abc-300x300.png",
+    )
+    result = service._pick_actor_thumb_url(streamer, tmp_path, "gronkh")
+    assert result == "https://static-cdn.jtvnw.net/jtv_user_pictures/abc-300x300.png"
+
+
+def test_actor_thumb_uses_profile_image_url_when_http(
+    service: MetadataService, tmp_path: Path
+) -> None:
+    streamer = SimpleNamespace(
+        username="gronkh",
+        profile_image_url="https://example.com/avatar.jpg",
+        original_profile_image_url=None,
+    )
+    result = service._pick_actor_thumb_url(streamer, tmp_path, "gronkh")
+    assert result == "https://example.com/avatar.jpg"
+
+
+def test_actor_thumb_falls_back_to_relative_path(
+    service: MetadataService, tmp_path: Path
+) -> None:
+    streamer = SimpleNamespace(
+        username="gronkh",
+        # Both point to a local cached file (not an http URL)
+        profile_image_url="/recordings/.media/profiles/profile_avatar_1.jpg",
+        original_profile_image_url="/recordings/.media/profiles/profile_avatar_1.jpg",
+    )
+    result = service._pick_actor_thumb_url(streamer, tmp_path, "gronkh")
+    # Should return a relative path that ends with the cached poster filename
+    assert result is not None
+    assert result.endswith(".media/artwork/gronkh/poster.jpg")
+
+
+# ---------------------------------------------------------------------------
+# _collect_streamer_genres
+# ---------------------------------------------------------------------------
+
+def _build_mock_db(category_rows: list[tuple]) -> MagicMock:
+    """Build a MagicMock Session that returns ``category_rows`` for the category query."""
+    db = MagicMock()
+    query = db.query.return_value
+    query.filter.return_value = query
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.all.return_value = category_rows
+    return db
+
+
+def test_collect_genres_from_streams(service: MetadataService) -> None:
+    db = _build_mock_db([("Minecraft",), ("World of Warcraft",), ("Just Chatting",)])
+    streamer = SimpleNamespace(
+        id=1,
+        username="dhalucard",
+        category_name=None,
+        last_stream_category_name=None,
+    )
+    assert service._collect_streamer_genres(db, streamer) == [
+        "Minecraft",
+        "World of Warcraft",
+        "Just Chatting",
+    ]
+
+
+def test_collect_genres_deduplicates_case_insensitive(service: MetadataService) -> None:
+    db = _build_mock_db(
+        [("Minecraft",), ("minecraft",), ("  Minecraft  ",), ("Just Chatting",)]
+    )
+    streamer = SimpleNamespace(
+        id=1,
+        username="dhalucard",
+        category_name=None,
+        last_stream_category_name=None,
+    )
+    assert service._collect_streamer_genres(db, streamer) == [
+        "Minecraft",
+        "Just Chatting",
+    ]
+
+
+def test_collect_genres_includes_streamer_fallback_fields(service: MetadataService) -> None:
+    db = _build_mock_db([])  # no historical rows
+    streamer = SimpleNamespace(
+        id=1,
+        username="dhalucard",
+        category_name="Just Chatting",
+        last_stream_category_name="Minecraft",
+    )
+    assert service._collect_streamer_genres(db, streamer) == [
+        "Just Chatting",
+        "Minecraft",
+    ]
+
+
+def test_collect_genres_empty_when_nothing_known(service: MetadataService) -> None:
+    db = _build_mock_db([])
+    streamer = SimpleNamespace(
+        id=1,
+        username="dhalucard",
+        category_name=None,
+        last_stream_category_name=None,
+    )
+    assert service._collect_streamer_genres(db, streamer) == []
+
+
+def test_collect_genres_respects_limit(service: MetadataService) -> None:
+    many = [(f"Category {i}",) for i in range(30)]
+    db = _build_mock_db(many)
+    streamer = SimpleNamespace(
+        id=1,
+        username="x",
+        category_name=None,
+        last_stream_category_name=None,
+    )
+    result = service._collect_streamer_genres(db, streamer, limit=5)
+    assert len(result) == 5
+    assert result[0] == "Category 0"


### PR DESCRIPTION
- Add 'description' column to streamers (Migration 036) and persist the Twitch 'About' bio on streamer create, EventSub stream.online and periodic refresh.
- tvshow.nfo: use the streamer's Twitch bio as <plot> (falls back to the previous generic placeholder when the bio is empty).
- tvshow.nfo: emit one <genre> per unique historical stream category so Plex/Emby display the full range of games the streamer has played (deduplicated, capped at 20 most recent, with 'Livestream' fallback).
- Actor cast image: prefer the HTTPS Twitch CDN URL for <actor><thumb> in both tvshow.nfo and episode.nfo so Plex' new NFO scanner can resolve it reliably; fall back to the relative cached poster path when unavailable.
- Create local .Actors/<name>/folder.jpg next to tvshow.nfo as an offline fallback for Emby/Jellyfin.
- Tests: 12 new unit tests for the helpers (_series_plot_text, _pick_actor_thumb_url, _collect_streamer_genres).