### PR TITLE
ci: fix stale frontend cache causing missing live streaming fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,18 +207,15 @@ jobs:
         id: frontend-cache
         uses: actions/cache@v6
         with:
-          path: |
-            app/frontend/dist
-            app/frontend/node_modules
-          key: frontend-build-${{ hashFiles('app/frontend/package-lock.json', 'app/frontend/src/**') }}
+          path: app/frontend/node_modules
+          key: frontend-build-${{ hashFiles('app/frontend/package-lock.json') }}
           restore-keys: |
             frontend-build-
 
       - name: Build Frontend
-        if: steps.frontend-cache.outputs.cache-hit != 'true'
         working-directory: app/frontend
         run: |
-          npm ci
+          npm ci --no-audit
           rm -rf dist || true
           npm run build
 


### PR DESCRIPTION
### Problem
The CI workflow skipped the frontend build when a cache hit occurred. However, the `restore-keys` prefix fallback could restore an old `dist/` directory from a different branch or previous build, resulting in stale frontend code being shipped even when the backend contained fresh fixes.

### Changes
- Cache only `node_modules` (not `dist`)
- Always run `npm run build` to guarantee fresh `dist/`
- Remove the `cache-hit != true` guard that was causing the skip

### Impact
Frontend builds remain fast because `node_modules` are cached, but `dist/` is always rebuilt from current source. This prevents the live streaming UI fixes from being silently dropped again.