### PR TITLE
Fix native live HLS authentication

### DIFF
--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -387,7 +387,7 @@ const initPlayer = async (sid: string, useNativeHls: boolean = preferNativeHls.v
 
   try {
     const Hls = await loadHlsJs()
-    const playlistUrl = liveApi.getPlaylistUrl(sid)
+    const playlistUrl = streamInfo.value?.playlist_url || liveApi.getPlaylistUrl(sid)
 
     if (useNativeHls && videoElement.value.canPlayType('application/vnd.apple.mpegurl')) {
       // Native HLS is preferred for HEVC-capable Safari/WebKit pipelines.

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -121,6 +121,9 @@ class AuthMiddleware:
             "/api/twitch/auth-url",
             # Public video sharing (share-token authenticated)
             "/api/videos/public/",
+            # Live HLS playback uses per-session playback tokens in the route.
+            # Native video/HLS requests cannot reliably attach Authorization headers.
+            "/api/live/stream/",
             # PWA assets (must load before login screen renders)
             "/assets/",
             "/registerSW.js",

--- a/app/routes/live.py
+++ b/app/routes/live.py
@@ -13,6 +13,7 @@ Endpoints:
 
 import logging
 from typing import Optional
+from urllib.parse import quote
 
 from fastapi import (
     APIRouter,
@@ -20,7 +21,7 @@ from fastapi import (
     Depends,
     Request,
 )
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -32,6 +33,24 @@ from app.services.live_streaming_service import live_streaming_service
 logger = logging.getLogger("streamvault")
 
 router = APIRouter(prefix="/api/live", tags=["live"])
+
+
+def _append_playback_token_to_playlist(playlist: str, token: str) -> str:
+    """Append the playback token to segment URIs in a media playlist."""
+    encoded_token = quote(token, safe="")
+    rewritten_lines = []
+
+    for line in playlist.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            rewritten_lines.append(line)
+            continue
+
+        separator = "&" if "?" in line else "?"
+        rewritten_lines.append(f"{line}{separator}token={encoded_token}")
+
+    trailing_newline = "\n" if playlist.endswith("\n") else ""
+    return "\n".join(rewritten_lines) + trailing_newline
 
 
 class LiveStartRequest(BaseModel):
@@ -89,7 +108,16 @@ async def start_live_stream(
             user_id=user_id,
         )
 
-        playlist_url = f"/api/live/stream/{session_id}/playlist.m3u8"
+        session = live_streaming_service.get_session(session_id)
+        if not session:
+            raise HTTPException(
+                status_code=500, detail="Stream session not found after start"
+            )
+
+        playlist_url = (
+            f"/api/live/stream/{session_id}/playlist.m3u8"
+            f"?token={quote(session.playback_token, safe='')}"
+        )
 
         logger.info(
             f"[LIVE] Stream started by user {user_id}: {session_id} ({streamer_name})"
@@ -169,7 +197,7 @@ async def get_stream_status(session_id: str):
 
 
 @router.get("/stream/{session_id}/playlist.m3u8")
-async def get_hls_playlist(session_id: str):
+async def get_hls_playlist(session_id: str, token: Optional[str] = None):
     """
     Serve the HLS playlist (.m3u8) for a live stream.
 
@@ -179,6 +207,8 @@ async def get_hls_playlist(session_id: str):
         session = live_streaming_service.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Stream session not found")
+        if not session.validate_playback_token(token):
+            raise HTTPException(status_code=403, detail="Invalid live playback token")
 
         playlist_path = session.playlist_path
 
@@ -196,9 +226,12 @@ async def get_hls_playlist(session_id: str):
         # Update access time
         session.touch()
 
+        playlist = playlist_path.read_text(encoding="utf-8")
+        playlist = _append_playback_token_to_playlist(playlist, session.playback_token)
+
         # Serve with appropriate HLS headers
-        return FileResponse(
-            path=str(playlist_path),
+        return Response(
+            content=playlist,
             media_type="application/vnd.apple.mpegurl",
             headers={
                 "Cache-Control": "no-cache",
@@ -214,7 +247,9 @@ async def get_hls_playlist(session_id: str):
 
 
 @router.get("/stream/{session_id}/{segment_name}")
-async def get_hls_segment(session_id: str, segment_name: str):
+async def get_hls_segment(
+    session_id: str, segment_name: str, token: Optional[str] = None
+):
     """
     Serve an HLS segment (.ts file) for a live stream.
 
@@ -226,6 +261,8 @@ async def get_hls_segment(session_id: str, segment_name: str):
         session = live_streaming_service.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Stream session not found")
+        if not session.validate_playback_token(token):
+            raise HTTPException(status_code=403, detail="Invalid live playback token")
 
         segment_path = session.output_dir / segment_name
 
@@ -270,7 +307,10 @@ async def get_active_streams(current_user: User = Depends(get_current_user)):
                         "session_id": session.session_id,
                         "streamer_name": session.streamer_name,
                         "quality": session.quality,
-                        "playlist_url": f"/api/live/stream/{session_id}/playlist.m3u8",
+                        "playlist_url": (
+                            f"/api/live/stream/{session_id}/playlist.m3u8"
+                            f"?token={quote(session.playback_token, safe='')}"
+                        ),
                         "is_active": session.is_active,
                         "created_at": session.created_at.isoformat(),
                     }

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -22,6 +22,7 @@ Features:
 import asyncio
 import logging
 import os
+import secrets
 import shutil
 import uuid
 from datetime import datetime
@@ -56,6 +57,7 @@ class LiveStreamSession:
         self.ffmpeg_process = ffmpeg_process
         self.output_dir = output_dir
         self.user_id = user_id
+        self.playback_token = secrets.token_urlsafe(32)
         self.created_at = datetime.utcnow()
         self.last_accessed = datetime.utcnow()
         self.is_active = True
@@ -67,6 +69,10 @@ class LiveStreamSession:
     @property
     def playlist_path(self) -> Path:
         return self.output_dir / "playlist.m3u8"
+
+    def validate_playback_token(self, token: Optional[str]) -> bool:
+        """Validate the bearer token used by native HLS/video requests."""
+        return bool(token) and secrets.compare_digest(token, self.playback_token)
 
     def is_expired(self, timeout_seconds: int = 60) -> bool:
         """Check if session has timed out due to inactivity"""

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -26,6 +26,10 @@ def test_live_stream_session_properties():
     assert session.streamer_name == "test_streamer"
     assert session.quality == "best"
     assert session.is_active is True
+    assert session.playback_token
+    assert session.validate_playback_token(session.playback_token) is True
+    assert session.validate_playback_token("wrong-token") is False
+    assert session.validate_playback_token(None) is False
 
     # Fresh session not expired
     assert session.is_expired(timeout_seconds=60) is False
@@ -81,6 +85,20 @@ def test_normalize_supported_codecs_for_live_playback():
     )
     assert LiveStreamingService._normalize_supported_codecs("vp9,unknown") == "h264"
     assert LiveStreamingService._normalize_supported_codecs("") == "h264"
+
+
+def test_append_playback_token_to_playlist():
+    """Test live playlist segment URIs receive playback tokens."""
+    from app.routes.live import _append_playback_token_to_playlist
+
+    playlist = "#EXTM3U\n#EXTINF:2.0,\nsegment_000.ts\nsegment_001.ts?range=1\n"
+
+    rewritten = _append_playback_token_to_playlist(playlist, "abc+/=")
+
+    assert "#EXTM3U" in rewritten
+    assert "segment_000.ts?token=abc%2B%2F%3D" in rewritten
+    assert "segment_001.ts?range=1&token=abc%2B%2F%3D" in rewritten
+    assert rewritten.endswith("\n")
 
 
 def test_build_ffmpeg_command_structure():


### PR DESCRIPTION
## Summary
- add a per-live-session playback token for HLS playlist and segment URLs
- return the tokenized playlist URL from live start and active stream responses
- rewrite HLS playlists so segment requests carry the same token
- let native browser/video HLS requests reach the live route, where the playback token is validated

## Root cause
The new log shows Streamlink does start Twitch HLS with OAuth, but the browser later requests /api/live/stream/.../playlist.m3u8 without a StreamVault session cookie or Bearer token and gets sent to /auth/login. hls.js can attach Authorization headers, but native video/HLS requests cannot reliably do that. The playback token makes both native HLS and hls.js work without leaking the Twitch OAuth token.

## Testing
- uvx ruff format/check app/services/live_streaming_service.py app/routes/live.py app/middleware/auth.py tests/test_live_streaming.py
- uv run ... pytest tests/test_live_streaming.py -q
- npm run lint:tokens
- npm run build