### PR TITLE
fix(dashboard): prevent descender clipping and title truncation on live streamer cards

### DIFF
--- a/app/frontend/src/components/cards/StreamerCard.vue
+++ b/app/frontend/src/components/cards/StreamerCard.vue
@@ -376,8 +376,8 @@ onUnmounted(() => {
   // Card-specific overrides
   :deep(.glass-card-content) {
     padding: var(--spacing-4);
-    min-height: 200px;
-    max-height: 260px;
+    min-height: 220px;
+    max-height: 300px;  /* FIX: bumped from 260 so 3-line titles fit without clipping */
     overflow: visible;
     display: flex;
     flex-direction: column;
@@ -583,11 +583,14 @@ onUnmounted(() => {
   font-size: var(--text-base);  /* INCREASED: Better readability */
   font-weight: v.$font-medium;
   color: var(--text-primary);
-  line-height: 1.4;
+  line-height: 1.5;  /* FIX: bumped from 1.4 to give descenders (g, j, p, y) room */
   margin: 0;
   width: 100%;
-  
+
   /* CRITICAL: Max 3 lines for live title (more important than description) */
+  /* FIX: -webkit-line-clamp + overflow:hidden clips descenders on the last line.
+     Use padding-bottom + matching max-height so descenders are not cut off, and
+     keep ellipsis behaviour. */
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -595,7 +598,9 @@ onUnmounted(() => {
   line-clamp: 3;
   -webkit-box-orient: vertical;
   word-break: break-word;
-  
+  padding-bottom: 0.2em;  /* descender safe-area */
+  max-height: calc(1.5em * 3 + 0.2em);  /* 3 lines * line-height + descender pad */
+
   &.no-title {
     font-style: italic;
     opacity: 0.6;
@@ -616,10 +621,11 @@ onUnmounted(() => {
   font-size: var(--text-sm);
   font-weight: v.$font-medium;
   color: var(--text-secondary);
-  line-height: 1.4;
+  line-height: 1.5;  /* FIX: bumped to give descenders (g, j, p, y) room */
   margin: 0;
-  
+
   /* Max 2 lines for last stream title */
+  /* FIX: descender-safe clamp (see .stream-title comment) */
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -627,7 +633,8 @@ onUnmounted(() => {
   line-clamp: 2;
   -webkit-box-orient: vertical;
   word-break: break-word;
-  max-height: 2.8em;  /* 2 * 1.4 line-height */
+  padding-bottom: 0.2em;  /* descender safe-area */
+  max-height: calc(1.5em * 2 + 0.2em);  /* 2 lines * line-height + descender pad */
 }
 
 .last-stream-category {


### PR DESCRIPTION
## Summary

Fixes two related visual bugs on the live streamer cards on the home dashboard:

1. **Descender clipping** — the bottoms of letters with descenders (`g`, `j`, `p`, `y`, `q`) were being cut off on the last visible line of the stream title.
2. **Premature title truncation** — even though the title is supposed to clamp at 3 lines, on most cards it visibly clamped at 1–2 lines.

## Root cause

- `-webkit-line-clamp` combined with `overflow: hidden` and a tight `line-height: 1.4` removes pixel rows below the baseline of the last line, eating descenders. Classic WebKit/Blink quirk.
- `.streamer-card` enforced `max-height: 260px`, which after avatar (~96px) + stats (~40px) + padding leaves too little room for a real 3-line title, so the clamp kicked in earlier than configured.

## Fix

`app/frontend/src/components/cards/StreamerCard.vue`:

- `line-height` 1.4 → 1.5 on `.stream-title` and `.last-stream-title`.
- Added `padding-bottom: 0.2em` and an explicit `max-height: calc(line-height * lines + 0.2em)` to both — reserves a descender safe-area while keeping the ellipsis.
- `.streamer-card`: `min-height` 200 → 220, `max-height` 260 → 300 so the 3-line clamp actually has room.

## Verification

- `npm run lint` — clean (no new warnings)
- `npm run type-check` — clean
- `npm run build` — builds, `StreamerCard-*.js` chunk regenerated
- Visual: descenders no longer clipped, titles render up to 3 full lines before ellipsis
