### PR TITLE
feat(frontend): mobile touch hardening + tap-target compliance + useModal rollout

### DIFF
--- a/app/frontend/src/components/StreamList.vue
+++ b/app/frontend/src/components/StreamList.vue
@@ -380,7 +380,7 @@
     
     <!-- Delete Confirmation Modal -->
     <div v-if="showDeleteModal" class="modal-overlay" @click.self="cancelDelete">
-      <div class="modal">
+      <div class="modal" ref="deleteModalRef" role="dialog" aria-modal="true" tabindex="-1">
         <div class="modal-header">
           <h3>Delete Stream</h3>
           <button 
@@ -422,7 +422,7 @@
     
     <!-- Delete All Confirmation Modal -->
     <div v-if="showDeleteAllModal" class="modal-overlay" @click.self="cancelDeleteAll">
-      <div class="modal">
+      <div class="modal" ref="deleteAllModalRef" role="dialog" aria-modal="true" tabindex="-1">
         <div class="modal-header">
           <h3>Delete All Streams</h3>
           <button 
@@ -466,6 +466,7 @@ import { useStreams } from '@/composables/useStreams'
 import { useSystemAndRecordingStatus } from '@/composables/useSystemAndRecordingStatus'
 import { useCategoryImages } from '@/composables/useCategoryImages'
 import { useForceRecording } from '@/composables/useForceRecording'
+import { useModal } from '@/composables/useModal'
 import { recordingApi, streamsApi, streamersApi } from '@/services/api'
 import type { Stream } from '@/types/streams'
 
@@ -525,6 +526,14 @@ const showDeleteModal = ref(false)
 const showDeleteAllModal = ref(false)
 const streamToDelete = ref<ExtendedStream | null>(null)
 const stoppingRecordingStreamerId = ref<number | null>(null)
+
+// Modal refs + lifecycles (body-scroll-lock + ESC + focus-trap via useModal)
+const deleteModalRef = ref<HTMLElement | null>(null)
+const deleteAllModalRef = ref<HTMLElement | null>(null)
+const deleteModal = useModal(deleteModalRef, { onClose: () => { showDeleteModal.value = false } })
+const deleteAllModal = useModal(deleteAllModalRef, { onClose: () => { showDeleteAllModal.value = false } })
+watch(showDeleteModal, (v) => { if (v) deleteModal.open(); else deleteModal.close() })
+watch(showDeleteAllModal, (v) => { if (v) deleteAllModal.open(); else deleteAllModal.close() })
 
 // WebSocket State for real-time updates
 const localRecordingState = ref<Record<number, boolean>>({})

--- a/app/frontend/src/components/VideoModal.vue
+++ b/app/frontend/src/components/VideoModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="video-modal-overlay" @click="closeModal">
-    <div class="video-modal" @click.stop>
+    <div class="video-modal" ref="modalRef" role="dialog" aria-modal="true" tabindex="-1" @click.stop>
       <!-- Modal Header -->
       <div class="modal-header">
         <h2>{{ video.title || 'Video Player' }}</h2>
@@ -121,6 +121,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { streamersApi, videoApi } from '@/services/api'
 import { UI } from '@/config/constants'
+import { useModal } from '@/composables/useModal'
 
 const props = defineProps({
   video: {
@@ -131,6 +132,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close'])
 
+const modalRef = ref(null)
 const videoPlayer = ref(null)
 const loading = ref(true)
 const error = ref(false)
@@ -153,12 +155,17 @@ const videoUrl = computed(() => {
   return `/api/videos/${props.video.id}/stream`
 })
 
+const { open: openModal, close: closeModalLifecycle } = useModal(modalRef, {
+  onClose: () => emit('close'),
+  autoFocus: false, // video player should keep its own focus / autoplay flow
+})
+
 const closeModal = () => {
   if (videoPlayer.value) {
     videoPlayer.value.pause()
     videoPlayer.value.removeEventListener('timeupdate', updateCurrentChapter)
   }
-  emit('close')
+  closeModalLifecycle()
 }
 
 const onLoadStart = () => {
@@ -406,24 +413,17 @@ const updateCurrentChapter = () => {
   }
 }
 
-// Handle ESC key
-const handleKeydown = (event) => {
-  if (event.key === 'Escape') {
-    closeModal()
-  }
-}
+// Handle ESC key + body scroll lock + focus trap are managed by useModal()
 
 onMounted(() => {
-  document.addEventListener('keydown', handleKeydown)
-  document.body.style.overflow = 'hidden'
-  
+  openModal()
   // Load chapters for this stream
   loadChapters()
 })
 
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', handleKeydown)
-  document.body.style.overflow = ''
+  // ensure body scroll is released even if parent unmounts us without calling closeModal()
+  closeModalLifecycle()
 })
 </script>
 

--- a/app/frontend/src/components/VideoTabs.vue
+++ b/app/frontend/src/components/VideoTabs.vue
@@ -73,7 +73,9 @@
             <div
               v-for="video in sortedVideos"
               :key="video.id"
-              @click="selectVideo(video)"
+              @click="onVideoClick($event, video)"
+              @touchstart.passive="onVideoTouchStart"
+              @touchmove.passive="onVideoTouchMove"
               :class="['video-card', { active: currentVideo?.id === video.id }]"
             >
               <div class="video-thumbnail">
@@ -149,6 +151,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import VideoPlayer from './VideoPlayer.vue'
+import { useTouchClick } from '@/composables/useTouchClick'
 
 interface VideoData {
   id: string
@@ -274,6 +277,21 @@ const gameStats = computed(() => {
 const selectVideo = (video: VideoData) => {
   currentVideo.value = video
   activeTab.value = 'player'
+}
+
+// Scroll-aware tap handling: do not select when user is panning the list.
+let pendingVideo: VideoData | null = null
+const {
+  onClick: onVideoClickGuarded,
+  onTouchStart: onVideoTouchStart,
+  onTouchMove: onVideoTouchMove,
+} = useTouchClick<MouseEvent>(() => {
+  if (pendingVideo) selectVideo(pendingVideo)
+  pendingVideo = null
+})
+const onVideoClick = (event: MouseEvent, video: VideoData) => {
+  pendingVideo = video
+  onVideoClickGuarded(event)
 }
 
 const onChapterChange = (_chapter: any, _index: number) => {

--- a/app/frontend/src/components/cards/GlassCard.vue
+++ b/app/frontend/src/components/cards/GlassCard.vue
@@ -12,6 +12,8 @@
       }
     ]"
     @click="handleClick"
+    @touchstart.passive="onTouchStart"
+    @touchmove.passive="onTouchMove"
   >
     <!-- Gradient Border (optional) -->
     <div v-if="gradient" class="gradient-border" :style="gradientStyle" />
@@ -25,6 +27,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useTouchClick } from '@/composables/useTouchClick'
 
 export type GlassVariant = 'subtle' | 'medium' | 'strong'
 export type HoverEffect = 'lift' | 'scale' | 'none'
@@ -87,11 +90,13 @@ const contentPaddingClasses = computed(() => {
   return ['with-padding']
 })
 
-const handleClick = (event: MouseEvent) => {
-  if (props.clickable) {
-    emit('click', event)
+const { onClick: handleClick, onTouchStart, onTouchMove } = useTouchClick<MouseEvent>(
+  (event) => {
+    if (props.clickable) {
+      emit('click', event)
+    }
   }
-}
+)
 </script>
 
 <style scoped lang="scss">

--- a/app/frontend/src/composables/useModal.ts
+++ b/app/frontend/src/composables/useModal.ts
@@ -1,0 +1,157 @@
+/**
+ * useModal — uniform modal/dialog behaviour:
+ *  - body scroll lock while open (preserves scrollY, restores on close)
+ *  - ESC closes
+ *  - basic focus trap (TAB / SHIFT+TAB cycle within container)
+ *  - autofocus first focusable element when opened
+ *
+ * Multiple stacked modals are supported via a shared lock counter.
+ *
+ * Usage:
+ *   const dialogRef = ref<HTMLElement | null>(null)
+ *   const { open, close, isOpen } = useModal(dialogRef, { onClose: () => emit('close') })
+ *
+ *   <div ref="dialogRef" v-if="isOpen" role="dialog" aria-modal="true">...</div>
+ */
+import { ref, watch, onBeforeUnmount, type Ref } from 'vue'
+
+export interface UseModalOptions {
+  /** Called when the modal should close (ESC, programmatic close, etc.) */
+  onClose?: () => void
+  /** Disable the ESC-to-close handler. */
+  closeOnEscape?: boolean
+  /** Focus the first focusable element on open. */
+  autoFocus?: boolean
+}
+
+let lockCount = 0
+let savedScrollY = 0
+let savedBodyStyles: { overflow: string; position: string; top: string; width: string } | null = null
+
+function lockBody() {
+  lockCount += 1
+  if (lockCount > 1) return
+  savedScrollY = window.scrollY
+  savedBodyStyles = {
+    overflow: document.body.style.overflow,
+    position: document.body.style.position,
+    top: document.body.style.top,
+    width: document.body.style.width,
+  }
+  document.body.style.position = 'fixed'
+  document.body.style.top = `-${savedScrollY}px`
+  document.body.style.width = '100%'
+  document.body.style.overflow = 'hidden'
+}
+
+function unlockBody() {
+  lockCount = Math.max(0, lockCount - 1)
+  if (lockCount > 0) return
+  if (savedBodyStyles) {
+    document.body.style.overflow = savedBodyStyles.overflow
+    document.body.style.position = savedBodyStyles.position
+    document.body.style.top = savedBodyStyles.top
+    document.body.style.width = savedBodyStyles.width
+    savedBodyStyles = null
+  }
+  window.scrollTo(0, savedScrollY)
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((el) => !el.hasAttribute('disabled') && el.offsetParent !== null)
+}
+
+export function useModal(
+  containerRef: Ref<HTMLElement | null>,
+  options: UseModalOptions = {}
+) {
+  const { onClose, closeOnEscape = true, autoFocus = true } = options
+  const isOpen = ref(false)
+  let previouslyFocused: HTMLElement | null = null
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (!isOpen.value) return
+
+    if (event.key === 'Escape' && closeOnEscape) {
+      event.preventDefault()
+      close()
+      return
+    }
+
+    if (event.key === 'Tab' && containerRef.value) {
+      const focusable = getFocusable(containerRef.value)
+      if (focusable.length === 0) {
+        event.preventDefault()
+        return
+      }
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+
+      if (event.shiftKey) {
+        if (active === first || !containerRef.value.contains(active)) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else if (active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+  }
+
+  const open = () => {
+    if (isOpen.value) return
+    isOpen.value = true
+    previouslyFocused = document.activeElement as HTMLElement | null
+    lockBody()
+    document.addEventListener('keydown', handleKeydown)
+  }
+
+  const close = () => {
+    if (!isOpen.value) return
+    isOpen.value = false
+    document.removeEventListener('keydown', handleKeydown)
+    unlockBody()
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      previouslyFocused.focus()
+    }
+    previouslyFocused = null
+    onClose?.()
+  }
+
+  if (autoFocus) {
+    watch(
+      () => [isOpen.value, containerRef.value] as const,
+      ([open, el]) => {
+        if (!open || !el) return
+        // wait a tick so the v-if rendered children are in the DOM
+        requestAnimationFrame(() => {
+          const focusable = getFocusable(el)
+          if (focusable.length > 0) focusable[0].focus()
+          else el.focus?.()
+        })
+      },
+      { flush: 'post' }
+    )
+  }
+
+  onBeforeUnmount(() => {
+    if (isOpen.value) {
+      document.removeEventListener('keydown', handleKeydown)
+      unlockBody()
+    }
+  })
+
+  return { isOpen, open, close }
+}

--- a/app/frontend/src/composables/useTouchClick.ts
+++ b/app/frontend/src/composables/useTouchClick.ts
@@ -1,0 +1,77 @@
+/**
+ * useTouchClick — prevents accidental clicks on touch devices when the user
+ * is actually scrolling/swiping over a clickable element.
+ *
+ * Pattern extracted from StreamerCard.vue. Use on any clickable element that
+ * lives inside a scrollable list/container so a vertical/horizontal pan does
+ * not get interpreted as a tap.
+ *
+ * Usage:
+ *   const { onClick, touchHandlers } = useTouchClick(() => router.push(...))
+ *
+ *   <div :="touchHandlers" @click="onClick">...</div>
+ *
+ * The exposed touchHandlers map exists so a template can spread it via
+ * v-bind. Most templates will just wire each handler explicitly:
+ *
+ *   <div
+ *     @click="onClick"
+ *     @touchstart.passive="onTouchStart"
+ *     @touchmove.passive="onTouchMove"
+ *   />
+ */
+import { ref } from 'vue'
+
+export interface UseTouchClickOptions {
+  /** Pixels of pointer movement before a touch is treated as a scroll. */
+  threshold?: number
+}
+
+export function useTouchClick<E extends Event = MouseEvent>(
+  callback: (event: E) => void,
+  options: UseTouchClickOptions = {}
+) {
+  const threshold = options.threshold ?? 10
+
+  const isTouchScrolling = ref(false)
+  const startX = ref(0)
+  const startY = ref(0)
+
+  const onTouchStart = (event: TouchEvent) => {
+    const t = event.touches[0]
+    if (!t) return
+    startX.value = t.clientX
+    startY.value = t.clientY
+    isTouchScrolling.value = false
+  }
+
+  const onTouchMove = (event: TouchEvent) => {
+    const t = event.touches[0]
+    if (!t) return
+    const dx = Math.abs(t.clientX - startX.value)
+    const dy = Math.abs(t.clientY - startY.value)
+    if (dx > threshold || dy > threshold) {
+      isTouchScrolling.value = true
+    }
+  }
+
+  const onClick = (event: E) => {
+    if (isTouchScrolling.value) {
+      isTouchScrolling.value = false
+      return
+    }
+    callback(event)
+  }
+
+  return {
+    isTouchScrolling,
+    onTouchStart,
+    onTouchMove,
+    onClick,
+    /** Spread on the element for convenience. */
+    touchHandlers: {
+      onTouchstartPassive: onTouchStart,
+      onTouchmovePassive: onTouchMove,
+    },
+  }
+}

--- a/app/frontend/src/styles/_layout.scss
+++ b/app/frontend/src/styles/_layout.scss
@@ -5,12 +5,20 @@
 // Base layout structure with improved responsiveness
 .app {
   min-height: 100vh;
+  // Prefer the small viewport unit (svh) on mobile so the dynamic browser
+  // chrome (URL bar, home indicator) does not push the layout around.
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   width: 100%;
   max-width: 100vw;
   overflow-x: hidden;
   position: relative;
+
+  // PWA / notched devices: respect safe areas on the sides at the root,
+  // so child layouts inherit a predictable available width.
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
 }
 
 // Vue-inspired header with subtle gradient
@@ -24,6 +32,9 @@
   z-index: map.get(v.$z-layers, 'overlay');
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
   padding: v.$spacing-sm v.$spacing-md;
+  // PWA / notched devices: extend the header into the status-bar area
+  // so the gradient/blur reaches the top edge of the screen.
+  padding-top: calc(#{v.$spacing-sm} + env(safe-area-inset-top, 0px));
   width: 100%;
   box-sizing: border-box;
   backdrop-filter: none;

--- a/app/frontend/src/styles/main.scss
+++ b/app/frontend/src/styles/main.scss
@@ -23,6 +23,23 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+// Mobile/PWA: kill 300ms double-tap delay and accidental pinch-zoom
+// on interactive elements without breaking page-level scroll.
+button,
+a,
+[role="button"],
+input[type="button"],
+input[type="submit"],
+input[type="reset"],
+input[type="checkbox"],
+input[type="radio"],
+select,
+summary,
+.clickable,
+.glass-card-clickable {
+  touch-action: manipulation;
+}
+
 :root {
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   font-size: 16px;

--- a/app/frontend/src/views/StreamerDetailView.vue
+++ b/app/frontend/src/views/StreamerDetailView.vue
@@ -173,7 +173,7 @@
     <!-- Delete Confirmation Modal -->
     <Teleport to="body">
       <div v-if="showConfirm" class="modal-overlay" @click.self="showConfirm = false">
-        <div class="modal">
+        <div class="modal" ref="confirmModalRef" role="dialog" aria-modal="true" tabindex="-1">
           <div class="modal-header">
             <h3>Delete All Streams</h3>
             <button class="close-btn" @click="showConfirm = false" v-ripple>×</button>
@@ -207,7 +207,7 @@
     <!-- Settings Modal -->
     <Teleport to="body">
       <div v-if="showSettings" class="modal-overlay" @click.self="closeSettings">
-        <div class="modal settings-modal">
+        <div class="modal settings-modal" ref="settingsModalRef" role="dialog" aria-modal="true" tabindex="-1">
           <div class="modal-header">
             <h3>Settings for {{ streamer?.name || 'Streamer' }}</h3>
             <button class="close-btn" @click="closeSettings" v-ripple>×</button>
@@ -319,11 +319,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { streamersApi } from '@/services/api'
 import { useForceRecording } from '@/composables/useForceRecording'
 import { useToast } from '@/composables/useToast'
+import { useModal } from '@/composables/useModal'
 import LoadingSkeleton from '@/components/LoadingSkeleton.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import StatusCard from '@/components/cards/StatusCard.vue'
@@ -361,6 +362,14 @@ const { forceRecordingStreamerId, forceStartRecording } = useForceRecording()
 // Settings modal
 const showSettings = ref(false)
 const savingSettings = ref(false)
+
+// Modal lifecycles (body-scroll-lock + ESC + focus-trap)
+const confirmModalRef = ref<HTMLElement | null>(null)
+const settingsModalRef = ref<HTMLElement | null>(null)
+const confirmModal = useModal(confirmModalRef, { onClose: () => { showConfirm.value = false } })
+const settingsModal = useModal(settingsModalRef, { onClose: () => { showSettings.value = false } })
+watch(showConfirm, (v) => { if (v) confirmModal.open(); else confirmModal.close() })
+watch(showSettings, (v) => { if (v) settingsModal.open(); else settingsModal.close() })
 const streamerSettings = ref({
   quality: '',
   filenameTemplate: '',

--- a/app/frontend/src/views/StreamersView.vue
+++ b/app/frontend/src/views/StreamersView.vue
@@ -977,7 +977,7 @@ onUnmounted(() => {
     .filter-tab {
       flex: 1;
       justify-content: center;
-      min-height: 40px;  // Touch-friendly
+      min-height: 44px;  // WCAG 2.5.5 / Apple HIG touch-target
       padding: var(--spacing-2) var(--spacing-2);
       font-size: var(--text-xs);
       

--- a/app/frontend/src/views/VideoPlayerView.vue
+++ b/app/frontend/src/views/VideoPlayerView.vue
@@ -642,7 +642,7 @@ onMounted(() => {
   cursor: pointer;
   transition: all v.$duration-200 v.$ease-out;
   flex-shrink: 0;
-  min-height: 36px;
+  min-height: 44px;
 
   .icon {
     width: 16px;

--- a/app/frontend/src/views/VideosView.vue
+++ b/app/frontend/src/views/VideosView.vue
@@ -849,8 +849,8 @@ onMounted(() => {
   top: var(--spacing-2);
   left: var(--spacing-2);
   z-index: 10;
-  min-width: 28px;
-  min-height: 28px;
+  min-width: 44px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -878,8 +878,8 @@ onMounted(() => {
 
   // Mobile: Larger touch target
   @include m.respond-below('md') {  // < 768px
-    min-width: 36px;
-    min-height: 36px;
+    min-width: 44px;
+    min-height: 44px;
     
     input[type="checkbox"] {
       width: 20px;


### PR DESCRIPTION
Sprint 1 of frontend consistency audit. Mobile/PWA-first fixes for accidental selects on scroll, missing safe-area-insets, sub-44px tap targets, and inconsistent modal behaviour.

Composables (new):
- useTouchClick: 10px scroll-threshold guard to suppress click events triggered by touch scrolling
- useModal: shared body-scroll-lock counter (preserves scrollY), ESC handler, basic focus trap (Tab/Shift+Tab cycle), autofocus on open

Touch & layout:
- GlassCard wires useTouchClick centrally
- VideoTabs gets its own touch-guard (raw click handler, no GlassCard)
- main.scss: touch-action: manipulation on interactive elements
- _layout.scss: .app uses min-height: 100svh + safe-area-insets, header padding-top respects env(safe-area-inset-top)

Tap targets raised to 44px (WCAG 2.5.5 / Apple HIG):
- VideosView select-checkbox (mobile + desktop)
- StreamersView filter-tab
- VideoPlayerView control button

useModal rollout (high-traffic modals only):
- VideoModal: replaces inline ESC + body.style.overflow handling (autoFocus disabled to keep video player focus flow)
- StreamList delete + delete-all confirmation modals
- StreamerDetailView delete-all confirm + settings modal