### PR TITLE
Add adaptive live player codec selection

### DIFF
--- a/app/frontend/src/services/api-real.ts
+++ b/app/frontend/src/services/api-real.ts
@@ -501,8 +501,14 @@ export const filenamePresetsApi = {
 // Live Streaming API endpoints
 export const liveApi = {
   // Start a live stream for a streamer
-  startLiveStream: (streamerName: string, quality: string = 'best') =>
-    apiClient.post(`/api/live/start/${streamerName}`, { quality }),
+  startLiveStream: (
+    streamerName: string,
+    quality: string = 'best',
+    supportedCodecs: string = 'h264'
+  ) => apiClient.post(`/api/live/start/${streamerName}`, {
+    quality,
+    supported_codecs: supportedCodecs
+  }),
 
   // Stop a live stream session
   stopLiveStream: (sessionId: string) =>

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -224,11 +224,16 @@ const mockFilenamePresetsApi = {
 }
 
 const mockLiveApi = {
-  startLiveStream: (streamerName: string, _quality: string = 'best') => mockResponse({
+  startLiveStream: (
+    streamerName: string,
+    quality: string = 'best',
+    supportedCodecs: string = 'h264'
+  ) => mockResponse({
     success: true,
     session_id: `mock-live-${Date.now()}`,
     streamer_name: streamerName,
-    quality: 'best',
+    quality,
+    supported_codecs: supportedCodecs,
     playlist_url: '/api/live/stream/mock/playlist.m3u8',
     message: 'Stream started (mock)'
   }),

--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -131,6 +131,14 @@
                 <span class="info-value">{{ selectedQualityLabel }}</span>
               </div>
               <div class="info-row">
+                <span class="info-label">Codec Mode</span>
+                <span class="info-value">{{ codecModeLabel }}</span>
+              </div>
+              <div class="info-row">
+                <span class="info-label">Codecs</span>
+                <span class="info-value">{{ activeSupportedCodecs }}</span>
+              </div>
+              <div class="info-row">
                 <span class="info-label">Status</span>
                 <span class="info-value" :class="{ 'text-live': isPlaying && !isBuffering }">
                   {{ streamStatusText }}
@@ -147,6 +155,21 @@
               Actions
             </h3>
             <div class="action-buttons">
+              <label class="codec-selector">
+                <span class="codec-selector-label">Live codec</span>
+                <select
+                  v-model="codecMode"
+                  class="codec-select"
+                  :disabled="isLoading || isStopping"
+                  @change="restartWithCodecMode"
+                >
+                  <option value="auto">Auto detect</option>
+                  <option value="h264">H264 compatibility</option>
+                  <option value="hevc">HEVC/1440p experimental</option>
+                </select>
+              </label>
+              <p class="codec-hint">{{ codecHint }}</p>
+
               <button class="action-btn danger" @click="stopStream" :disabled="isStopping" v-ripple>
                 <svg class="action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
@@ -182,6 +205,14 @@ interface HlsLevel {
   bitrate?: number
 }
 
+type LiveCodecMode = 'auto' | 'h264' | 'hevc'
+
+interface LiveCodecSelection {
+  supportedCodecs: string
+  useNativeHls: boolean
+  hevcSupported: boolean
+}
+
 const route = useRoute()
 const router = useRouter()
 
@@ -202,6 +233,14 @@ const qualityLevels = ref<Array<{ name: string; index: number }>>([])
 const selectedQuality = ref<string | number>('-1')
 const retryCount = ref(0)
 const retryTimer = ref<number | null>(null)
+const codecMode = ref<LiveCodecMode>(
+  ((route.query.codec as LiveCodecMode) ||
+    localStorage.getItem('streamvault-live-codec-mode') ||
+    'auto') as LiveCodecMode
+)
+const activeSupportedCodecs = ref('h264')
+const preferNativeHls = ref(false)
+const hevcSupported = ref(false)
 
 // Refs
 const videoElement = ref<HTMLVideoElement | null>(null)
@@ -224,11 +263,70 @@ const streamStatusText = computed(() => {
   return 'Connecting'
 })
 
+const codecModeLabel = computed(() => {
+  if (codecMode.value === 'h264') return 'H264 compatibility'
+  if (codecMode.value === 'hevc') return 'HEVC/1440p experimental'
+  return hevcSupported.value ? 'Auto (HEVC enabled)' : 'Auto (H264 fallback)'
+})
+
+const codecHint = computed(() => {
+  if (codecMode.value === 'h264') {
+    return 'Most compatible; caps live playback to H264-compatible qualities.'
+  }
+  if (codecMode.value === 'hevc') {
+    return 'Tries Twitch HEVC/1440p. If video is black, switch back to H264.'
+  }
+  return hevcSupported.value
+    ? 'HEVC appears supported here; Auto will allow 1440p/HEVC.'
+    : 'HEVC is not supported by this playback pipeline; Auto uses H264.'
+})
+
 // Load hls.js (bundled locally, no CDN dependency)
 import Hls from 'hls.js'
 
 const loadHlsJs = (): Promise<any> => {
   return Promise.resolve(Hls)
+}
+
+const canUseNativeHls = (): boolean => {
+  const video = document.createElement('video')
+  return Boolean(video.canPlayType('application/vnd.apple.mpegurl'))
+}
+
+const canUseHevcWithMse = (): boolean => {
+  if (typeof MediaSource === 'undefined') return false
+
+  const hevcCodecStrings = [
+    'video/mp4; codecs="hvc1.1.6.L120.90, mp4a.40.2"',
+    'video/mp4; codecs="hev1.1.6.L120.90, mp4a.40.2"',
+    'video/mp4; codecs="hvc1.1.6.L123.B0, mp4a.40.2"',
+    'video/mp4; codecs="hev1.1.6.L123.B0, mp4a.40.2"'
+  ]
+
+  return hevcCodecStrings.some(codec => MediaSource.isTypeSupported(codec))
+}
+
+const resolveLiveCodecSelection = (): LiveCodecSelection => {
+  const nativeHls = canUseNativeHls()
+  const mseHevc = canUseHevcWithMse()
+  const supportsHevc = nativeHls || mseHevc
+  const mode = ['auto', 'h264', 'hevc'].includes(codecMode.value)
+    ? codecMode.value
+    : 'auto'
+
+  hevcSupported.value = supportsHevc
+
+  if (mode === 'h264') {
+    return { supportedCodecs: 'h264', useNativeHls: false, hevcSupported: supportsHevc }
+  }
+
+  if (mode === 'hevc') {
+    return { supportedCodecs: 'h264,h265', useNativeHls: nativeHls, hevcSupported: supportsHevc }
+  }
+
+  return supportsHevc
+    ? { supportedCodecs: 'h264,h265', useNativeHls: nativeHls, hevcSupported: supportsHevc }
+    : { supportedCodecs: 'h264', useNativeHls: false, hevcSupported: supportsHevc }
 }
 
 // Start stream
@@ -240,7 +338,16 @@ const startStream = async () => {
     sessionId.value = null
 
     const quality = (route.query.quality as string) || 'best'
-    const response = await liveApi.startLiveStream(streamerName.value, quality)
+    const codecSelection = resolveLiveCodecSelection()
+    activeSupportedCodecs.value = codecSelection.supportedCodecs
+    preferNativeHls.value = codecSelection.useNativeHls
+    localStorage.setItem('streamvault-live-codec-mode', codecMode.value)
+
+    const response = await liveApi.startLiveStream(
+      streamerName.value,
+      quality,
+      codecSelection.supportedCodecs
+    )
 
     if (!response.success || !response.session_id) {
       throw new Error(response.message || 'Failed to start stream')
@@ -258,7 +365,7 @@ const startStream = async () => {
     // Small delay to ensure HLS playlist exists on backend
     await new Promise(r => setTimeout(r, 1500))
 
-    await initPlayer(response.session_id)
+    await initPlayer(response.session_id, codecSelection.useNativeHls)
   } catch (err: any) {
     console.error('Error starting stream:', err)
     error.value = err instanceof Error ? err.message : 'Failed to start live stream'
@@ -273,14 +380,21 @@ const startStream = async () => {
 }
 
 // Initialize HLS player
-const initPlayer = async (sid: string) => {
+const initPlayer = async (sid: string, useNativeHls: boolean = preferNativeHls.value) => {
   if (!videoElement.value) return
 
   try {
     const Hls = await loadHlsJs()
     const playlistUrl = liveApi.getPlaylistUrl(sid)
 
-    if (Hls.isSupported()) {
+    if (useNativeHls && videoElement.value.canPlayType('application/vnd.apple.mpegurl')) {
+      // Native HLS is preferred for HEVC-capable Safari/WebKit pipelines.
+      hlsInstance.value = null
+      videoElement.value.src = playlistUrl
+      videoElement.value.addEventListener('loadedmetadata', () => {
+        videoElement.value?.play().catch(() => {})
+      }, { once: true })
+    } else if (Hls.isSupported()) {
       const hls = new Hls({
         enableWorker: true,
         lowLatencyMode: true,
@@ -399,6 +513,29 @@ const retryStart = () => {
     retryTimer.value = null
   }
   startStream()
+}
+
+const restartWithCodecMode = async () => {
+  localStorage.setItem('streamvault-live-codec-mode', codecMode.value)
+  router.replace({
+    query: {
+      ...route.query,
+      codec: codecMode.value
+    }
+  }).catch(() => {})
+
+  const currentSessionId = sessionId.value
+  destroyPlayer()
+  sessionId.value = null
+  streamInfo.value = null
+  isPlaying.value = false
+  isBuffering.value = false
+
+  if (currentSessionId) {
+    await liveApi.stopLiveStream(currentSessionId).catch(() => {})
+  }
+
+  await startStream()
 }
 
 // Auto-retry logic
@@ -966,6 +1103,37 @@ onUnmounted(() => {
   @include m.respond-below('sm') {
     gap: var(--spacing-2);
   }
+}
+
+.codec-selector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.codec-selector-label {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: v.$font-medium;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.codec-select {
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--background-darker);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.codec-hint {
+  margin: calc(var(--spacing-2) * -1) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.4;
 }
 
 .action-btn {

--- a/app/routes/live.py
+++ b/app/routes/live.py
@@ -12,6 +12,7 @@ Endpoints:
 """
 
 import logging
+from typing import Optional
 
 from fastapi import (
     APIRouter,
@@ -20,6 +21,7 @@ from fastapi import (
     Request,
 )
 from fastapi.responses import FileResponse
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -30,6 +32,11 @@ from app.services.live_streaming_service import live_streaming_service
 logger = logging.getLogger("streamvault")
 
 router = APIRouter(prefix="/api/live", tags=["live"])
+
+
+class LiveStartRequest(BaseModel):
+    quality: Optional[str] = None
+    supported_codecs: Optional[str] = None
 
 
 @router.post("/start/{streamer_name}")
@@ -51,6 +58,18 @@ async def start_live_stream(
         {"session_id": str, "playlist_url": str, "streamer_name": str}
     """
     try:
+        body = LiveStartRequest()
+        if request.headers.get("content-type", "").startswith("application/json"):
+            try:
+                payload = await request.json()
+                if isinstance(payload, dict):
+                    body = LiveStartRequest(**payload)
+            except Exception:
+                logger.debug("[LIVE] Ignoring invalid JSON body for live start")
+
+        requested_quality = body.quality or quality
+        supported_codecs = body.supported_codecs or "h264"
+
         # Verify streamer exists
         streamer = db.query(Streamer).filter(Streamer.username == streamer_name).first()
         if not streamer:
@@ -65,7 +84,8 @@ async def start_live_stream(
         user_id = str(current_user.id) if current_user else None
         session_id = await live_streaming_service.start_stream(
             streamer_name=streamer_name,
-            quality=quality,
+            quality=requested_quality,
+            supported_codecs=supported_codecs,
             user_id=user_id,
         )
 
@@ -79,7 +99,10 @@ async def start_live_stream(
             "success": True,
             "session_id": session_id,
             "streamer_name": streamer_name,
-            "quality": quality,
+            "quality": requested_quality,
+            "supported_codecs": live_streaming_service._normalize_supported_codecs(
+                supported_codecs
+            ),
             "playlist_url": playlist_url,
             "message": "Stream started successfully",
         }

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -124,6 +124,7 @@ class LiveStreamingService:
         self,
         streamer_name: str,
         quality: str = "best",
+        supported_codecs: str = "h264",
         user_id: Optional[str] = None,
     ) -> str:
         """
@@ -132,6 +133,7 @@ class LiveStreamingService:
         Args:
             streamer_name: Twitch username to stream
             quality: Stream quality (best, 1080p, 720p, etc.)
+            supported_codecs: Comma-separated Twitch codecs supported by the player
             user_id: Optional user ID for session tracking
 
         Returns:
@@ -178,7 +180,7 @@ class LiveStreamingService:
         try:
             # Get fresh OAuth token and proxy settings
             streamlink_cmd = await self._build_streamlink_command(
-                streamer_name, quality
+                streamer_name, quality, supported_codecs=supported_codecs
             )
 
             # Build FFmpeg HLS command
@@ -186,7 +188,8 @@ class LiveStreamingService:
 
             logger.info(
                 f"[LIVE] Starting stream session {session_id} for {streamer_name} "
-                f"(quality: {quality})"
+                f"(quality: {quality}, codecs: "
+                f"{self._normalize_supported_codecs(supported_codecs)})"
             )
 
             # Start FFmpeg first (reads from stdin)
@@ -385,8 +388,28 @@ class LiveStreamingService:
             "playlist_url": f"/api/live/stream/{session_id}/playlist.m3u8",
         }
 
-    async def _build_streamlink_command(self, streamer_name: str, quality: str) -> list:
+    @staticmethod
+    def _normalize_supported_codecs(supported_codecs: str) -> str:
+        """Normalize live-player codec list to Streamlink's supported Twitch codecs."""
+        allowed = {"h264", "h265", "av1"}
+        codecs = []
+        for codec in (supported_codecs or "h264").split(","):
+            normalized = codec.strip().lower()
+            if normalized in allowed and normalized not in codecs:
+                codecs.append(normalized)
+
+        # Compatibility-first fallback: never let recording config leak into live
+        # playback implicitly. HEVC/AV1 must be requested by the browser/player.
+        return ",".join(codecs) if codecs else "h264"
+
+    async def _build_streamlink_command(
+        self,
+        streamer_name: str,
+        quality: str,
+        supported_codecs: str = "h264",
+    ) -> list:
         """Build Streamlink command for live streaming (no file output)"""
+        normalized_codecs = self._normalize_supported_codecs(supported_codecs)
         cmd = [
             "streamlink",
             "--config",
@@ -394,10 +417,9 @@ class LiveStreamingService:
             f"twitch.tv/{streamer_name}",
             quality,
             "--stdout",  # Output to stdout instead of file
-            # Force H.264 only for live playback: browsers cannot decode H.265/HEVC
-            # via Media Source Extensions (hls.js + MSE). H.265 is fine for file
-            # recordings but causes audio-only playback in the browser player.
-            "--twitch-supported-codecs=h264",
+            # Live playback must use the codecs the current browser/player pipeline
+            # can actually decode. Recordings may still use the global codec config.
+            f"--twitch-supported-codecs={normalized_codecs}",
         ]
 
         # Get fresh OAuth token

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -394,6 +394,10 @@ class LiveStreamingService:
             f"twitch.tv/{streamer_name}",
             quality,
             "--stdout",  # Output to stdout instead of file
+            # Force H.264 only for live playback: browsers cannot decode H.265/HEVC
+            # via Media Source Extensions (hls.js + MSE). H.265 is fine for file
+            # recordings but causes audio-only playback in the browser player.
+            "--twitch-supported-codecs=h264",
         ]
 
         # Get fresh OAuth token

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -66,6 +66,23 @@ def test_live_streaming_service_init():
     assert svc.user_sessions == {}
 
 
+def test_normalize_supported_codecs_for_live_playback():
+    """Test live codec normalization keeps recordings config out of live playback."""
+    from app.services.live_streaming_service import LiveStreamingService
+
+    assert LiveStreamingService._normalize_supported_codecs("h264") == "h264"
+    assert LiveStreamingService._normalize_supported_codecs("h264,h265") == "h264,h265"
+    assert (
+        LiveStreamingService._normalize_supported_codecs(" h265 , h264 ") == "h265,h264"
+    )
+    assert (
+        LiveStreamingService._normalize_supported_codecs("h264,h264,h265")
+        == "h264,h265"
+    )
+    assert LiveStreamingService._normalize_supported_codecs("vp9,unknown") == "h264"
+    assert LiveStreamingService._normalize_supported_codecs("") == "h264"
+
+
 def test_build_ffmpeg_command_structure():
     """Test FFmpeg command contains required arguments"""
     from app.services.live_streaming_service import LiveStreamingService


### PR DESCRIPTION
## Summary
- add live-player codec modes: Auto detect, H264 compatibility, and HEVC/1440p experimental
- detect native HLS and HEVC/MSE support before starting a live session
- pass the browser-supported codec list to the backend per live session instead of always inheriting recording codecs
- keep recordings unchanged; only live playback Streamlink commands get per-session codecs

## Testing
- uvx ruff format app/services/live_streaming_service.py app/routes/live.py tests/test_live_streaming.py
- uvx ruff check app/services/live_streaming_service.py app/routes/live.py tests/test_live_streaming.py
- npm run build
- uv run --with pytest --with fastapi==0.138.1 --with 'SQLAlchemy==2.0.51' --with 'psycopg[binary]==3.3.4' --with pydantic-settings==2.14.2 --with aiohttp==3.14.1 --with cachetools==7.1.4 --with argon2-cffi==25.1.0 --with cryptography==49.0.0 --with python-dotenv==1.2.2 --with aiofiles==25.1.0 --with pillow==12.2.0 --with psutil==7.2.2 --with apprise==1.11.0 pytest tests/test_live_streaming.py tests/test_streamlink_command_format.py -q