### PR TITLE
fix(about): drop green checkmark from up-to-date row

### DIFF
--- a/app/frontend/src/views/SettingsView.vue
+++ b/app/frontend/src/views/SettingsView.vue
@@ -297,7 +297,6 @@
                     </span>
                   </div>
                   <div v-else class="up-to-date">
-                    <span class="check-icon">✅</span>
                     <span>{{ upToDateText }}</span>
                     <a v-if="versionInfo.latest_version_url"
                        :href="versionInfo.latest_version_url"
@@ -1122,10 +1121,6 @@ onMounted(() => {
   color: var(--success-color);
   margin: var(--spacing-3) 0;
   flex-wrap: wrap;
-
-  .check-icon {
-    font-size: var(--text-lg);
-  }
 
   .release-link {
     color: var(--text-secondary);


### PR DESCRIPTION
Removes the leftover green check emoji on the About page's up-to-date row, as requested. The text alone is sufficient and matches the rest of the page's tone.