### PR TITLE
Fix live player duplicate sessions and fullscreen UI

### DIFF
--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -58,16 +58,6 @@
               <p>Buffering...</p>
             </div>
 
-            <!-- Quality Selector -->
-            <div class="quality-selector" v-if="hlsInstance && qualityLevels.length > 0">
-              <select v-model="selectedQuality" @change="changeQuality" class="quality-select">
-                <option value="-1">Auto</option>
-                <option v-for="(level, index) in qualityLevels" :key="index" :value="index">
-                  {{ level.name }}
-                </option>
-              </select>
-            </div>
-
             <!-- Controls Overlay -->
             <div class="live-controls-overlay">
               <div class="controls-bottom">
@@ -224,6 +214,7 @@ const error = ref<string | null>(null)
 const sessionId = ref<string | null>(null)
 const streamInfo = ref<any>(null)
 const isStopping = ref(false)
+const isStarting = ref(false)
 const isBuffering = ref(false)
 const isPlaying = ref(false)
 const isMuted = ref(true)
@@ -252,7 +243,10 @@ const sessionIdShort = computed(() => {
 })
 
 const selectedQualityLabel = computed(() => {
-  if (selectedQuality.value === '-1') return 'Auto'
+  if (selectedQuality.value === '-1') {
+    const requestedQuality = streamInfo.value?.quality
+    return requestedQuality && requestedQuality !== 'best' ? requestedQuality : 'Auto'
+  }
   const level = qualityLevels.value.find(l => l.index === Number(selectedQuality.value))
   return level ? level.name : 'Auto'
 })
@@ -331,7 +325,10 @@ const resolveLiveCodecSelection = (): LiveCodecSelection => {
 
 // Start stream
 const startStream = async () => {
+  if (isStarting.value) return
+
   try {
+    isStarting.value = true
     isLoading.value = true
     error.value = null
     retryCount.value = 0
@@ -376,6 +373,7 @@ const startStream = async () => {
     if (!sessionId.value) {
       isLoading.value = false
     }
+    isStarting.value = false
   }
 }
 
@@ -408,11 +406,15 @@ const initPlayer = async (sid: string, useNativeHls: boolean = preferNativeHls.v
 
       hls.on(Hls.Events.MANIFEST_PARSED, (_event: string, data: any) => {
         isBuffering.value = false
-        // Build quality levels
+        // StreamVault remuxes one selected Twitch rendition into a local HLS stream.
+        // hls.js can report that single remuxed rendition as height=0 because the
+        // generated playlist has no adaptive RESOLUTION metadata. Do not surface
+        // those pseudo-levels as a broken "0p" quality picker.
         const levels: Array<{ name: string; index: number }> = []
         if (data.levels) {
           data.levels.forEach((level: HlsLevel, index: number) => {
             const height = level.height || 0
+            if (height <= 0) return
             const name = height >= 1080 ? '1080p' : height >= 720 ? '720p' : height >= 480 ? '480p' : `${height}p`
             levels.push({ name, index })
           })
@@ -480,13 +482,6 @@ const destroyPlayer = () => {
   qualityLevels.value = []
 }
 
-// Quality change
-const changeQuality = () => {
-  if (!hlsInstance.value) return
-  const level = Number(selectedQuality.value)
-  hlsInstance.value.currentLevel = level
-}
-
 // Stop stream
 const stopStream = async () => {
   if (!sessionId.value || isStopping.value) return
@@ -516,6 +511,8 @@ const retryStart = () => {
 }
 
 const restartWithCodecMode = async () => {
+  if (isStarting.value || isStopping.value) return
+
   localStorage.setItem('streamvault-live-codec-mode', codecMode.value)
   router.replace({
     query: {
@@ -829,11 +826,27 @@ onUnmounted(() => {
     margin: 0;
     aspect-ratio: 16/9;
   }
+
+  &:fullscreen {
+    width: 100vw;
+    height: 100vh;
+    max-width: none;
+    margin: 0;
+    aspect-ratio: auto;
+    background: var(--background-darker);
+  }
+
+  &:fullscreen .video-element {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    object-fit: contain;
+  }
 }
 
 .video-element {
   width: 100%;
-  height: auto;
+  height: 100%;
   display: block;
   background: var(--background-darker);
   object-fit: contain;
@@ -896,29 +909,6 @@ onUnmounted(() => {
 
 @keyframes spin {
   to { transform: rotate(360deg); }
-}
-
-.quality-selector {
-  position: absolute;
-  top: var(--spacing-3);
-  right: var(--spacing-3);
-  z-index: 15;
-}
-
-.quality-select {
-  background: rgba(0, 0, 0, 0.7);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-1) var(--spacing-3);
-  font-size: var(--text-sm);
-  cursor: pointer;
-  backdrop-filter: blur(4px);
-
-  option {
-    background: var(--background-darker);
-    color: var(--text-primary);
-  }
 }
 
 .live-controls-overlay {

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -126,6 +126,7 @@ class LiveStreamingService:
         quality: str = "best",
         supported_codecs: str = "h264",
         user_id: Optional[str] = None,
+        replace_existing: bool = True,
     ) -> str:
         """
         Start a new live streaming session.
@@ -135,6 +136,7 @@ class LiveStreamingService:
             quality: Stream quality (best, 1080p, 720p, etc.)
             supported_codecs: Comma-separated Twitch codecs supported by the player
             user_id: Optional user ID for session tracking
+            replace_existing: Stop an existing live session for the same user/streamer
 
         Returns:
             session_id: Unique identifier for this streaming session
@@ -142,6 +144,9 @@ class LiveStreamingService:
         Raises:
             RuntimeError: If max concurrent streams reached or stream start fails
         """
+        if replace_existing and user_id:
+            await self._stop_existing_user_streams(user_id, streamer_name)
+
         async with self._lock:
             # Check global concurrent limit
             active_count = sum(1 for s in self.sessions.values() if s.is_active)
@@ -270,6 +275,28 @@ class LiveStreamingService:
                 ffmpeg_process.kill()
             shutil.rmtree(output_dir, ignore_errors=True)
             raise
+
+    async def _stop_existing_user_streams(
+        self, user_id: str, streamer_name: str
+    ) -> None:
+        """Stop older sessions for the same user and streamer before replacement."""
+        async with self._lock:
+            session_ids = [
+                session_id
+                for session_id, session in self.sessions.items()
+                if session.is_active
+                and session.user_id == user_id
+                and session.streamer_name.lower() == streamer_name.lower()
+            ]
+
+        for session_id in session_ids:
+            logger.info(
+                "[LIVE] Replacing existing session %s for user %s (%s)",
+                session_id,
+                user_id,
+                streamer_name,
+            )
+            await self.stop_stream(session_id)
 
     async def _wait_for_playlist(self, playlist_path: Path, timeout: int = 15) -> bool:
         """Poll until the HLS playlist file exists or timeout is reached."""

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -131,3 +131,45 @@ def test_stop_stream_not_found():
     svc = LiveStreamingService()
     result = asyncio.run(svc.stop_stream("nonexistent"))
     assert result is False
+
+
+def test_stop_existing_user_streams_replaces_same_streamer():
+    """Test replacement cleanup only stops matching user/streamer sessions."""
+    import asyncio
+    from app.services.live_streaming_service import (
+        LiveStreamingService,
+        LiveStreamSession,
+    )
+
+    svc = LiveStreamingService()
+
+    def make_session(session_id: str, streamer_name: str, user_id: str):
+        streamlink_process = MagicMock()
+        streamlink_process.returncode = 0
+        ffmpeg_process = MagicMock()
+        ffmpeg_process.returncode = 0
+        output_dir = MagicMock()
+        output_dir.exists.return_value = False
+        return LiveStreamSession(
+            session_id=session_id,
+            streamer_name=streamer_name,
+            quality="best",
+            streamlink_process=streamlink_process,
+            ffmpeg_process=ffmpeg_process,
+            output_dir=output_dir,
+            user_id=user_id,
+        )
+
+    svc.sessions = {
+        "old": make_session("old", "HandOfBlood", "user-1"),
+        "other-streamer": make_session("other-streamer", "maxim", "user-1"),
+        "other-user": make_session("other-user", "HandOfBlood", "user-2"),
+    }
+    svc.user_sessions = {"user-1": {"old", "other-streamer"}, "user-2": {"other-user"}}
+
+    asyncio.run(svc._stop_existing_user_streams("user-1", "handofblood"))
+
+    assert "old" not in svc.sessions
+    assert "old" not in svc.user_sessions["user-1"]
+    assert "other-streamer" in svc.sessions
+    assert "other-user" in svc.sessions


### PR DESCRIPTION
## Summary
- replace existing live sessions for the same user and streamer before starting a new one to avoid 429s during codec/player restarts
- guard against duplicate frontend start attempts
- remove the broken hls.js quality selector that showed 0p for the single remuxed live rendition
- keep only the bottom status quality label and fix fullscreen sizing so the video container fills the screen

## Testing
- uvx ruff format app/services/live_streaming_service.py tests/test_live_streaming.py
- uvx ruff check app/services/live_streaming_service.py tests/test_live_streaming.py
- npm run build
- uv run --with pytest --with fastapi==0.138.1 --with 'SQLAlchemy==2.0.51' --with 'psycopg[binary]==3.3.4' --with pydantic-settings==2.14.2 --with aiohttp==3.14.1 --with cachetools==7.1.4 --with argon2-cffi==25.1.0 --with cryptography==49.0.0 --with python-dotenv==1.2.2 --with aiofiles==25.1.0 --with pillow==12.2.0 --with psutil==7.2.2 --with apprise==1.11.0 pytest tests/test_live_streaming.py -q