### PR TITLE
style: fix ruff formatting in live_streaming_service.py

### DIFF
--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -278,7 +278,9 @@ class LiveStreamingService:
                 logger.info(f"[LIVE] HLS playlist ready after {elapsed:.1f}s")
                 return True
             await asyncio.sleep(0.5)
-        logger.warning(f"[LIVE] HLS playlist did not appear within {timeout}s: {playlist_path}")
+        logger.warning(
+            f"[LIVE] HLS playlist did not appear within {timeout}s: {playlist_path}"
+        )
         return False
 
     async def _log_stderr(


### PR DESCRIPTION
The warning log line in `_wait_for_playlist()` exceeded 88 chars and was not wrapped properly, causing the CI lint check to fail.