### PR TITLE
feat(about): always check for updates against matching GitHub release channel

### DIFF
--- a/app/frontend/src/views/SettingsView.vue
+++ b/app/frontend/src/views/SettingsView.vue
@@ -275,7 +275,13 @@
                   <div v-if="versionInfo.update_available" class="update-notice">
                     <span class="update-icon">🎉</span>
                     <span class="update-text">
-                      Update available: <strong>{{ versionInfo.latest_version }}</strong>
+                      Update available:
+                      <strong>{{ displayVersion }}</strong>
+                      &rarr;
+                      <strong>{{ versionInfo.latest_version }}</strong>
+                      <span v-if="versionInfo.release_channel" class="channel-badge">
+                        {{ versionInfo.release_channel }}
+                      </span>
                     </span>
                     <a v-if="versionInfo.latest_version_url"
                        :href="versionInfo.latest_version_url"
@@ -284,9 +290,21 @@
                       View Release
                     </a>
                   </div>
-                  <div v-else-if="!versionInfo.update_check_error" class="up-to-date">
+                  <div v-else-if="versionInfo.update_check_error" class="update-notice update-error">
+                    <span class="update-icon">⚠️</span>
+                    <span class="update-text">
+                      Update check failed: {{ versionInfo.update_check_error }}
+                    </span>
+                  </div>
+                  <div v-else class="up-to-date">
                     <span class="check-icon">✅</span>
                     <span>{{ upToDateText }}</span>
+                    <a v-if="versionInfo.latest_version_url"
+                       :href="versionInfo.latest_version_url"
+                       target="_blank"
+                       class="release-link">
+                      View release
+                    </a>
                   </div>
                 </div>
                 <p v-else class="about-version">Loading version...</p>
@@ -409,9 +427,11 @@ const displayVersion = computed(() => {
 const upToDateText = computed(() => {
   const v = versionInfo.value
   if (!v) return "You're running the latest version"
-  if (v.branch === 'develop') return "You're running the latest develop build"
-  if (v.branch && !['main', 'develop'].includes(v.branch)) return `Running ${v.branch} build (no update checks)`
-  return "You're running the latest version"
+  const channel = v.release_channel === 'prerelease' ? 'develop' : 'stable'
+  if (v.latest_version) {
+    return `You're on the latest ${channel} release (${v.latest_version})`
+  }
+  return `You're on the latest ${channel} release`
 })
 
 // Theme management - use global theme composable
@@ -1101,10 +1121,37 @@ onMounted(() => {
   font-size: var(--text-sm);
   color: var(--success-color);
   margin: var(--spacing-3) 0;
-  
+  flex-wrap: wrap;
+
   .check-icon {
     font-size: var(--text-lg);
   }
+
+  .release-link {
+    color: var(--text-secondary);
+    text-decoration: underline;
+    font-size: var(--text-xs);
+
+    &:hover {
+      color: var(--text-primary);
+    }
+  }
+}
+
+.update-error {
+  color: var(--warning-color, #f59e0b);
+}
+
+.channel-badge {
+  display: inline-block;
+  margin-left: var(--spacing-2);
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--surface-secondary, rgba(255, 255, 255, 0.08));
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .about-description {

--- a/app/frontend/src/views/SettingsView.vue
+++ b/app/frontend/src/views/SettingsView.vue
@@ -1139,7 +1139,7 @@ onMounted(() => {
 }
 
 .update-error {
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning-color);
 }
 
 .channel-badge {

--- a/app/routes/version.py
+++ b/app/routes/version.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 import httpx
 import logging
+import re
 from datetime import datetime, timedelta
 
 from app.database import get_db
@@ -16,6 +17,8 @@ logger = logging.getLogger("streamvault")
 
 # Cache for GitHub API responses (avoid rate limiting)
 _update_check_cache = {"data": None, "expires_at": None}
+
+GITHUB_REPO = "Serph91P/StreamVault"
 
 
 @router.get("")
@@ -31,6 +34,7 @@ async def get_version(db: Session = Depends(get_db)):
         - is_production: True if running main branch
         - update_available: True if newer version exists on GitHub
         - latest_version: Latest version from GitHub (if available)
+        - release_channel: Which channel was checked ("stable" or "prerelease")
     """
     version_info = get_version_info()
 
@@ -40,10 +44,52 @@ async def get_version(db: Session = Depends(get_db)):
     return {**version_info, **update_info}
 
 
+def _is_prerelease_version(version: str) -> bool:
+    """
+    Determine if the running build is a prerelease/develop build.
+
+    Heuristics (in order):
+      1. Explicit BRANCH == "develop" wins.
+      2. Version string contains "-dev" or starts with "dev." -> prerelease.
+      3. Version string is the literal "dev" placeholder -> prerelease
+         (local/unknown build, default to develop channel).
+      4. Otherwise stable.
+    """
+    if BRANCH == "develop":
+        return True
+    if BRANCH == "main":
+        return False
+    v = (version or "").lower()
+    if "-dev" in v or v.startswith("dev.") or v.startswith("dev-"):
+        return True
+    if v in ("dev", "unknown", ""):
+        return True
+    return False
+
+
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+
+def _parse_version_tuple(version: str) -> tuple[int, int, int] | None:
+    """Extract (major, minor, patch) from a version string. Returns None on failure."""
+    if not version:
+        return None
+    m = _VERSION_RE.search(version)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
 async def _check_for_updates() -> dict:
     """
     Check GitHub for newer version.
     Uses caching to avoid rate limiting (cache: 5 minutes).
+
+    Channel selection is driven by the running version's suffix (not BRANCH),
+    so unknown/local builds still get a sensible check:
+      - Prerelease builds (-dev / develop) are compared against the highest
+        prerelease on GitHub.
+      - Stable builds are compared against /releases/latest.
     """
     now = datetime.utcnow()
 
@@ -51,95 +97,90 @@ async def _check_for_updates() -> dict:
     if _update_check_cache["expires_at"] and now < _update_check_cache["expires_at"]:
         return _update_check_cache["data"]
 
+    is_prerelease = _is_prerelease_version(VERSION)
+    channel = "prerelease" if is_prerelease else "stable"
+
     result = {
         "update_available": False,
         "latest_version": None,
         "latest_version_url": None,
         "update_check_error": None,
+        "release_channel": channel,
     }
 
     try:
-        # Only check for updates on main/develop branches
-        if BRANCH not in ["main", "develop"]:
-            # Not an error — feature/local branches simply don't get
-            # update notifications (Sprint 8 requirement).
-            result["update_check_error"] = None
-            return result
-
-        # Determine which releases to check
-        if BRANCH == "main":
-            # Main branch: Check latest stable release
-            api_url = (
-                "https://api.github.com/repos/Serph91P/StreamVault/releases/latest"
-            )
-        else:
-            # Develop branch: Check all releases for latest develop tag
-            api_url = "https://api.github.com/repos/Serph91P/StreamVault/releases"
-
         async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.get(
-                api_url,
-                headers={
-                    "Accept": "application/vnd.github.v3+json",
-                    "User-Agent": "StreamVault-UpdateChecker",
-                },
-            )
+            headers = {
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "StreamVault-UpdateChecker",
+            }
 
-            if response.status_code != 200:
-                result["update_check_error"] = (
-                    f"GitHub API returned {response.status_code}"
+            if not is_prerelease:
+                # Stable channel: latest non-prerelease release.
+                response = await client.get(
+                    f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest",
+                    headers=headers,
                 )
-                return result
+                if response.status_code != 200:
+                    result["update_check_error"] = (
+                        f"GitHub API returned {response.status_code}"
+                    )
+                    return _cache_and_return(result, now)
 
-            data = response.json()
-
-            if BRANCH == "main":
-                # Main: Direct latest release
-                latest_version = data.get("tag_name", "").replace("v", "")
+                data = response.json()
+                latest_tag = data.get("tag_name", "")
                 latest_url = data.get("html_url")
             else:
-                # Develop: Find latest develop-tagged release
+                # Prerelease channel: scan recent releases, take the highest
+                # prerelease by semver (independent of GitHub's sort order).
+                response = await client.get(
+                    f"https://api.github.com/repos/{GITHUB_REPO}/releases?per_page=30",
+                    headers=headers,
+                )
+                if response.status_code != 200:
+                    result["update_check_error"] = (
+                        f"GitHub API returned {response.status_code}"
+                    )
+                    return _cache_and_return(result, now)
+
+                data = response.json()
                 if not isinstance(data, list):
                     result["update_check_error"] = "Unexpected GitHub API response"
-                    return result
+                    return _cache_and_return(result, now)
 
-                develop_releases = [
-                    r for r in data if "develop" in r.get("tag_name", "").lower()
-                ]
-                if not develop_releases:
-                    # No develop tagged releases yet — treat as up-to-date
-                    # instead of surfacing an error (Sprint 8 requirement).
-                    result["update_check_error"] = None
-                    result["update_available"] = False
+                prereleases = [r for r in data if r.get("prerelease")]
+                if not prereleases:
+                    # No prereleases yet, treat as up-to-date.
                     result["latest_version"] = VERSION
-                    _update_check_cache["data"] = result
-                    _update_check_cache["expires_at"] = now + timedelta(minutes=5)
-                    return result
+                    return _cache_and_return(result, now)
 
-                latest_release = develop_releases[0]
-                latest_version = latest_release.get("tag_name", "").replace("v", "")
+                def _key(r):
+                    parsed = _parse_version_tuple(r.get("tag_name", ""))
+                    return parsed if parsed else (-1, -1, -1)
+
+                latest_release = max(prereleases, key=_key)
+                latest_tag = latest_release.get("tag_name", "")
                 latest_url = latest_release.get("html_url")
 
-            result["latest_version"] = latest_version
+            # Strip a leading "v" but keep the rest of the tag for display.
+            latest_display = (
+                latest_tag[1:] if latest_tag.startswith("v") else latest_tag
+            )
+            result["latest_version"] = latest_display
             result["latest_version_url"] = latest_url
 
-            # Compare versions (simple string comparison for semantic versioning)
-            current_version = VERSION.replace("v", "")
+            # Compare semver tuples. If parsing fails on either side we cannot
+            # tell, so we fall back to "no update" rather than crying wolf.
+            current_parts = _parse_version_tuple(VERSION)
+            latest_parts = _parse_version_tuple(latest_tag)
 
-            # Skip comparison if running dev build
-            if "dev" in current_version.lower() or BRANCH == "develop":
+            if current_parts and latest_parts:
+                result["update_available"] = latest_parts > current_parts
+            elif latest_parts and not current_parts:
+                # Local build (VERSION == "dev" / "unknown") cannot be compared.
+                # Surface the latest version but do not flag an update so we
+                # don't nag developers running their own builds.
                 result["update_available"] = False
-            else:
-                # Parse versions (e.g., "1.2.3" -> [1, 2, 3])
-                try:
-                    current_parts = [int(x) for x in current_version.split(".")]
-                    latest_parts = [int(x) for x in latest_version.split(".")]
-
-                    # Compare major.minor.patch
-                    result["update_available"] = latest_parts > current_parts
-                except (ValueError, AttributeError):
-                    # Fallback to string comparison
-                    result["update_available"] = latest_version > current_version
 
     except httpx.TimeoutException:
         result["update_check_error"] = "GitHub API timeout"
@@ -148,8 +189,11 @@ async def _check_for_updates() -> dict:
         result["update_check_error"] = "Failed to check for updates"
         logger.error(f"Failed to check for updates: {e}")
 
-    # Cache result for 5 minutes
+    return _cache_and_return(result, now)
+
+
+def _cache_and_return(result: dict, now: datetime) -> dict:
+    """Cache the result for 5 minutes and return it."""
     _update_check_cache["data"] = result
     _update_check_cache["expires_at"] = now + timedelta(minutes=5)
-
     return result


### PR DESCRIPTION
## What

Removes the dead-end `✅ Running unknown build (no update checks)` state on the Settings -> About page. Every build now gets a real version check against GitHub Releases:

- **Stable builds** (BRANCH=main, version like `2.0.88`) -> compared against `/releases/latest`
- **Develop / prerelease builds** (BRANCH=develop, version contains `-dev` or starts with `dev.`) -> compared against the highest prerelease in `/releases`
- **Local builds** (BRANCH=unknown, VERSION=dev) -> default to develop channel, surface the latest prerelease but don't flag a false update

The UI now shows current -> latest, the channel being checked (`stable` / `prerelease` badge), and a link to the matching GitHub release.

## Why

Branch-only channel detection meant any image that wasn't built on `main`/`develop` (e.g. `latest` tag without proper BRANCH env, or local docker-compose builds) hit the `no update checks` dead-end and never told the user what version they were on or what was available. The new heuristic looks at the **version string** rather than only `BRANCH`, so the check works for every image variant.

## Backend changes (`app/routes/version.py`)

- New `_is_prerelease_version()` decides channel from BRANCH **or** version suffix
- New `_parse_version_tuple()` shared semver parser, tolerant of `v` prefix and `-dev`/`dev.` suffixes
- Prerelease channel scans `?per_page=30`, filters `prerelease=true`, picks max by parsed semver (independent of GitHub's sort order)
- Skips the comparison cleanly when the local version cannot be parsed (no false "update available" prompts)
- Adds `release_channel` (`stable` / `prerelease`) to the API response
- Cache logic centralised in `_cache_and_return()`, all exit paths get the same 5 min TTL

## Frontend changes (`SettingsView.vue`)

- Removed the `Running ${branch} build (no update checks)` branch
- "Update available" shows `current -> latest` with a `stable`/`prerelease` badge
- "Up to date" reads `You're on the latest stable release (vX.Y.Z)` (or develop equivalent), with a release link
- New explicit error state when `update_check_error` is set
- Added `.channel-badge`, `.release-link`, `.update-error` styles

## Compat

No tests exist for `routes/version.py` and no callers depend on the removed behaviour. `update_available` / `latest_version` / `latest_version_url` keys are unchanged. New optional `release_channel` key is additive.