### PR TITLE
fix: stop PR release drafts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,9 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - main  # Only on main, not develop
-  pull_request_target:  # Uses pull_request_target instead of pull_request
-    types: [opened, reopened, synchronize]
+      - main
 
 permissions:
   contents: read

--- a/app/frontend/src/components/settings/TwitchConnectionPanel.vue
+++ b/app/frontend/src/components/settings/TwitchConnectionPanel.vue
@@ -550,6 +550,7 @@ function formatSource(source: string): string {
 .detail-item {
   display: flex;
   justify-content: space-between;
+  gap: v.$spacing-4;
   font-size: v.$text-sm;
   
   &:not(:last-child) {
@@ -558,6 +559,7 @@ function formatSource(source: string): string {
 }
 
 .detail-label {
+  flex-shrink: 0;
   color: var(--text-secondary);
   font-weight: v.$font-medium;
 }
@@ -565,6 +567,7 @@ function formatSource(source: string): string {
 .detail-value {
   color: var(--text-primary);
   font-weight: v.$font-semibold;
+  text-align: right;
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- Removes the Release Drafter `pull_request_target` trigger so PR updates stop creating or refreshing draft releases.
- Keeps Release Drafter limited to pushes on `main`.
- Adds spacing between labels and values in the Twitch connection status details so long `Source` values are not cramped.

## Testing
- `git diff --check`
- YAML parsed for `.github/workflows/release-drafter.yml` and `.github/release-drafter.yml`
- `npm run build` in `app/frontend`
