### PR TITLE
Authenticate live HLS playlist requests

### DIFF
--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -282,6 +282,10 @@ const loadHlsJs = (): Promise<any> => {
   return Promise.resolve(Hls)
 }
 
+const getStoredSessionToken = (): string | null => {
+  return localStorage.getItem('streamvault_session')
+}
+
 const canUseNativeHls = (): boolean => {
   const video = document.createElement('video')
   return Boolean(video.canPlayType('application/vnd.apple.mpegurl'))
@@ -400,6 +404,13 @@ const initPlayer = async (sid: string, useNativeHls: boolean = preferNativeHls.v
         maxBufferLength: 30,
         liveSyncDurationCount: 3,
         liveMaxLatencyDurationCount: 5,
+        xhrSetup: (xhr: XMLHttpRequest) => {
+          xhr.withCredentials = true
+          const sessionToken = getStoredSessionToken()
+          if (sessionToken) {
+            xhr.setRequestHeader('Authorization', `Bearer ${sessionToken}`)
+          }
+        },
       })
 
       hlsInstance.value = hls


### PR DESCRIPTION
## Summary
- pass the stored StreamVault session token to hls.js playlist and segment requests via Authorization: Bearer
- enable credentials on the hls.js XHR loader so protected live stream endpoints do not redirect to /auth/login
- keep Twitch OAuth server-side in Streamlink, as confirmed by the submitted log

## Log finding
The new log confirms the Twitch OAuth token already reaches Streamlink via --twitch-api-header, and Streamlink opens 1440p60. The playback requests then log: No session cookie or Bearer token for /api/live/stream/.../playlist.m3u8 followed by /auth/login. This points to missing StreamVault session auth on hls.js HLS requests, not missing Twitch OAuth in Streamlink.

## Testing
- npm run lint:tokens
- npm run build