### PR TITLE
feat(auth): API key authentication for external API access

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -328,6 +328,11 @@
         <rect x="5" y="2" width="14" height="20" rx="2" ry="2"/>
         <line x1="12" y1="18" x2="12.01" y2="18"/>
       </symbol>
+
+      <!-- Key (API Keys) -->
+      <symbol id="icon-key" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/>
+      </symbol>
       
       <!-- Repeat (Circular Arrows/Refresh All) -->
       <symbol id="icon-repeat" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/app/frontend/src/components/settings/ApiKeysPanel.vue
+++ b/app/frontend/src/components/settings/ApiKeysPanel.vue
@@ -1,0 +1,294 @@
+<template>
+  <div class="api-keys-panel">
+    <div class="panel-intro">
+      <p>
+        API keys provide programmatic access to StreamVault without an
+        interactive login. Send them as
+        <code>X-API-Key: sv_…</code> or
+        <code>Authorization: ApiKey sv_…</code>.
+      </p>
+      <p class="hint">
+        Public Twitch endpoints (<code>/eventsub</code>,
+        <code>/api/twitch/callback</code>) and the auth flow do not need a key.
+        Everything else can be reached either with a session cookie or with an
+        API key, e.g. <code>/api/status/recordings-active</code>.
+      </p>
+    </div>
+
+    <!-- Create form -->
+    <div class="create-row">
+      <input
+        v-model="newKeyName"
+        type="text"
+        placeholder="Key name (e.g. 'monitoring')"
+        class="key-name-input"
+        @keyup.enter="createKey"
+      />
+      <button
+        class="btn btn-primary"
+        :disabled="!newKeyName.trim() || creating"
+        @click="createKey"
+      >
+        {{ creating ? 'Creating…' : 'Create API Key' }}
+      </button>
+    </div>
+
+    <!-- Freshly created key (only shown once) -->
+    <div v-if="freshKey" class="fresh-key">
+      <div class="fresh-key-header">
+        <strong>New API key created – copy it now.</strong>
+        <button class="btn btn-sm" @click="freshKey = null">Dismiss</button>
+      </div>
+      <p class="fresh-key-warning">
+        This is the only time the full key is shown. If you lose it, revoke it
+        and create a new one.
+      </p>
+      <div class="fresh-key-row">
+        <code class="fresh-key-value">{{ freshKey.key }}</code>
+        <button class="btn btn-sm" @click="copyFresh">Copy</button>
+      </div>
+    </div>
+
+    <!-- Existing keys -->
+    <div v-if="loading" class="loading">Loading…</div>
+    <div v-else-if="keys.length === 0" class="empty">
+      No API keys yet.
+    </div>
+    <table v-else class="keys-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Prefix</th>
+          <th>Created</th>
+          <th>Last used</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="k in keys" :key="k.id">
+          <td>{{ k.name }}</td>
+          <td><code>{{ k.prefix }}…</code></td>
+          <td>{{ formatDate(k.created_at) }}</td>
+          <td>{{ k.last_used_at ? formatDate(k.last_used_at) : 'never' }}</td>
+          <td>
+            <button class="btn btn-sm btn-danger" @click="revokeKey(k)">
+              Revoke
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div v-if="error" class="error">{{ error }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface ApiKey {
+  id: number
+  name: string
+  prefix: string
+  created_at: string
+  last_used_at: string | null
+}
+
+interface ApiKeyCreated extends ApiKey {
+  key: string
+}
+
+const keys = ref<ApiKey[]>([])
+const loading = ref(false)
+const creating = ref(false)
+const newKeyName = ref('')
+const freshKey = ref<ApiKeyCreated | null>(null)
+const error = ref<string | null>(null)
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await fetch('/api/api-keys', { credentials: 'include' })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    keys.value = await res.json()
+  } catch (e: any) {
+    error.value = `Failed to load API keys: ${e.message}`
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createKey() {
+  const name = newKeyName.value.trim()
+  if (!name) return
+  creating.value = true
+  error.value = null
+  try {
+    const res = await fetch('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ name })
+    })
+    if (!res.ok) {
+      const txt = await res.text()
+      throw new Error(`HTTP ${res.status}: ${txt}`)
+    }
+    freshKey.value = await res.json()
+    newKeyName.value = ''
+    await load()
+  } catch (e: any) {
+    error.value = `Failed to create API key: ${e.message}`
+  } finally {
+    creating.value = false
+  }
+}
+
+async function revokeKey(k: ApiKey) {
+  if (!confirm(`Revoke API key "${k.name}"? Existing clients using it will stop working.`)) return
+  error.value = null
+  try {
+    const res = await fetch(`/api/api-keys/${k.id}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (!res.ok && res.status !== 204) {
+      throw new Error(`HTTP ${res.status}`)
+    }
+    await load()
+  } catch (e: any) {
+    error.value = `Failed to revoke key: ${e.message}`
+  }
+}
+
+function copyFresh() {
+  if (!freshKey.value) return
+  navigator.clipboard.writeText(freshKey.value.key).catch(() => {})
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.api-keys-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.panel-intro p {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+.panel-intro .hint {
+  opacity: 0.7;
+}
+.panel-intro code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+.create-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.key-name-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.3);
+  color: inherit;
+}
+.fresh-key {
+  border: 1px solid rgba(255, 200, 0, 0.4);
+  background: rgba(255, 200, 0, 0.08);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+.fresh-key-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.4rem;
+}
+.fresh-key-warning {
+  font-size: 0.85rem;
+  opacity: 0.8;
+  margin: 0 0 0.5rem 0;
+}
+.fresh-key-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.fresh-key-value {
+  flex: 1;
+  font-family: monospace;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  word-break: break-all;
+}
+.keys-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+.keys-table th,
+.keys-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.keys-table th {
+  font-weight: 600;
+  opacity: 0.8;
+}
+.empty,
+.loading {
+  opacity: 0.6;
+  font-style: italic;
+}
+.error {
+  color: #ff6b6b;
+  font-size: 0.9rem;
+}
+.btn {
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  cursor: pointer;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: #6366f1;
+  border-color: #6366f1;
+  color: white;
+}
+.btn-danger {
+  background: rgba(255, 80, 80, 0.15);
+  border-color: rgba(255, 80, 80, 0.4);
+  color: #ff8a8a;
+}
+.btn-sm {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+}
+</style>

--- a/app/frontend/src/views/SettingsView.vue
+++ b/app/frontend/src/views/SettingsView.vue
@@ -215,6 +215,25 @@
           </GlassCard>
         </div>
 
+        <!-- API Keys -->
+        <div v-if="activeSection === 'api-keys'" class="settings-section">
+          <div class="section-header">
+            <h2 class="section-title">
+              <svg class="section-icon">
+                <use href="#icon-key" />
+              </svg>
+              API Keys
+            </h2>
+            <p class="section-description">
+              Manage long-lived tokens for external clients (monitoring, scripts, dashboards).
+            </p>
+          </div>
+
+          <GlassCard variant="strong" padding="lg">
+            <ApiKeysPanel />
+          </GlassCard>
+        </div>
+
         <!-- About Settings -->
         <div v-if="activeSection === 'about'" class="settings-section">
           <div class="section-header">
@@ -310,6 +329,7 @@ import ProxySettingsPanel from '@/components/settings/ProxySettingsPanel.vue'
 import FavoritesSettingsPanel from '@/components/settings/FavoritesSettingsPanel.vue'
 import PWAPanel from '@/components/settings/PWAPanel.vue'
 import TwitchConnectionPanel from '@/components/settings/TwitchConnectionPanel.vue'
+import ApiKeysPanel from '@/components/settings/ApiKeysPanel.vue'
 import type { NotificationSettings, StreamerNotificationSettings } from '@/types/settings'
 import type { RecordingSettings } from '@/types/recording'
 
@@ -350,6 +370,12 @@ const sections = [
     label: 'PWA & Mobile',
     description: 'Mobile app settings',
     icon: 'smartphone'
+  },
+  {
+    id: 'api-keys',
+    label: 'API Keys',
+    description: 'External access tokens',
+    icon: 'key'
   },
   {
     id: 'about',

--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -76,7 +76,7 @@ export default defineConfig({
         // PERFORMANCE OPTIMIZATION
         rollupOptions: {
             output: {
-                manualChunks: function (id) {
+                manualChunks(id) {
                     // Split vendor libraries for better caching
                     if (id.includes('node_modules/vue/') || id.includes('node_modules/vue-router/')) {
                         return 'vue-vendor';

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.routes import push as push_router
 from app.routes import admin as admin_router
 from app.routes import migration as migration_router
 from app.routes import version as version_router
+from app.routes import api_keys as api_keys_router
 from app.api import unified_recovery_endpoints
 from app.api import automated_recovery_endpoints
 from app.services.system.development_test_runner import run_development_tests
@@ -1041,6 +1042,9 @@ app.include_router(migration_router.router)
 
 # Version routes
 app.include_router(version_router.router, prefix="/api")
+
+# API key management routes (session-protected, never API-key-protected)
+app.include_router(api_keys_router.router)
 
 # Explicit SPA routes - these must come after API routes but before static files
 

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -1,6 +1,7 @@
 from fastapi import Request
 from fastapi.responses import RedirectResponse, JSONResponse
 from app.services.core.auth_service import AuthService
+from app.services.core.api_key_service import ApiKeyService
 from app.database import SessionLocal
 import logging
 
@@ -19,6 +20,35 @@ def _extract_bearer_token(headers: list) -> str | None:
             value = header_value.decode("utf-8", errors="ignore")
             if value.startswith("Bearer "):
                 return value[7:]  # Strip "Bearer " prefix
+    return None
+
+
+def _extract_api_key(request_or_headers) -> str | None:
+    """Extract a long-lived API key from the request.
+
+    Accepts either:
+      - X-API-Key: sv_<token>
+      - Authorization: ApiKey sv_<token>
+
+    Cookies/Bearer session tokens are handled separately and take precedence.
+    """
+    # Accept both a Request object and the raw scope headers list
+    if isinstance(request_or_headers, list):
+        for header_name, header_value in request_or_headers:
+            name = header_name.decode("ascii", errors="ignore").lower()
+            value = header_value.decode("utf-8", errors="ignore")
+            if name == "x-api-key" and value:
+                return value.strip()
+            if name == "authorization" and value.startswith("ApiKey "):
+                return value[7:].strip()
+        return None
+
+    api_key = request_or_headers.headers.get("x-api-key")
+    if api_key:
+        return api_key.strip()
+    auth = request_or_headers.headers.get("authorization", "")
+    if auth.startswith("ApiKey "):
+        return auth[7:].strip()
     return None
 
 
@@ -135,6 +165,34 @@ class AuthMiddleware:
                 auth_header = request.headers.get("authorization", "")
                 if auth_header.startswith("Bearer "):
                     session_token = auth_header[7:]
+
+            # API-key fallback (X-API-Key or "Authorization: ApiKey <token>").
+            # Sessions/cookies always take precedence. The /api/api-keys
+            # management endpoints intentionally REJECT API-key auth — those
+            # routes re-validate that an interactive session exists, so a
+            # stolen key cannot be used to mint or revoke more keys.
+            if not session_token:
+                api_key = _extract_api_key(request)
+                if api_key:
+                    # SECURITY: Never allow API-key auth on the management
+                    # endpoints — minting/revoking keys must require an
+                    # interactive session.
+                    if request.url.path.startswith("/api/api-keys"):
+                        logger.warning(
+                            f"Blocked API-key auth attempt on management endpoint {request.url.path}"
+                        )
+                    else:
+                        api_key_service = ApiKeyService(db=db)
+                        record = api_key_service.validate(api_key)
+                        if record:
+                            logger.debug(
+                                f"Authenticated via API key id={record.id} for {request.url.path}"
+                            )
+                            return await self.app(scope, receive, send)
+                        else:
+                            logger.warning(
+                                f"Rejected invalid API key for {request.url.path}"
+                            )
 
             if not session_token:
                 logger.debug(

--- a/app/models.py
+++ b/app/models.py
@@ -247,6 +247,31 @@ class Session(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
+class ApiKey(Base):
+    """Long-lived API key for programmatic access without an interactive session.
+
+    Key value is generated server-side, returned to the user ONCE on creation,
+    and only the SHA-256 hash is persisted. Keys are scoped to the user that
+    created them and can be revoked at any time. Used for monitoring/automation
+    that needs to call StreamVault endpoints (e.g. /api/status/recordings-active)
+    without performing an interactive login.
+    """
+
+    __tablename__ = "api_keys"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name = Column(String, nullable=False)
+    key_hash = Column(String, unique=True, nullable=False, index=True)
+    key_prefix = Column(String(12), nullable=False)  # First chars of raw key for UI
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+
 class NotificationSettings(Base):
     __tablename__ = "notification_settings"
     __table_args__ = {"extend_existing": True}

--- a/app/routes/api_keys.py
+++ b/app/routes/api_keys.py
@@ -1,0 +1,104 @@
+"""API key management routes.
+
+These endpoints manage API keys themselves and therefore REQUIRE an interactive
+session (cookie or Bearer). API key holders cannot manage their own keys —
+revoke/rotate must happen from the web UI.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from app.database import SessionLocal
+from app.models import User
+from app.schemas.api_key import ApiKeyCreate, ApiKeyCreated, ApiKeyResponse
+from app.services.core.api_key_service import ApiKeyService
+from app.services.core.auth_service import AuthService
+
+logger = logging.getLogger("streamvault")
+
+router = APIRouter(prefix="/api/api-keys", tags=["api-keys"])
+
+
+def _resolve_session_user(request: Request) -> User:
+    """Resolve the User behind the current cookie/Bearer session.
+
+    The global AuthMiddleware has already validated that *some* form of auth is
+    present; here we still re-resolve the User because the middleware doesn't
+    expose it on the request. We intentionally REJECT API-key auth for these
+    endpoints to prevent a stolen key from being used to mint more keys.
+    """
+    session_token = request.cookies.get("session")
+    if not session_token:
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.startswith("Bearer "):
+            session_token = auth_header[7:]
+
+    if not session_token:
+        raise HTTPException(
+            status_code=401,
+            detail="Interactive session required to manage API keys",
+        )
+
+    import hashlib
+    from app.models import Session as DbSession
+
+    token_hash = hashlib.sha256(session_token.encode("utf-8")).hexdigest()
+
+    with SessionLocal() as db:
+        sess = db.query(DbSession).filter(DbSession.token == token_hash).first()
+        if not sess:
+            raise HTTPException(
+                status_code=401,
+                detail="Interactive session required to manage API keys",
+            )
+        user = db.query(User).filter(User.id == sess.user_id).first()
+        if not user:
+            raise HTTPException(status_code=401, detail="User not found")
+        # Detach so the caller can use it after the session closes
+        db.expunge(user)
+        return user
+
+
+@router.get("", response_model=List[ApiKeyResponse])
+async def list_api_keys(request: Request):
+    """List the current user's API keys (hashes/secrets are never returned)."""
+    user = _resolve_session_user(request)
+    with SessionLocal() as db:
+        service = ApiKeyService(db)
+        records = service.list_for_user(user.id)
+        return [ApiKeyResponse.model_validate(r) for r in records]
+
+
+@router.post("", response_model=ApiKeyCreated, status_code=201)
+async def create_api_key(payload: ApiKeyCreate, request: Request):
+    """Create a new API key for the current user.
+
+    The raw key value is included in the response and CANNOT be retrieved later.
+    """
+    user = _resolve_session_user(request)
+    with SessionLocal() as db:
+        service = ApiKeyService(db)
+        record, raw_key = service.create(user.id, payload.name)
+        return ApiKeyCreated(
+            id=record.id,
+            name=record.name,
+            key_prefix=record.key_prefix,
+            created_at=record.created_at,
+            last_used_at=record.last_used_at,
+            revoked_at=record.revoked_at,
+            key=raw_key,
+        )
+
+
+@router.delete("/{key_id}", status_code=204)
+async def revoke_api_key(key_id: int, request: Request):
+    """Revoke (soft-delete) one of the current user's API keys."""
+    user = _resolve_session_user(request)
+    with SessionLocal() as db:
+        service = ApiKeyService(db)
+        ok = service.revoke(key_id, user_id=user.id)
+        if not ok:
+            raise HTTPException(status_code=404, detail="API key not found or already revoked")
+    return None

--- a/app/routes/api_keys.py
+++ b/app/routes/api_keys.py
@@ -8,13 +8,12 @@ revoke/rotate must happen from the web UI.
 import logging
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 
 from app.database import SessionLocal
 from app.models import User
 from app.schemas.api_key import ApiKeyCreate, ApiKeyCreated, ApiKeyResponse
 from app.services.core.api_key_service import ApiKeyService
-from app.services.core.auth_service import AuthService
 
 logger = logging.getLogger("streamvault")
 
@@ -100,5 +99,7 @@ async def revoke_api_key(key_id: int, request: Request):
         service = ApiKeyService(db)
         ok = service.revoke(key_id, user_id=user.id)
         if not ok:
-            raise HTTPException(status_code=404, detail="API key not found or already revoked")
+            raise HTTPException(
+                status_code=404, detail="API key not found or already revoked"
+            )
     return None

--- a/app/schemas/api_key.py
+++ b/app/schemas/api_key.py
@@ -5,7 +5,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ApiKeyCreate(BaseModel):
-    name: str = Field(..., min_length=1, max_length=100, description="Human readable label")
+    name: str = Field(
+        ..., min_length=1, max_length=100, description="Human readable label"
+    )
 
 
 class ApiKeyResponse(BaseModel):
@@ -24,7 +26,9 @@ class ApiKeyResponse(BaseModel):
 class ApiKeyCreated(ApiKeyResponse):
     """Returned exactly ONCE on creation. Includes the raw key value."""
 
-    key: str = Field(..., description="Raw API key value. Store securely; not retrievable later.")
+    key: str = Field(
+        ..., description="Raw API key value. Store securely; not retrievable later."
+    )
 
 
 class ApiKeyList(BaseModel):

--- a/app/schemas/api_key.py
+++ b/app/schemas/api_key.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional, List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ApiKeyCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100, description="Human readable label")
+
+
+class ApiKeyResponse(BaseModel):
+    """Public representation of an API key (never includes the raw secret)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    key_prefix: str
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+    revoked_at: Optional[datetime] = None
+
+
+class ApiKeyCreated(ApiKeyResponse):
+    """Returned exactly ONCE on creation. Includes the raw key value."""
+
+    key: str = Field(..., description="Raw API key value. Store securely; not retrievable later.")
+
+
+class ApiKeyList(BaseModel):
+    keys: List[ApiKeyResponse]

--- a/app/services/core/api_key_service.py
+++ b/app/services/core/api_key_service.py
@@ -1,0 +1,121 @@
+"""API key service.
+
+Manages long-lived programmatic access tokens. Raw key values are returned to
+the user exactly once at creation and never stored; only the SHA-256 hash is
+persisted (mirrors the session token strategy in AuthService).
+"""
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.models import ApiKey, User
+
+logger = logging.getLogger("streamvault")
+
+# Raw API key format: "sv_<43-char urlsafe random>" — distinguishable prefix
+# avoids confusion with session cookies / Twitch tokens in logs and config.
+_KEY_PREFIX = "sv_"
+_KEY_RANDOM_BYTES = 32  # token_urlsafe(32) -> 43 chars
+_PREFIX_DISPLAY_LEN = 10  # Number of chars stored for UI display (e.g. "sv_abcdef…")
+
+
+def hash_api_key(raw_key: str) -> str:
+    """SECURITY: SHA-256 the raw key before DB lookup/storage (CWE-312)."""
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+class ApiKeyService:
+    def __init__(self, db: DBSession):
+        self.db = db
+
+    @staticmethod
+    def generate_key() -> str:
+        """Generate a new raw API key value."""
+        return f"{_KEY_PREFIX}{secrets.token_urlsafe(_KEY_RANDOM_BYTES)}"
+
+    def create(self, user_id: int, name: str) -> tuple[ApiKey, str]:
+        """Create and persist a new API key. Returns (record, raw_key)."""
+        raw_key = self.generate_key()
+        record = ApiKey(
+            user_id=user_id,
+            name=name.strip(),
+            key_hash=hash_api_key(raw_key),
+            key_prefix=raw_key[:_PREFIX_DISPLAY_LEN],
+        )
+        self.db.add(record)
+        self.db.commit()
+        self.db.refresh(record)
+        logger.info(
+            f"API key created (id={record.id}, name={record.name!r}, user_id={user_id})"
+        )
+        return record, raw_key
+
+    def list_for_user(self, user_id: int) -> List[ApiKey]:
+        return (
+            self.db.query(ApiKey)
+            .filter(ApiKey.user_id == user_id)
+            .order_by(ApiKey.created_at.desc())
+            .all()
+        )
+
+    def list_all(self) -> List[ApiKey]:
+        return self.db.query(ApiKey).order_by(ApiKey.created_at.desc()).all()
+
+    def revoke(self, key_id: int, user_id: Optional[int] = None) -> bool:
+        """Revoke a key. If user_id is given, scope to that user.
+
+        Returns True if a record was revoked, False if not found / already revoked.
+        """
+        q = self.db.query(ApiKey).filter(ApiKey.id == key_id)
+        if user_id is not None:
+            q = q.filter(ApiKey.user_id == user_id)
+        record = q.first()
+        if not record:
+            return False
+        if record.revoked_at is not None:
+            return False
+        record.revoked_at = datetime.now(timezone.utc)
+        self.db.add(record)
+        self.db.commit()
+        logger.info(f"API key revoked (id={record.id}, name={record.name!r})")
+        return True
+
+    def validate(self, raw_key: str) -> Optional[ApiKey]:
+        """Validate a raw API key. Returns the active ApiKey record or None.
+
+        Touches `last_used_at` on success. Validation is constant-time-safe
+        because the lookup is by SHA-256 hash (no string comparison on secret).
+        """
+        if not raw_key or not raw_key.startswith(_KEY_PREFIX):
+            return None
+        try:
+            record = (
+                self.db.query(ApiKey)
+                .filter(ApiKey.key_hash == hash_api_key(raw_key))
+                .first()
+            )
+            if not record or record.revoked_at is not None:
+                return None
+            # Best-effort touch; failure must not block the request.
+            try:
+                record.last_used_at = datetime.now(timezone.utc)
+                self.db.add(record)
+                self.db.commit()
+            except Exception as touch_err:
+                logger.debug(f"Could not update last_used_at: {touch_err}")
+                self.db.rollback()
+            return record
+        except Exception as e:
+            logger.error(f"Error validating API key: {e}")
+            return None
+
+    def get_user_for_key(self, raw_key: str) -> Optional[User]:
+        record = self.validate(raw_key)
+        if not record:
+            return None
+        return self.db.query(User).filter(User.id == record.user_id).first()

--- a/migrations/037_add_api_keys.py
+++ b/migrations/037_add_api_keys.py
@@ -1,0 +1,85 @@
+"""
+Migration 037: Add API Keys table
+
+Creates the `api_keys` table that stores long-lived programmatic access tokens.
+The raw key is shown to the user exactly once at creation; only a SHA-256 hash
+is persisted. API keys allow external monitoring tooling to call StreamVault
+endpoints (e.g. /api/status/recordings-active) without an interactive login.
+
+Idempotent: safe to run multiple times.
+"""
+
+import logging
+from sqlalchemy import text
+from app.database import SessionLocal
+
+logger = logging.getLogger("streamvault")
+
+
+def run_migration():
+    """Create api_keys table (PostgreSQL)."""
+
+    with SessionLocal() as session:
+        try:
+            logger.info("🔄 Running Migration 037: Add API Keys")
+
+            exists = session.execute(
+                text(
+                    """
+                    SELECT to_regclass('public.api_keys') AS reg
+                    """
+                )
+            ).fetchone()
+
+            if exists and exists[0]:
+                logger.info("✅ Table 'api_keys' already exists, skipping create")
+            else:
+                session.execute(
+                    text(
+                        """
+                        CREATE TABLE api_keys (
+                            id SERIAL PRIMARY KEY,
+                            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                            name VARCHAR NOT NULL,
+                            key_hash VARCHAR NOT NULL UNIQUE,
+                            key_prefix VARCHAR(12) NOT NULL,
+                            created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+                            last_used_at TIMESTAMP WITH TIME ZONE,
+                            revoked_at TIMESTAMP WITH TIME ZONE
+                        )
+                        """
+                    )
+                )
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_api_keys_user_id ON api_keys (user_id)"
+                    )
+                )
+                session.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_api_keys_key_hash ON api_keys (key_hash)"
+                    )
+                )
+                logger.info("✅ Created 'api_keys' table")
+
+            session.commit()
+            logger.info("✅ Migration 037 completed successfully")
+
+        except Exception as e:
+            session.rollback()
+            logger.error(f"❌ Migration 037 failed: {e}")
+            raise
+
+
+def rollback_migration():
+    """Rollback migration 037"""
+    with SessionLocal() as session:
+        try:
+            logger.info("🔄 Rolling back Migration 037")
+            session.execute(text("DROP TABLE IF EXISTS api_keys CASCADE"))
+            session.commit()
+            logger.info("✅ Migration 037 rollback completed")
+        except Exception as e:
+            session.rollback()
+            logger.error(f"❌ Migration 037 rollback failed: {e}")
+            raise


### PR DESCRIPTION
## Summary

Adds API key authentication so external clients (monitoring, automation, dashboards) can call StreamVault's API without an interactive browser session. Endpoints like `/api/status/recordings-active` are now reachable with a token; only the genuinely public surface (Twitch EventSub callbacks, health checks, login flow) remains unauthenticated.

## Why

Until now every protected endpoint required a cookie session, which made it impossible to script status checks (e.g. "is a recording running right now?") from outside the browser. This adds a second auth path alongside the existing session/cookie auth.

## How it works

- New `ApiKey` model + migration `037_add_api_keys.py` (table `api_keys`, FK to users, soft-delete via `revoked_at`).
- Keys have the format `sv_<43 url-safe chars>` (`secrets.token_urlsafe(32)` + prefix). Only the SHA-256 hash is stored; the raw key is shown **once** at creation and never again.
- `AuthMiddleware` accepts the key via either header:
  - `X-API-Key: sv_…`
  - `Authorization: ApiKey sv_…`
  Sessions/cookies still take precedence; the API key is a fallback.
- Management endpoints under `/api/api-keys` (list / create / revoke) **require an interactive session** — a stolen API key cannot be used to mint more keys (defense in depth).
- Frontend: new `ApiKeysPanel.vue` in Settings with a "key" tab — create named keys, see the one-time raw value, revoke existing ones. Lucide-style key icon added to `App.vue`.

## Files

**New**
- `migrations/037_add_api_keys.py`
- `app/schemas/api_key.py`
- `app/services/core/api_key_service.py`
- `app/routes/api_keys.py`
- `app/frontend/src/components/settings/ApiKeysPanel.vue`

**Modified**
- `app/models.py` — `ApiKey` model
- `app/middleware/auth.py` — API key extraction + validation, `/api/api-keys` excluded from API-key auth
- `app/main.py` — register router
- `app/frontend/src/App.vue` — `icon-key` SVG symbol
- `app/frontend/src/views/SettingsView.vue` — new tab + section

## Usage

```bash
# Issue a key from the Settings → API Keys panel, then:
curl -H "X-API-Key: sv_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
     https://your-streamvault/api/status/recordings-active
```

## Security notes

- Only SHA-256 hashes stored (CWE-312 mitigated).
- Raw key returned exactly once at creation.
- Soft-revoke via `revoked_at`; revoked keys fail validation immediately.
- API-key holders cannot manage keys (no privilege escalation from a leaked key).
- Sessions/cookies retain priority over API key auth.

## Migration

`037_add_api_keys.py` runs automatically on app start via the existing migration auto-discovery — no manual step required.

## Tests / CI

All local CI gates green:
- `ruff check` ✅
- `ruff format --check` ✅
- `pytest tests/` ✅ 78/78
- `python -m app.migrations_init` ✅
- `eslint . --fix` ✅ (Node 24)
- `vue-tsc --build` ✅
- `vite build` ✅
- `bandit -ll` ✅ (no new findings)

mypy shows the same pre-existing SQLAlchemy `Column[T]` pattern as the rest of the codebase (CI runs with `|| true`).
