### PR TITLE
fix(notifications): pin panel header + add Clear all; document API-key SHA-256

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -467,9 +467,20 @@
           <div v-if="showNotifications" ref="notificationPanelRef" class="glass-popup-panel notification-panel">
             <div class="glass-popup-header">
               <h3>Notifications</h3>
-              <button class="glass-btn-icon" @click="closeNotificationPanel" aria-label="Close notifications">
-                <svg><use href="#icon-x" /></svg>
-              </button>
+              <div class="notification-header-actions">
+                <button
+                  v-if="notificationCount > 0"
+                  class="glass-btn-text clear-all-btn"
+                  @click="clearAllNotifications"
+                  aria-label="Clear all notifications"
+                  title="Clear all notifications"
+                >
+                  Clear all
+                </button>
+                <button class="glass-btn-icon" @click="closeNotificationPanel" aria-label="Close notifications">
+                  <svg><use href="#icon-x" /></svg>
+                </button>
+              </div>
             </div>
             <NotificationFeed 
               @notifications-read="markAsRead" 
@@ -560,6 +571,7 @@ onMounted(() => {
 
 const showNotifications = ref(false)
 const unreadCount = ref(0)
+const notificationCount = ref(0)
 const lastReadTimestamp = ref(localStorage.getItem('lastReadTimestamp') || '0')
 
 const { messages } = useWebSocket()
@@ -821,6 +833,7 @@ async function clearAllNotifications() {
   markAsRead()
   // Reset notification count
   unreadCount.value = 0
+  notificationCount.value = 0
   // Dispatch event to notify other components
   window.dispatchEvent(new CustomEvent('notificationsUpdated', {
     detail: { count: 0 }
@@ -844,6 +857,9 @@ function updateUnreadCountFromStorage() {
       const notifications = JSON.parse(notificationsStr)
       
       if (Array.isArray(notifications)) {
+        // Total count includes ALL notifications in storage. Used to decide
+        // whether to render the "Clear all" button in the panel header.
+        notificationCount.value = notifications.length
         // Only count real notification types, not connection status
         const validNotificationTypes = [
           'stream.online', 
@@ -871,6 +887,7 @@ function updateUnreadCountFromStorage() {
     }
   } else {
     unreadCount.value = 0
+    notificationCount.value = 0
   }
 }
 
@@ -1203,6 +1220,37 @@ watch(messages, (newMessages) => {
   // Must beat scoped selector specificity: .feed-header[data-v-xxx]
   .notification-feed .feed-header {
     display: none !important;
+  }
+
+  // Header action group: "Clear all" text button + close icon button
+  .notification-header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+  }
+
+  .clear-all-btn {
+    background: transparent;
+    border: 1px solid var(--glass-border-hover);
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background var(--duration-150) var(--ease-out),
+                color var(--duration-150) var(--ease-out),
+                border-color var(--duration-150) var(--ease-out);
+
+    &:hover {
+      background: var(--glass-bg-subtle);
+      color: var(--text-primary);
+      border-color: var(--text-secondary);
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
   }
   
   @include m.respond-below('lg') {

--- a/app/frontend/src/styles/_glass-system.scss
+++ b/app/frontend/src/styles/_glass-system.scss
@@ -718,12 +718,32 @@ $glass-shadow-xl: 0 12px 48px rgba(0, 0, 0, 0.3);
     background: var(--glass-bg-solid);
   }
 
+  // Flex column so the header stays pinned and only the content area scrolls.
+  // Without this, the panel itself becomes the scroll container and the
+  // (non-sticky) header gets overlapped by the first content row when you scroll.
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
   // Desktop: dropdown from header
   top: 72px;
   right: var(--spacing-4);
   width: min(420px, 90vw);
   max-height: 70vh;
-  overflow-y: auto;
+
+  .glass-popup-header {
+    flex-shrink: 0;
+  }
+
+  // Direct child that is NOT the header becomes the scroll area.
+  // This covers the NotificationFeed pattern (no .glass-popup-content wrapper)
+  // while leaving .glass-popup-content (BackgroundQueueMonitor pattern) to manage
+  // its own scroll behaviour.
+  > :not(.glass-popup-header):not(.glass-popup-content) {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
 
   // Full-screen overlay for tablets and below
   @include m.respond-below('lg') {
@@ -735,11 +755,8 @@ $glass-shadow-xl: 0 12px 48px rgba(0, 0, 0, 0.3);
     max-height: 100dvh;
     height: 100dvh;
     border-radius: 0;
-    display: flex;
-    flex-direction: column;
 
     .glass-popup-header {
-      flex-shrink: 0;
       border-radius: 0;
     }
   }

--- a/app/services/core/api_key_service.py
+++ b/app/services/core/api_key_service.py
@@ -25,8 +25,22 @@ _PREFIX_DISPLAY_LEN = 10  # Number of chars stored for UI display (e.g. "sv_abcd
 
 
 def hash_api_key(raw_key: str) -> str:
-    """SECURITY: SHA-256 the raw key before DB lookup/storage (CWE-312)."""
-    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+    """Hash a raw API key for DB lookup/storage.
+
+    SECURITY NOTE (CodeQL py/weak-sensitive-data-hashing, false positive):
+    SHA-256 is used here intentionally instead of bcrypt/argon2/scrypt.
+    Slow KDFs exist to make brute-forcing low-entropy human-chosen passwords
+    economically infeasible. The input here is NOT a password: it is a
+    cryptographically random token produced by ``secrets.token_urlsafe(32)``
+    (~256 bits of entropy, prefixed with ``sv_``). Brute-forcing such a token
+    is computationally infeasible regardless of hash speed, so a slow KDF
+    would only add per-request latency without improving security.
+    SHA-256 also gives us constant-time DB lookups via an indexed hash column.
+    Mirrors the strategy used by GitHub PATs, AWS access keys, Stripe secret
+    keys, and StreamVault's own AuthService session tokens.
+    """
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+    # codeql[py/weak-sensitive-data-hashing]: input is a 256-bit random token, not a password.
 
 
 class ApiKeyService:

--- a/app/services/core/api_key_service.py
+++ b/app/services/core/api_key_service.py
@@ -39,7 +39,9 @@ def hash_api_key(raw_key: str) -> str:
     Mirrors the strategy used by GitHub PATs, AWS access keys, Stripe secret
     keys, and StreamVault's own AuthService session tokens.
     """
-    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
+    return hashlib.sha256(
+        raw_key.encode("utf-8")
+    ).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
     # codeql[py/weak-sensitive-data-hashing]: input is a 256-bit random token, not a password.
 
 


### PR DESCRIPTION
Two fixes bundled on one branch.

## 1. Notification panel header overlap + missing Clear-all (UX)

**Problem A**: `.glass-popup-panel` was the scroll container (`overflow-y: auto`) and `.glass-popup-header` was not sticky. As soon as you scrolled, the first notification slid up under the header and overlapped the title + close button.

**Fix**: convert `.glass-popup-panel` to a flex column with `overflow: hidden`. Header gets `flex-shrink: 0` (pinned). The first non-header / non-`.glass-popup-content` direct child becomes the scroll area. `BackgroundQueueMonitor` is unaffected because it has its own `.glass-popup-content` wrapper that already manages scrolling.

**Problem B**: clearing all notifications required opening the internal feed header, which App.vue hides via `display: none !important`. There was no visible "clear all" affordance.

**Fix**: render a "Clear all" text button in the panel's `.glass-popup-header`, shown only when `notificationCount > 0`, wired to the existing `clearAllNotifications()` handler. Tracks total notification count from localStorage alongside the unread count.

## 2. CodeQL `py/weak-sensitive-data-hashing` on `api_key_service.py` (false positive)

CodeQL flags `hash_api_key()` and recommends bcrypt/argon2/scrypt. This is a false positive: the input is not a password, it is a 256-bit cryptographically random token from `secrets.token_urlsafe(32)`. Slow KDFs only help against low-entropy inputs; brute-forcing a 256-bit random token is computationally infeasible regardless of hash speed.

**Fix**: expand the docstring with the full rationale and add inline `# lgtm[py/weak-sensitive-data-hashing]` + `# codeql[...]` suppression markers. Mirrors the strategy used by GitHub PATs, AWS access keys, Stripe secret keys, and StreamVault's own `AuthService` session tokens.

After merge, dismiss the corresponding CodeQL alert in the Security tab as "won't fix / false positive".