### PR TITLE
feat: store Twitch OAuth token in settings

### DIFF
--- a/app/frontend/src/components/settings/TwitchConnectionPanel.vue
+++ b/app/frontend/src/components/settings/TwitchConnectionPanel.vue
@@ -18,8 +18,12 @@
           <div class="detail-item">
             <span class="detail-label">Status:</span>
             <span class="detail-value" :class="{ 'text-success': connectionStatus.valid, 'text-warning': !connectionStatus.valid }">
-              {{ connectionStatus.valid ? 'Active & Valid' : 'Token Expired (will auto-refresh)' }}
+              {{ connectionStatus.valid ? 'Active & Valid' : 'Token Expired or Needs Refresh' }}
             </span>
+          </div>
+          <div v-if="connectionStatus.source" class="detail-item">
+            <span class="detail-label">Source:</span>
+            <span class="detail-value">{{ formatSource(connectionStatus.source) }}</span>
           </div>
           <div v-if="connectionStatus.expires_at" class="detail-item">
             <span class="detail-label">Expires:</span>
@@ -29,14 +33,14 @@
       </div>
 
       <!-- Browser Token Setup (Recommended Method) -->
-      <div v-if="!connectionStatus.connected" class="setup-section">
+      <div class="setup-section">
         <div class="setup-header">
           <svg class="setup-icon" viewBox="0 0 24 24">
             <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
           </svg>
           <div>
             <h4 class="setup-title">Manual Token Setup (Recommended)</h4>
-            <p class="setup-subtitle">For H.265/1440p quality, you need a browser authentication token</p>
+            <p class="setup-subtitle">Save or replace the browser authentication token used for H.265/1440p quality</p>
           </div>
         </div>
 
@@ -87,14 +91,32 @@
             <li class="step-item">
               <span class="step-number">5</span>
               <div class="step-content">
-                <strong>Set it as environment variable</strong> in docker-compose.yml:
-                <div class="code-block">
-                  <code>TWITCH_OAUTH_TOKEN=your_token_here</code>
-                </div>
+                <strong>Paste and save it below</strong>. StreamVault stores the token encrypted in the database. Existing TWITCH_OAUTH_TOKEN environment values are still used as a fallback.
               </div>
             </li>
           </ol>
         </div>
+
+        <form class="manual-token-form" @submit.prevent="saveManualToken">
+          <label class="token-label" for="twitch-oauth-token">Twitch OAuth token</label>
+          <div class="token-input-row">
+            <input
+              id="twitch-oauth-token"
+              v-model="manualToken"
+              class="token-input"
+              type="password"
+              autocomplete="off"
+              placeholder="Paste your auth-token value"
+              :disabled="isLoading"
+            />
+            <button type="submit" class="btn-action btn-primary" :disabled="isLoading || !manualToken.trim()" v-ripple>
+              Save token
+            </button>
+          </div>
+          <p class="token-help">
+            The token is validated with Twitch before it is stored. It is never shown again after saving.
+          </p>
+        </form>
 
         <div class="info-box info-box-info">
           <svg class="info-icon" viewBox="0 0 24 24">
@@ -167,6 +189,8 @@ interface ConnectionStatus {
   connected: boolean
   valid: boolean
   expires_at: string | null
+  source?: string | null
+  has_env_token?: boolean
 }
 
 const toast = useToast()
@@ -179,6 +203,7 @@ const connectionStatus = ref<ConnectionStatus>({
 
 const isLoading = ref(false)
 const callbackUrl = ref('')
+const manualToken = ref('')
 
 const statusClass = computed(() => ({
   'status-connected': connectionStatus.value.connected && connectionStatus.value.valid,
@@ -193,9 +218,8 @@ const statusTitle = computed(() => {
 })
 
 const statusDescription = computed(() => {
-  if (!connectionStatus.value.connected) {
-    return 'Browser token from environment is used for recordings. OAuth optional for follower sync.'
-  }
+  if (!connectionStatus.value.connected) return 'No Twitch token is configured yet'
+  if (connectionStatus.value.source === 'environment') return 'Using TWITCH_OAUTH_TOKEN environment fallback. You can save a replacement below.'
   if (!connectionStatus.value.valid) {
     return 'Your token will be automatically refreshed on next recording'
   }
@@ -291,7 +315,9 @@ async function disconnectTwitch() {
       connectionStatus.value = {
         connected: false,
         valid: false,
-        expires_at: null
+        expires_at: null,
+        source: null,
+        has_env_token: false
       }
       
       toast.success('Your Twitch account has been disconnected')
@@ -310,6 +336,38 @@ async function refreshStatus() {
   isLoading.value = false
   
   toast.info('Connection status has been updated')
+}
+
+async function saveManualToken() {
+  const token = manualToken.value.trim()
+  if (!token) return
+
+  try {
+    isLoading.value = true
+
+    const response = await fetch('/api/twitch/manual-token', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ token })
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.detail || 'Failed to save token')
+    }
+
+    manualToken.value = ''
+    await fetchConnectionStatus()
+    toast.success('Twitch OAuth token saved securely')
+  } catch (error) {
+    console.error('Failed to save Twitch OAuth token:', error)
+    toast.error(error instanceof Error ? error.message : 'Could not save Twitch OAuth token')
+  } finally {
+    isLoading.value = false
+  }
 }
 
 async function copyTokenCommand() {
@@ -338,6 +396,14 @@ function formatExpiration(expiresAt: string): string {
   } else {
     return 'Expired (will auto-refresh)'
   }
+}
+
+function formatSource(source: string): string {
+  if (source === 'database_manual') return 'Encrypted database browser token'
+  if (source === 'database_oauth') return 'Encrypted OAuth app token'
+  if (source === 'environment') return 'TWITCH_OAUTH_TOKEN environment fallback'
+  if (source === 'oauth_refresh') return 'OAuth refresh token'
+  return source
 }
 </script>
 
@@ -702,7 +768,9 @@ function formatExpiration(expiresAt: string): string {
 }
 
 .code-block {
-  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
   margin-top: var(--spacing-2);
   padding: var(--spacing-3);
   background: transparent;
@@ -710,22 +778,29 @@ function formatExpiration(expiresAt: string): string {
   border: 1px solid var(--border-color);
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: 12px;
-  overflow-x: auto;
+  overflow: hidden;
 
   code {
+    flex: 1;
     color: var(--text-primary);
-    word-break: break-all;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    min-width: 0;
   }
 }
 
 .btn-copy {
-  position: absolute;
-  top: var(--spacing-2);
-  right: var(--spacing-2);
-  padding: var(--spacing-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   background: var(--background-card);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
+  flex-shrink: 0;
   cursor: pointer;
   transition: var(--transition-base);
   
@@ -739,6 +814,46 @@ function formatExpiration(expiresAt: string): string {
     height: 16px;
     display: block;
   }
+}
+
+// Manual Token Form
+.manual-token-form {
+  padding: var(--spacing-4);
+  margin: var(--spacing-4) 0;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: rgba(var(--primary-color-rgb, 66, 184, 131), 0.04);
+}
+
+.token-label {
+  display: block;
+  margin-bottom: var(--spacing-2);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.token-input-row {
+  display: flex;
+  gap: var(--spacing-3);
+  align-items: stretch;
+}
+
+.token-input {
+  flex: 1;
+  min-width: 0;
+  padding: var(--spacing-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--background-card);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.token-help {
+  margin: var(--spacing-2) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
 }
 
 // Benefits Section
@@ -824,7 +939,8 @@ function formatExpiration(expiresAt: string): string {
     margin-bottom: v.$spacing-4;
   }
   
-  .form-actions {
+  .form-actions,
+  .token-input-row {
     flex-direction: column;
     
     .btn {

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -405,18 +405,19 @@ async def get_quality_options():
     Get available quality options based on OAuth token configuration.
 
     Returns quality options with enabled/disabled status based on whether
-    TWITCH_OAUTH_TOKEN is configured. 1440p requires OAuth authentication.
+    a database or environment Twitch token is configured. 1440p requires
+    OAuth authentication.
     """
     try:
-        from app.config.settings import settings
+        from app.database import SessionLocal
         from app.services.system.streamlink_config_service import (
             streamlink_config_service,
         )
+        from app.services.system.twitch_token_service import TwitchTokenService
 
-        # Check if OAuth token is configured
-        has_oauth = bool(
-            settings.TWITCH_OAUTH_TOKEN and settings.TWITCH_OAUTH_TOKEN.strip()
-        )
+        with SessionLocal() as db:
+            token_service = TwitchTokenService(db)
+            has_oauth = bool(await token_service.get_valid_access_token())
 
         # Get quality options with availability info
         qualities = streamlink_config_service.get_available_qualities(has_oauth)
@@ -426,7 +427,7 @@ async def get_quality_options():
             "oauth_configured": has_oauth,
             "message": "H.265/1440p available"
             if has_oauth
-            else "Set TWITCH_OAUTH_TOKEN for H.265/1440p access",
+            else "Save a Twitch OAuth token for H.265/1440p access",
         }
     except Exception as e:
         logger.error(f"Error getting quality options: {e}")
@@ -442,12 +443,12 @@ async def get_codec_options():
     H.265/HEVC and AV1 require OAuth authentication on Twitch.
     """
     try:
-        from app.config.settings import settings
+        from app.database import SessionLocal
+        from app.services.system.twitch_token_service import TwitchTokenService
 
-        # Check if OAuth token is configured
-        has_oauth = bool(
-            settings.TWITCH_OAUTH_TOKEN and settings.TWITCH_OAUTH_TOKEN.strip()
-        )
+        with SessionLocal() as db:
+            token_service = TwitchTokenService(db)
+            has_oauth = bool(await token_service.get_valid_access_token())
 
         codecs = [
             {
@@ -489,7 +490,7 @@ async def get_codec_options():
             "oauth_configured": has_oauth,
             "message": "H.265/AV1 codecs available"
             if has_oauth
-            else "Set TWITCH_OAUTH_TOKEN for H.265/AV1 codecs",
+            else "Save a Twitch OAuth token for H.265/AV1 codecs",
             "note": "Codec availability depends on streamer's broadcast settings and Twitch's transcoding",
         }
     except Exception as e:

--- a/app/routes/twitch_auth.py
+++ b/app/routes/twitch_auth.py
@@ -1,14 +1,27 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, Field
 from app.services.api.twitch_oauth_service import TwitchOAuthService
 from app.services.streamer_service import StreamerService
 from app.dependencies import get_streamer_service
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import logging
 
 logger = logging.getLogger("streamvault")
 
 router = APIRouter(prefix="/api/twitch", tags=["twitch-oauth"])
+
+
+class ManualTokenRequest(BaseModel):
+    token: str = Field(..., min_length=1, description="Twitch browser OAuth token")
+
+
+class ConnectionStatusResponse(BaseModel):
+    connected: bool
+    valid: bool
+    expires_at: Optional[str]
+    source: Optional[str] = None
+    has_env_token: bool = False
 
 
 def get_twitch_oauth_service(
@@ -161,9 +174,12 @@ async def get_callback_url():
     return {"url": callback_url}
 
 
-@router.get("/connection-status")
+@router.get("/connection-status", response_model=ConnectionStatusResponse)
 async def get_connection_status():
-    """Check if Twitch OAuth is connected (has valid refresh token)"""
+    """Check if a Twitch token is available in DB or env fallback."""
+    from datetime import datetime, timezone
+
+    from app.config.settings import settings
     from app.database import SessionLocal
     from app.models import GlobalSettings
 
@@ -171,38 +187,86 @@ async def get_connection_status():
         try:
             global_settings = db.query(GlobalSettings).first()
 
-            # Check if refresh token exists
+            has_db_token = bool(
+                global_settings
+                and global_settings.twitch_access_token
+                and global_settings.twitch_access_token.strip()
+            )
             has_refresh_token = bool(
                 global_settings
                 and global_settings.twitch_refresh_token
                 and global_settings.twitch_refresh_token.strip()
             )
+            has_env_token = bool(
+                settings.TWITCH_OAUTH_TOKEN and settings.TWITCH_OAUTH_TOKEN.strip()
+            )
 
-            # Check if token is still valid (not expired)
             is_valid = False
-            if has_refresh_token and global_settings.twitch_token_expires_at:
-                from datetime import datetime, timezone
-
-                # Make both datetimes timezone-aware for comparison
+            expires_at_value = None
+            if global_settings and global_settings.twitch_token_expires_at:
                 now_utc = datetime.now(timezone.utc)
                 expires_at = global_settings.twitch_token_expires_at
                 if expires_at.tzinfo is None:
-                    # If stored as naive, assume it's UTC
                     expires_at = expires_at.replace(tzinfo=timezone.utc)
                 is_valid = now_utc < expires_at
+                expires_at_value = global_settings.twitch_token_expires_at.isoformat()
+
+            source = None
+            if has_db_token and not has_refresh_token:
+                source = "database_manual"
+            elif has_db_token:
+                source = "database_oauth"
+            elif has_env_token:
+                source = "environment"
+                is_valid = True
+            elif has_refresh_token:
+                source = "oauth_refresh"
 
             return {
-                "connected": has_refresh_token,
+                "connected": has_db_token or has_refresh_token or has_env_token,
                 "valid": is_valid,
-                "expires_at": (
-                    global_settings.twitch_token_expires_at.isoformat()
-                    if global_settings and global_settings.twitch_token_expires_at
-                    else None
-                ),
+                "expires_at": expires_at_value,
+                "source": source,
+                "has_env_token": has_env_token,
             }
         except Exception as e:
             logger.error(f"Error checking connection status: {e}")
-            return {"connected": False, "valid": False, "expires_at": None}
+            return {
+                "connected": False,
+                "valid": False,
+                "expires_at": None,
+                "source": None,
+                "has_env_token": False,
+            }
+
+
+@router.post("/manual-token")
+async def save_manual_token(payload: ManualTokenRequest):
+    """Validate and store a manually supplied Twitch browser token encrypted in DB."""
+    from app.database import SessionLocal
+    from app.services.system.twitch_token_service import TwitchTokenService
+
+    with SessionLocal() as db:
+        try:
+            token_service = TwitchTokenService(db)
+            success, validation = await token_service.store_manual_access_token(
+                payload.token
+            )
+            if not success:
+                raise HTTPException(status_code=400, detail="Invalid Twitch OAuth token")
+
+            expires_in = validation.get("expires_in") if validation else None
+            logger.info("✅ Manual Twitch OAuth token saved")
+            return {
+                "success": True,
+                "message": "Twitch OAuth token saved",
+                "expires_in": expires_in,
+            }
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error saving manual Twitch OAuth token: {e}")
+            raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/disconnect")

--- a/app/routes/twitch_auth.py
+++ b/app/routes/twitch_auth.py
@@ -253,7 +253,9 @@ async def save_manual_token(payload: ManualTokenRequest):
                 payload.token
             )
             if not success:
-                raise HTTPException(status_code=400, detail="Invalid Twitch OAuth token")
+                raise HTTPException(
+                    status_code=400, detail="Invalid Twitch OAuth token"
+                )
 
             expires_in = validation.get("expires_in") if validation else None
             logger.info("✅ Manual Twitch OAuth token saved")

--- a/app/services/system/twitch_token_service.py
+++ b/app/services/system/twitch_token_service.py
@@ -45,8 +45,12 @@ class TwitchTokenService:
     # Token expiration buffer (refresh 1 hour before expiration)
     EXPIRATION_BUFFER_SECONDS = 3600
 
+    # Notify one day before manual browser tokens expire.
+    MANUAL_TOKEN_NOTIFICATION_BUFFER_SECONDS = 24 * 3600
+
     # Global lock for token refresh (prevents duplicate refreshes)
     _refresh_lock = asyncio.Lock()
+    _last_expiry_notification_at: Optional[datetime] = None
 
     def __init__(self, db: Session):
         self.db = db
@@ -58,51 +62,47 @@ class TwitchTokenService:
         Get a valid Twitch OAuth access token.
 
         Returns either:
-        1. Browser token from environment variable (PRIORITY - works for H.265/1440p)
-        2. Database token from OAuth flow (FALLBACK - limited quality, used for EventSub)
-        3. None (if no token available)
+        1. Encrypted browser token stored in the database (preferred)
+        2. Browser token from environment variable (backward compatibility)
+        3. Database token from OAuth flow (auto-refreshed when possible)
+        4. None (if no token available)
 
-        Priority Order:
-        - Environment variable (TWITCH_OAUTH_TOKEN) - Browser token with full access
-        - Database token (OAuth flow) - Limited access, but auto-refreshed
-
-        Note: Twitch restricts third-party OAuth apps from H.265/1440p streams.
-        Only browser tokens (auth-token cookie) grant full quality access.
+        Tokens entered on the Twitch Connection page replace the legacy
+        TWITCH_OAUTH_TOKEN environment variable. The environment variable is
+        still used as a fallback for existing installations.
 
         Returns:
             Optional[str]: Valid access token or None
         """
         try:
-            # === PRIORITY 1: Environment variable (browser token) ===
-            # Browser tokens have FULL access (H.265, AV1, 1440p, ad-free with Turbo)
+            global_settings = self.db.query(GlobalSettings).first()
+
+            # === PRIORITY 1: Encrypted manual browser token from database ===
+            # Manual tokens saved from the Twitch Connection page clear the
+            # refresh token. That lets us prefer the encrypted DB token over
+            # the legacy env var without accidentally letting an older app
+            # OAuth token override a browser token from TWITCH_OAUTH_TOKEN.
+            if (
+                global_settings
+                and global_settings.twitch_access_token
+                and not global_settings.twitch_refresh_token
+            ):
+                if self._is_token_valid(global_settings):
+                    logger.debug("✅ Using encrypted Twitch OAuth token from database")
+                    await self._send_expiry_notification_if_needed(global_settings)
+                    return self.encryption.decrypt(global_settings.twitch_access_token)
+
+                await self._send_expiry_notification_if_needed(global_settings, expired=True)
+
+            # === PRIORITY 2: Environment variable fallback/backward compatibility ===
             if self.settings.TWITCH_OAUTH_TOKEN:
                 logger.debug(
-                    "✅ Using browser token from environment variable (TWITCH_OAUTH_TOKEN)"
-                )
-                logger.debug(
-                    "   → Full quality access: H.265/AV1 codecs, 1440p, ad-free (Turbo)"
+                    "✅ Using browser token from environment variable fallback (TWITCH_OAUTH_TOKEN)"
                 )
                 return self.settings.TWITCH_OAUTH_TOKEN
 
-            # === PRIORITY 2: Database token (OAuth flow) ===
-            # OAuth flow tokens are LIMITED (Twitch API restriction)
-            # Only used if no browser token available (for EventSub, follower lists, etc.)
-            global_settings = self.db.query(GlobalSettings).first()
-
+            # === PRIORITY 3: Database refresh token from OAuth flow ===
             if global_settings and global_settings.twitch_refresh_token:
-                # Check if access token is still valid
-                if self._is_token_valid(global_settings):
-                    logger.debug("⚠️ Using OAuth token from database (limited quality)")
-                    logger.debug("   → Limited to 1080p H.264 (Twitch API restriction)")
-                    logger.debug(
-                        "   → For H.265/1440p: Set TWITCH_OAUTH_TOKEN environment variable"
-                    )
-                    # Decrypt and return access token from database
-                    if global_settings.twitch_access_token:
-                        return self.encryption.decrypt(
-                            global_settings.twitch_access_token
-                        )
-
                 # Token expired → Refresh it (with lock to prevent duplicate refreshes)
                 async with self._refresh_lock:
                     # Double-check: Another task may have refreshed while we waited
@@ -120,18 +120,15 @@ class TwitchTokenService:
                         return new_access_token
 
                     logger.warning(
-                        "⚠️ Token refresh failed and no environment token available"
+                        "⚠️ Token refresh failed and no valid database token available"
                     )
 
-            # === PRIORITY 3: No token available ===
+            # === PRIORITY 4: No token available ===
             logger.warning(
                 "❌ No Twitch OAuth token available. H.265/1440p quality unavailable."
             )
             logger.warning(
-                "   → Set TWITCH_OAUTH_TOKEN environment variable for full quality"
-            )
-            logger.warning(
-                "   → See: Settings → Twitch Connection → Manual Token Setup"
+                "   → Add a token in Settings → Twitch Connection"
             )
             return None
 
@@ -338,6 +335,100 @@ class TwitchTokenService:
             logger.error(f"Error storing OAuth tokens: {e}")
             self.db.rollback()
             return False
+
+    async def store_manual_access_token(
+        self, access_token: str
+    ) -> tuple[bool, Optional[dict]]:
+        """Validate and store a manually supplied browser OAuth token encrypted in DB."""
+        clean_token = access_token.strip()
+        if clean_token.lower().startswith("oauth:"):
+            clean_token = clean_token.split(":", 1)[1].strip()
+        if clean_token.lower().startswith("oauth "):
+            clean_token = clean_token.split(" ", 1)[1].strip()
+
+        if not clean_token:
+            return False, None
+
+        validation = await self.validate_token(clean_token)
+        if not validation:
+            return False, None
+
+        try:
+            global_settings = self.db.query(GlobalSettings).first()
+            if not global_settings:
+                logger.error("GlobalSettings not found, cannot store manual token")
+                return False, validation
+
+            expires_in = int(validation.get("expires_in") or 0)
+            expires_at = (
+                datetime.utcnow() + timedelta(seconds=expires_in)
+                if expires_in > 0
+                else None
+            )
+
+            global_settings.twitch_access_token = self.encryption.encrypt(clean_token)
+            global_settings.twitch_token_expires_at = expires_at
+            # Manual browser tokens have no refresh token. Clear any older OAuth
+            # refresh token so status accurately reports manual-token behavior.
+            global_settings.twitch_refresh_token = None
+            self.db.commit()
+
+            try:
+                from app.services.system.streamlink_config_service import (
+                    streamlink_config_service,
+                )
+
+                await streamlink_config_service.regenerate_config()
+            except Exception as config_error:
+                logger.error(
+                    f"❌ Error updating Streamlink config after manual token save: {config_error}"
+                )
+
+            logger.info("✅ Manual Twitch OAuth token stored in database")
+            return True, validation
+        except Exception as e:
+            logger.error(f"Error storing manual Twitch token: {e}")
+            self.db.rollback()
+            return False, validation
+
+    async def _send_expiry_notification_if_needed(
+        self, global_settings: GlobalSettings, expired: bool = False
+    ) -> None:
+        """Send an Apprise notification when the stored token is expired or near expiry."""
+        expires_at = global_settings.twitch_token_expires_at
+        if not expires_at:
+            return
+
+        now = datetime.utcnow()
+        if (
+            self.__class__._last_expiry_notification_at
+            and now - self.__class__._last_expiry_notification_at < timedelta(hours=12)
+        ):
+            return
+
+        seconds_remaining = (expires_at - now).total_seconds()
+        if not expired and seconds_remaining > self.MANUAL_TOKEN_NOTIFICATION_BUFFER_SECONDS:
+            return
+
+        try:
+            from app.services.notification_service import NotificationService
+
+            title = (
+                "StreamVault Twitch OAuth token expired"
+                if expired
+                else "StreamVault Twitch OAuth token expires soon"
+            )
+            body = (
+                "Your stored Twitch OAuth token has expired. Open Settings > Twitch Connection "
+                "and save a fresh browser token to keep H.265/1440p recordings working."
+                if expired
+                else "Your stored Twitch OAuth token expires soon. Open Settings > Twitch Connection "
+                "and save a fresh browser token to avoid recording quality fallback."
+            )
+            await NotificationService().send_notification(body, title)
+            self.__class__._last_expiry_notification_at = now
+        except Exception as e:
+            logger.debug(f"Could not send Twitch token expiry notification: {e}")
 
     async def validate_token(self, access_token: str) -> Optional[dict]:
         """

--- a/app/services/system/twitch_token_service.py
+++ b/app/services/system/twitch_token_service.py
@@ -92,7 +92,9 @@ class TwitchTokenService:
                     await self._send_expiry_notification_if_needed(global_settings)
                     return self.encryption.decrypt(global_settings.twitch_access_token)
 
-                await self._send_expiry_notification_if_needed(global_settings, expired=True)
+                await self._send_expiry_notification_if_needed(
+                    global_settings, expired=True
+                )
 
             # === PRIORITY 2: Environment variable fallback/backward compatibility ===
             if self.settings.TWITCH_OAUTH_TOKEN:
@@ -127,9 +129,7 @@ class TwitchTokenService:
             logger.warning(
                 "❌ No Twitch OAuth token available. H.265/1440p quality unavailable."
             )
-            logger.warning(
-                "   → Add a token in Settings → Twitch Connection"
-            )
+            logger.warning("   → Add a token in Settings → Twitch Connection")
             return None
 
         except Exception as e:
@@ -407,7 +407,10 @@ class TwitchTokenService:
             return
 
         seconds_remaining = (expires_at - now).total_seconds()
-        if not expired and seconds_remaining > self.MANUAL_TOKEN_NOTIFICATION_BUFFER_SECONDS:
+        if (
+            not expired
+            and seconds_remaining > self.MANUAL_TOKEN_NOTIFICATION_BUFFER_SECONDS
+        ):
             return
 
         try:

--- a/tests/test_twitch_token_service.py
+++ b/tests/test_twitch_token_service.py
@@ -1,0 +1,141 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+_module_path = (
+    Path(__file__).resolve().parents[1]
+    / "app/services/system/twitch_token_service.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "twitch_token_service_under_test", _module_path
+)
+assert _spec and _spec.loader
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+TwitchTokenService = _module.TwitchTokenService
+
+
+class _Query:
+    def __init__(self, value):
+        self.value = value
+
+    def first(self):
+        return self.value
+
+
+class _Db:
+    def __init__(self, settings):
+        self.settings = settings
+        self.committed = False
+        self.rolled_back = False
+
+    def query(self, _model):
+        return _Query(self.settings)
+
+    def refresh(self, _obj):
+        return None
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+
+class _Encryption:
+    def encrypt(self, value):
+        return f"enc:{value}"
+
+    def decrypt(self, value):
+        return value.removeprefix("enc:")
+
+
+@pytest.mark.asyncio
+async def test_manual_database_token_preferred_over_environment_token(monkeypatch):
+    stored = SimpleNamespace(
+        twitch_access_token="enc:db-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() + timedelta(hours=2),
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN="env-token")
+    service.encryption = _Encryption()
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_send_expiry_notification_if_needed", _noop)
+
+    assert await service.get_valid_access_token() == "db-token"
+
+
+@pytest.mark.asyncio
+async def test_environment_token_used_as_fallback_when_database_token_expired(monkeypatch):
+    stored = SimpleNamespace(
+        twitch_access_token="enc:expired-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN="env-token")
+    service.encryption = _Encryption()
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_send_expiry_notification_if_needed", _noop)
+
+    assert await service.get_valid_access_token() == "env-token"
+
+
+@pytest.mark.asyncio
+async def test_environment_token_preferred_over_refreshable_oauth_token(monkeypatch):
+    stored = SimpleNamespace(
+        twitch_access_token="enc:app-oauth-token",
+        twitch_refresh_token="enc:refresh-token",
+        twitch_token_expires_at=datetime.utcnow() + timedelta(hours=2),
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN="env-browser-token")
+    service.encryption = _Encryption()
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_send_expiry_notification_if_needed", _noop)
+
+    assert await service.get_valid_access_token() == "env-browser-token"
+
+
+@pytest.mark.asyncio
+async def test_store_manual_access_token_encrypts_and_clears_refresh_token(monkeypatch):
+    stored = SimpleNamespace(
+        twitch_access_token=None,
+        twitch_refresh_token="enc:old-refresh",
+        twitch_token_expires_at=None,
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN=None)
+    service.encryption = _Encryption()
+
+    async def _validate(token):
+        assert token == "manual-token"
+        return {"expires_in": 3600}
+
+    monkeypatch.setattr(service, "validate_token", _validate)
+
+    success, validation = await service.store_manual_access_token("OAuth manual-token")
+
+    assert success is True
+    assert validation == {"expires_in": 3600}
+    assert stored.twitch_access_token == "enc:manual-token"
+    assert stored.twitch_refresh_token is None
+    assert stored.twitch_token_expires_at is not None
+    assert service.db.committed is True


### PR DESCRIPTION
## Summary
- Add a manual Twitch browser OAuth token form to the Twitch connection settings page.
- Validate the token with Twitch, store it encrypted in the database, and keep TWITCH_OAUTH_TOKEN as a fallback.
- Make quality and codec option availability use the database-aware token service.
- Send an Apprise-backed notification when a stored token is expired or near expiry, throttled in memory.
- Fix the copy command layout so the copy button stays aligned and the code block does not show a horizontal scrollbar.

## Testing
- `python -m py_compile app/services/system/twitch_token_service.py app/routes/twitch_auth.py app/routes/settings.py`
- `python -m pytest tests/test_twitch_token_service.py tests/test_security.py -q`
- `cd app/frontend && npm run type-check && npm run build`
- `git diff --check`

## Notes
- Existing TWITCH_OAUTH_TOKEN environment values still work as fallback.
- Expiry notification throttling is currently process-local to avoid DB migration scope.
