### PR TITLE
fix: repair stale manual twitch token status

### DIFF
--- a/app/routes/twitch_auth.py
+++ b/app/routes/twitch_auth.py
@@ -251,6 +251,28 @@ async def get_connection_status():
     with SessionLocal() as db:
         try:
             global_settings = db.query(GlobalSettings).first()
+
+            # If a stored manual browser token has a missing/stale expiry, do a
+            # live Twitch validation before building status. This covers valid
+            # tokens saved by older versions or interrupted saves. If validation
+            # fails, _build_connection_status still reports a valid
+            # TWITCH_OAUTH_TOKEN fallback instead of the stale DB token.
+            if (
+                global_settings
+                and global_settings.twitch_access_token
+                and not global_settings.twitch_refresh_token
+            ):
+                _, is_manual_token_current = _normalize_expires_at(
+                    global_settings.twitch_token_expires_at
+                )
+                if not is_manual_token_current:
+                    from app.services.system.twitch_token_service import (
+                        TwitchTokenService,
+                    )
+
+                    token_service = TwitchTokenService(db)
+                    await token_service.revalidate_stored_manual_token(global_settings)
+
             return _build_connection_status(
                 global_settings, settings.TWITCH_OAUTH_TOKEN
             )

--- a/app/services/system/twitch_token_service.py
+++ b/app/services/system/twitch_token_service.py
@@ -48,6 +48,10 @@ class TwitchTokenService:
     # Notify one day before manual browser tokens expire.
     MANUAL_TOKEN_NOTIFICATION_BUFFER_SECONDS = 24 * 3600
 
+    # Conservative fallback when Twitch validation confirms a manual browser
+    # token but does not include a usable expires_in value.
+    DEFAULT_MANUAL_TOKEN_EXPIRES_IN_SECONDS = 60 * 24 * 3600
+
     # Global lock for token refresh (prevents duplicate refreshes)
     _refresh_lock = asyncio.Lock()
     _last_expiry_notification_at: Optional[datetime] = None
@@ -360,11 +364,14 @@ class TwitchTokenService:
                 return False, validation
 
             expires_in = int(validation.get("expires_in") or 0)
-            expires_at = (
-                datetime.utcnow() + timedelta(seconds=expires_in)
-                if expires_in > 0
-                else None
-            )
+            if expires_in <= 0:
+                logger.warning(
+                    "Twitch token validation did not include a usable expires_in; "
+                    "using default manual token lifetime"
+                )
+                expires_in = self.DEFAULT_MANUAL_TOKEN_EXPIRES_IN_SECONDS
+
+            expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
 
             global_settings.twitch_access_token = self.encryption.encrypt(clean_token)
             global_settings.twitch_token_expires_at = expires_at
@@ -390,6 +397,54 @@ class TwitchTokenService:
             logger.error(f"Error storing manual Twitch token: {e}")
             self.db.rollback()
             return False, validation
+
+    async def revalidate_stored_manual_token(
+        self, global_settings: GlobalSettings
+    ) -> bool:
+        """Live-validate a stored manual browser token and repair its expiry.
+
+        Manual browser tokens do not have refresh tokens. Older installs may
+        have a valid encrypted token with a missing or stale expiry timestamp,
+        which makes the UI report "Browser Token Expired" even though Twitch
+        still accepts the token. This method validates the decrypted token with
+        Twitch and updates the stored expiry from the validation response.
+
+        Returns True when Twitch confirms the token is currently valid.
+        """
+        if (
+            not global_settings
+            or not global_settings.twitch_access_token
+            or global_settings.twitch_refresh_token
+        ):
+            return False
+
+        try:
+            access_token = self.encryption.decrypt(global_settings.twitch_access_token)
+            if not access_token:
+                return False
+
+            validation = await self.validate_token(access_token)
+            if not validation:
+                return False
+
+            expires_in = int(validation.get("expires_in") or 0)
+            if expires_in <= 0:
+                logger.warning(
+                    "Twitch token revalidation did not include a usable expires_in; "
+                    "using default manual token lifetime"
+                )
+                expires_in = self.DEFAULT_MANUAL_TOKEN_EXPIRES_IN_SECONDS
+
+            global_settings.twitch_token_expires_at = datetime.utcnow() + timedelta(
+                seconds=expires_in
+            )
+            self.db.commit()
+
+            return True
+        except Exception as e:
+            logger.error(f"Error revalidating stored manual Twitch token: {e}")
+            self.db.rollback()
+            return False
 
     async def _send_expiry_notification_if_needed(
         self, global_settings: GlobalSettings, expired: bool = False

--- a/tests/test_twitch_connection_status.py
+++ b/tests/test_twitch_connection_status.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
-from app.routes.twitch_auth import _build_connection_status
+import pytest
+
+from app.routes.twitch_auth import _build_connection_status, get_connection_status
 
 
 def test_connection_status_uses_env_when_manual_database_token_is_expired():
@@ -54,3 +56,99 @@ def test_connection_status_keeps_expired_manual_database_status_without_env_fall
     assert status["expires_at"] == expires_at.isoformat()
     assert status["source"] == "database_manual"
     assert status["has_env_token"] is False
+
+
+class _Query:
+    def __init__(self, value):
+        self.value = value
+
+    def first(self):
+        return self.value
+
+
+class _Db:
+    def __init__(self, settings):
+        self.settings = settings
+
+    def query(self, _model):
+        return _Query(self.settings)
+
+
+class _SessionContext:
+    def __init__(self, db):
+        self.db = db
+
+    def __enter__(self):
+        return self.db
+
+    def __exit__(self, *_args):
+        return False
+
+
+async def _fake_revalidate(_service, global_settings):
+    global_settings.twitch_token_expires_at = datetime.utcnow() + timedelta(days=30)
+    return True
+
+
+async def _fake_failed_revalidate(_service, _global_settings):
+    return False
+
+
+async def _call_connection_status(monkeypatch, stored, env_token, revalidate):
+    import app.config.settings as settings_module
+    import app.database as database_module
+    from app.services.system.twitch_token_service import TwitchTokenService
+
+    monkeypatch.setattr(settings_module.settings, "TWITCH_OAUTH_TOKEN", env_token)
+    monkeypatch.setattr(
+        database_module, "SessionLocal", lambda: _SessionContext(_Db(stored))
+    )
+    monkeypatch.setattr(
+        TwitchTokenService, "revalidate_stored_manual_token", revalidate
+    )
+
+    return await get_connection_status()
+
+
+@pytest.mark.asyncio
+async def test_connection_status_repairs_valid_stale_manual_token_before_env_fallback(
+    monkeypatch,
+):
+    stored = SimpleNamespace(
+        twitch_access_token="encrypted-new-browser-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() - timedelta(days=1),
+    )
+
+    status = await _call_connection_status(
+        monkeypatch, stored, "env-browser-token", _fake_revalidate
+    )
+
+    assert status["connected"] is True
+    assert status["valid"] is True
+    assert status["source"] == "database_manual"
+    assert status["has_env_token"] is True
+    assert status["expires_at"] == stored.twitch_token_expires_at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_connection_status_reports_env_when_stale_manual_token_revalidation_fails(
+    monkeypatch,
+):
+    stored = SimpleNamespace(
+        twitch_access_token="encrypted-old-browser-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() - timedelta(days=1),
+    )
+
+    status = await _call_connection_status(
+        monkeypatch, stored, "env-browser-token", _fake_failed_revalidate
+    )
+
+    assert status == {
+        "connected": True,
+        "valid": True,
+        "expires_at": None,
+        "source": "environment",
+        "has_env_token": True,
+    }

--- a/tests/test_twitch_token_service.py
+++ b/tests/test_twitch_token_service.py
@@ -141,3 +141,133 @@ async def test_store_manual_access_token_encrypts_and_clears_refresh_token(monke
     assert stored.twitch_token_expires_at is not None
     assert service.settings.TWITCH_OAUTH_TOKEN is None
     assert service.db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_store_manual_access_token_uses_default_expiry_when_expires_in_missing(
+    monkeypatch,
+):
+    stored = SimpleNamespace(
+        twitch_access_token=None,
+        twitch_refresh_token="enc:old-refresh",
+        twitch_token_expires_at=None,
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN=None)
+    service.encryption = _Encryption()
+
+    async def _validate(token):
+        assert token == "manual-token"
+        return {"client_id": "client", "login": "user"}
+
+    monkeypatch.setattr(service, "validate_token", _validate)
+
+    success, validation = await service.store_manual_access_token("manual-token")
+
+    assert success is True
+    assert validation == {"client_id": "client", "login": "user"}
+    assert stored.twitch_access_token == "enc:manual-token"
+    assert stored.twitch_refresh_token is None
+    assert stored.twitch_token_expires_at > datetime.utcnow() + timedelta(days=59)
+    assert service.db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_store_manual_access_token_uses_default_expiry_when_expires_in_zero(
+    monkeypatch,
+):
+    stored = SimpleNamespace(
+        twitch_access_token=None,
+        twitch_refresh_token="enc:old-refresh",
+        twitch_token_expires_at=None,
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN=None)
+    service.encryption = _Encryption()
+
+    async def _validate(_token):
+        return {"expires_in": 0}
+
+    monkeypatch.setattr(service, "validate_token", _validate)
+
+    success, validation = await service.store_manual_access_token("manual-token")
+
+    assert success is True
+    assert validation == {"expires_in": 0}
+    assert stored.twitch_token_expires_at > datetime.utcnow() + timedelta(days=59)
+    assert service.db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_revalidate_stored_manual_token_repairs_stale_expiry(monkeypatch):
+    stored = SimpleNamespace(
+        twitch_access_token="enc:manual-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() - timedelta(days=1),
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN=None)
+    service.encryption = _Encryption()
+
+    async def _validate(token):
+        assert token == "manual-token"
+        return {"expires_in": 7200}
+
+    monkeypatch.setattr(service, "validate_token", _validate)
+
+    assert await service.revalidate_stored_manual_token(stored) is True
+    assert stored.twitch_token_expires_at > datetime.utcnow() + timedelta(hours=1)
+    assert service.db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_revalidate_stored_manual_token_uses_default_expiry_when_expires_in_missing(
+    monkeypatch,
+):
+    stored = SimpleNamespace(
+        twitch_access_token="enc:manual-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() - timedelta(days=1),
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN=None)
+    service.encryption = _Encryption()
+
+    async def _validate(token):
+        assert token == "manual-token"
+        return {"client_id": "client", "login": "user"}
+
+    monkeypatch.setattr(service, "validate_token", _validate)
+
+    assert await service.revalidate_stored_manual_token(stored) is True
+    assert stored.twitch_token_expires_at > datetime.utcnow() + timedelta(days=59)
+    assert service.db.committed is True
+
+
+@pytest.mark.asyncio
+async def test_revalidate_stored_manual_token_keeps_stale_expiry_when_invalid(
+    monkeypatch,
+):
+    stale_expiry = datetime.utcnow() - timedelta(days=1)
+    stored = SimpleNamespace(
+        twitch_access_token="enc:manual-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=stale_expiry,
+    )
+    service = TwitchTokenService.__new__(TwitchTokenService)
+    service.db = _Db(stored)
+    service.settings = SimpleNamespace(TWITCH_OAUTH_TOKEN=None)
+    service.encryption = _Encryption()
+
+    async def _validate(_token):
+        return None
+
+    monkeypatch.setattr(service, "validate_token", _validate)
+
+    assert await service.revalidate_stored_manual_token(stored) is False
+    assert stored.twitch_token_expires_at == stale_expiry
+    assert service.db.committed is False


### PR DESCRIPTION
## Summary
- Repair manual Twitch browser token expiry when validation has missing or zero `expires_in`
- Live-validate stale stored manual browser tokens before showing env fallback status
- Add regression coverage for save-time expiry fallback and connection status repair

## Test Plan
- `python -m pytest tests/test_twitch_token_service.py tests/test_twitch_connection_status.py -q`
- `opencode run ...` focused review, result: `14 passed`

## Notes
- Existing unrelated untracked files were left untouched and unstaged.
