### PR TITLE
fix: race condition in LivePlayerView causing eternal buffering

### DIFF
--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -162,7 +162,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import LoadingSkeleton from '@/components/LoadingSkeleton.vue'
 import EmptyState from '@/components/EmptyState.vue'
@@ -259,7 +259,13 @@ const startStream = async () => {
     sessionId.value = response.session_id
     streamInfo.value = response
 
-    // Wait a moment for the playlist to be generated
+    // CRITICAL FIX: Set loading false BEFORE initPlayer so videoElement exists in DOM
+    isLoading.value = false
+
+    // Wait for Vue to render the player block (videoElement must exist)
+    await nextTick()
+
+    // Small delay to ensure HLS playlist exists on backend
     await new Promise(r => setTimeout(r, 1500))
 
     await initPlayer(response.session_id)
@@ -269,7 +275,10 @@ const startStream = async () => {
     sessionId.value = null
     streamInfo.value = null
   } finally {
-    isLoading.value = false
+    // Ensure loading is cleared in error cases too (success path clears it above)
+    if (!sessionId.value) {
+      isLoading.value = false
+    }
   }
 }
 

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -270,11 +270,15 @@ class LiveStreamingService:
 
     async def _wait_for_playlist(self, playlist_path: Path, timeout: int = 15) -> bool:
         """Poll until the HLS playlist file exists or timeout is reached."""
+        logger.info(f"[LIVE] Waiting for HLS playlist to appear: {playlist_path}")
         deadline = asyncio.get_event_loop().time() + timeout
         while asyncio.get_event_loop().time() < deadline:
             if playlist_path.exists() and playlist_path.stat().st_size > 0:
+                elapsed = timeout - (deadline - asyncio.get_event_loop().time())
+                logger.info(f"[LIVE] HLS playlist ready after {elapsed:.1f}s")
                 return True
             await asyncio.sleep(0.5)
+        logger.warning(f"[LIVE] HLS playlist did not appear within {timeout}s: {playlist_path}")
         return False
 
     async def _log_stderr(


### PR DESCRIPTION
### Problem
The frontend set `sessionId` and called `initPlayer()` while `isLoading` was still `true`. Vue rendered the Loading block instead of the Player block, so `videoElement` ref was null. `initPlayer()` silently returned due to the null check, but no error was shown. `isLoading` was only set to false AFTER `initPlayer()` completed, leaving a permanently buffering empty video element.

### Root Cause
`startStream()`:
1. Set `sessionId`
2. Wait 1.5s
3. Call `initPlayer()" -\- while `isLoading == true`
4. Vue renders Loading block, not Player block
5. `initPlayer()` returns immediately: `if (!videoElement.value) return`
6. No HLS instance created, no playlist request made
7. `finally` block: `isLoading = false`
8. Player block appears, but nothing to play → eternal buffering

### Changes
- Set `isLoading = false` BEFORE calling `initPlayer()`
- Use `nextTick()` to ensure DOM is updated and `videoElement` exists
- Add backend logs for `_wait_for_playlist()` diagnostics
- Keep finally-block cleanup for error cases

### Verification
After merge and deployment, the browser should make GET requests to `/api/live/stream/{id}/playlist.m3u8` (visible in backend logs).