### PR TITLE
docs: refresh readme and add wiki source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,17 @@
 
 # StreamVault
 
-### Self-hosted Twitch stream recorder and media library
+### Self-hosted Twitch recorder, live player, and media library
 
-Never miss a stream again. StreamVault automatically detects when your favorite streamers go live, records their broadcasts with Streamlink, performs post-processing with rich metadata and artwork, and serves everything through a modern Progressive Web App.
+StreamVault records Twitch streams automatically, keeps the recordings organized with metadata and artwork, and provides a modern web app for watching, managing, and sharing your archive.
 
 [![Python](https://img.shields.io/badge/Python-3.12+-3776ab?style=flat-square&logo=python&logoColor=white)](https://python.org)
-[![FastAPI](https://img.shields.io/badge/FastAPI-latest-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
-[![Vue.js](https://img.shields.io/badge/Vue.js-3.5-4FC08D?style=flat-square&logo=vue.js&logoColor=white)](https://vuejs.org)
-[![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?style=flat-square&logo=docker&logoColor=white)](https://docker.com)
+[![FastAPI](https://img.shields.io/badge/FastAPI-FastAPI-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
+[![Vue](https://img.shields.io/badge/Vue-3.5-4FC08D?style=flat-square&logo=vue.js&logoColor=white)](https://vuejs.org)
+[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker&logoColor=white)](https://docker.com)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
-[Features](#features) • [Getting Started](#getting-started) • [Documentation](#documentation) • [API Reference](#api-reference)
-
-![StreamVault Interface](https://via.placeholder.com/800x400/1a1a1a/4FC08D?text=StreamVault+Interface)
+[Features](#features) | [Quick start](#quick-start) | [Configuration](#configuration) | [Documentation](#documentation) | [Development](#development)
 
 </div>
 
@@ -22,522 +20,197 @@ Never miss a stream again. StreamVault automatically detects when your favorite 
 
 ## Features
 
-### Automated Recording
-- **EventSub webhooks** - Instant stream detection when channels go live
-- **Quality selection** - Record in best quality or choose specific resolutions (1080p, 720p, 480p)
-- **H.265/AV1 codecs** - Access advanced codecs and 1440p quality with browser token authentication
-- **Multi-hour streams** - Safe 24h+ recording with automatic segmentation
-- **Proxy support** - HTTP/HTTPS proxies with automatic audio synchronization
-- **Manual controls** - Start and stop recordings on-demand via web interface
+### Twitch recording
 
-### Rich Media Library
-- **Metadata generation** - Comprehensive NFO files with title, description, date, and categories
-- **Automatic chapters** - VTT and XML chapter files from stream events
-- **Thumbnails** - Multiple quality options generated from video content
-- **Artwork pipeline** - Poster, banner, and fanart images for media servers
-- **Episode numbering** - Automatic episode tracking per streamer
-- **Media server ready** - Compatible with Plex, Emby, Jellyfin, and Kodi
+- EventSub based live detection for automatic recording.
+- Manual recording controls from the web interface.
+- Streamlink based downloads with configurable quality, codec, and proxy settings.
+- H.265, AV1, and 1440p recording support when a Twitch browser token is configured.
+- Safe handling for long streams, recording state recovery, and orphan cleanup.
 
-### Modern Web Interface
-- **Progressive Web App** - Install on any device, works offline
-- **Real-time updates** - WebSocket connections show live recording status
-- **Responsive design** - Touch-optimized for phones and tablets
-- **Dark/Light themes** - Automatic system theme detection
-- **Background queue monitor** - Track post-processing tasks in real-time
-- **Session authentication** - Secure cookie-based authentication
+### Native live playback
 
-### Intelligent Management
-- **Storage policies** - Automatic cleanup by age, size, or file count
-- **Per-streamer settings** - Individual recording preferences and cleanup rules
-- **Filename templates** - Customize naming with variables (streamer, date, category, title)
-- **Bulk operations** - Enable/disable multiple streamers at once
-- **Import follows** - Sync your Twitch followed channels
+- Watch live Twitch streams inside StreamVault through `/live/:streamer`.
+- Streamlink and FFmpeg create HLS output that is played by bundled `hls.js`.
+- Authenticated playlist and segment requests use playback tokens.
+- Live playback uses browser compatible H.264 where needed while recordings can keep higher quality codec preferences.
+- Temporary live segments are stored in `/tmp/streamvault-live` and cleaned up automatically.
 
-### Notifications
-- **100+ services** - Discord, Telegram, Slack, Ntfy, Email, and more via Apprise
-- **Web push** - Browser notifications with automatic VAPID key generation
-- **Event filtering** - Choose which events trigger notifications
-- **Test system** - Verify notification configuration before deploying
+### Media library
 
+- PWA frontend for streamers, recordings, live playback, settings, and admin tools.
+- Metadata, NFO files, thumbnails, banners, posters, fanart, and chapter files.
+- Bulk video selection and deletion with confirmation.
+- Media server friendly output for Plex, Emby, Jellyfin, Kodi, and similar libraries.
 
+### Operations
 
----
+- Docker Compose deployment with PostgreSQL and persistent volumes.
+- Session based authentication and API key support for automation.
+- Notifications through Apprise plus web push notifications.
+- Cleanup policies by age, size, count, and per streamer overrides.
+- GitHub Actions for tests, security scanning, and Docker image builds.
 
-## Getting Started
+## Quick start
 
-### Prerequisites
+### Requirements
 
-Before you begin, ensure you have:
+- Docker and Docker Compose.
+- A public HTTPS URL for Twitch EventSub webhooks.
+- A Twitch developer application with client ID and client secret.
+- Enough storage for recordings. A 4 hour 1080p stream can easily use 8 to 15 GB.
 
-- **Docker & Docker Compose** - [Install Docker](https://docs.docker.com/get-docker/)
-- **HTTPS domain with valid certificate** - Required for Twitch EventSub webhooks
-- **Twitch Developer Application** - Free, [create one here](https://dev.twitch.tv/console/apps)
-- **Minimum 2GB RAM** and **50GB storage** (recordings grow 2-8GB per hour at 1080p)
+### 1. Clone the repository
 
-> [!IMPORTANT]
-> Twitch EventSub webhooks require a publicly accessible HTTPS endpoint with a valid SSL certificate. Use Let's Encrypt with Traefik, Caddy, Nginx, or a Cloudflare Tunnel.
+```bash
+git clone https://github.com/Serph91P/StreamVault.git
+cd StreamVault
+```
 
-### Quick Start
+### 2. Configure your environment
 
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/Serph91P/StreamVault.git
-   cd StreamVault
-   ```
-
-2. **Create environment configuration:**
-   ```bash
-   cp .env.example .env
-   ```
-
-3. **Configure Twitch application:**
-   
-   Create a [Twitch application](https://dev.twitch.tv/console/apps):
-   - **Name**: StreamVault (or your preference)
-   - **OAuth Redirect URLs**: `https://your-domain.com/auth/callback`
-   - **Category**: Application Integration
-   
-   Copy the Client ID and Client Secret to your `.env` file:
-   ```env
-   TWITCH_APP_ID=your_client_id_here
-   TWITCH_APP_SECRET=your_client_secret_here
-   BASE_URL=https://your-domain.com
-   EVENTSUB_SECRET=random_secure_string_here
-   ```
-
-4. **Start StreamVault:**
-   ```bash
-   docker compose -f docker/docker-compose.yml up -d
-   ```
-
-5. **Access the web interface:**
-   
-   Open `https://your-domain.com` in your browser (port 7000 is used internally).
-
-### Configuration
-
-#### Environment Variables
-
-Edit your `.env` file with these settings:
+Edit the repository `.env` file and set at least these values:
 
 ```env
-# Twitch API Configuration (Required)
 TWITCH_APP_ID=your_twitch_client_id
 TWITCH_APP_SECRET=your_twitch_client_secret
-TWITCH_OAUTH_TOKEN=                    # Optional: enables H.265/1440p
-
-# Application URLs (Required)
-BASE_URL=https://your-domain.com       # Must be HTTPS
-EVENTSUB_SECRET=random_secure_string   # Generate with: openssl rand -hex 32
-
-# Database Configuration
+BASE_URL=https://streamvault.example.com
+EVENTSUB_SECRET=replace_with_a_random_secret
 POSTGRES_USER=streamvault
-POSTGRES_PASSWORD=strong_secure_password_here
+POSTGRES_PASSWORD=replace_with_a_strong_password
 POSTGRES_DB=streamvault
-
-# Optional Settings
-TZ=Europe/Berlin                       # Your timezone
-LOG_LEVEL=INFO                         # DEBUG, INFO, WARNING, ERROR
+TZ=Europe/Berlin
 ```
 
-#### HTTPS Setup Example
+Generate a webhook secret with:
 
-**Using Nginx:**
-
-```nginx
-server {
-    listen 443 ssl http2;
-    server_name your-domain.com;
-    
-    ssl_certificate /path/to/certificate.crt;
-    ssl_certificate_key /path/to/private.key;
-    
-    location / {
-        proxy_pass http://localhost:7000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
-}
+```bash
+openssl rand -hex 32
 ```
 
-**Using Caddy:**
+### 3. Start StreamVault
 
-```caddy
-your-domain.com {
-    reverse_proxy localhost:7000
-}
+```bash
+docker compose -f docker/docker-compose.yml up -d
 ```
 
-### Enabling Premium Quality
+Open your `BASE_URL` in the browser. The container exposes port `7000` internally and through the compose file.
 
-> [!NOTE]
-> Twitch restricts third-party apps to 1080p H.264. To unlock H.265/AV1 codecs and 1440p quality, add a browser authentication token.
+## Configuration
 
-1. Log in to [Twitch.tv](https://www.twitch.tv)
-2. Open browser DevTools (F12) → Console tab
-3. Run this command:
-   ```javascript
-   document.cookie.split("; ").find(item=>item.startsWith("auth-token="))?.split("=")[1]
-   ```
-4. Copy the 30-character token and add to `.env`:
-   ```env
-   TWITCH_OAUTH_TOKEN=<your-browser-token-here>
-   ```
-5. Restart the container:
-   ```bash
-   docker compose restart app
-   ```
+### Twitch application
 
-**Quality comparison:**
-- **Without token**: 1080p60 H.264 only
-- **With token**: Up to 1440p60, H.265/HEVC, AV1, smaller file sizes
+Create an application in the [Twitch developer console](https://dev.twitch.tv/console/apps):
 
-See [`docs/BROWSER_TOKEN_SETUP.md`](docs/BROWSER_TOKEN_SETUP.md) for detailed instructions.
+- OAuth redirect URL: `https://your-domain.example/auth/callback`
+- Category: Application Integration
 
+### Browser token for higher quality recordings
 
+StreamVault can store a Twitch browser token through **Settings > Twitch Connection**. The token is encrypted in the database and the `TWITCH_OAUTH_TOKEN` environment variable remains available as a fallback.
 
----
+Use a browser token when you want:
+
+- 1440p60 recording when available.
+- H.265 or AV1 recording when available.
+- Better compression for archived files.
+
+Live browser playback intentionally selects compatible codecs so playback works reliably in hls.js and browser Media Source Extensions.
+
+### Volumes
+
+The compose file stores data in these locations:
+
+| Path or volume | Purpose |
+| --- | --- |
+| `./recordings` | Recorded video files and generated media files |
+| `app_data` | Application data |
+| `app_logs` | Application logs |
+| `db_data` | PostgreSQL database data |
+| `./config/streamlink` | Streamlink configuration files |
+| `/tmp/streamvault-live` | Temporary HLS files for native live playback |
 
 ## Documentation
 
-Comprehensive guides are available in the `docs/` directory:
+Repository docs:
 
-- **[User Guide](docs/USER_GUIDE.md)** - Complete setup and usage instructions
-- **[Browser Token Setup](docs/BROWSER_TOKEN_SETUP.md)** - Enable H.265/1440p quality
+- [User guide](docs/USER_GUIDE.md)
+- [Browser token setup](docs/BROWSER_TOKEN_SETUP.md)
+- [Development guide](docs/DEVELOPMENT.md)
+- [Wiki source](docs/wiki/Home.md)
 
+Wiki pages prepared in this repository:
 
+- [Home](docs/wiki/Home.md)
+- [Installation](docs/wiki/Installation.md)
+- [Configuration](docs/wiki/Configuration.md)
+- [Usage](docs/wiki/Usage.md)
+- [Live Streaming](docs/wiki/Live-Streaming.md)
+- [Development](docs/wiki/Development.md)
+- [Troubleshooting](docs/wiki/Troubleshooting.md)
 
----
+## API
 
-## Usage
+Interactive API documentation is available from a running instance:
 
-### Adding Streamers
+- Swagger UI: `/docs`
+- OpenAPI schema: `/openapi.json`
 
-1. Navigate to the **Streamers** page
-2. Click **Add Streamer**
-3. Enter the Twitch username
-4. Configure recording preferences (optional):
-   - Recording quality (best, 1080p, 720p, etc.)
-   - Filename template
-   - Cleanup policies
-5. Enable recording for the streamer
+Common API groups include:
 
-### Importing Followed Channels
-
-1. Go to **Settings** → **Twitch Connection**
-2. Click **Connect Twitch Account**
-3. Authorize StreamVault to access your followed channels
-4. Select channels to import
-5. Configure default recording settings
-
-### Managing Recordings
-
-**Live Streaming:**
-- Click the **Watch Live** button on any streamer card to start a live HLS stream in your browser
-- StreamVault fetches the Twitch stream via Streamlink and transmuxes it into HLS segments using FFmpeg
-- Playback uses **hls.js** (dynamically loaded from CDN) for broad browser compatibility
-- Streams auto-stop after 60 seconds of inactivity or can be stopped manually
-- Supports up to 5 global concurrent live streams (2 per user)
-
-**Manual Recording:**
-- Click the record button on any streamer card to start recording
-- Stop recording anytime from the dashboard or streamer page
-
-**Automatic Recording:**
-- Enable "Auto Record" for streamers you want to monitor
-- StreamVault detects when they go live via Twitch webhooks
-- Recordings start automatically and stop when the stream ends
-
-### Configuring Notifications
-
-1. Go to **Settings** → **Notifications**
-2. Add notification service URLs (see [Apprise documentation](https://github.com/caronc/apprise))
-3. Select which events trigger notifications:
-   - Stream online/offline
-   - Recording started/completed/failed
-   - Favorite category detected
-4. Test your configuration with the **Send Test** button
-
-**Example service URLs:**
-```
-Discord: discord://webhook_id/webhook_token
-Telegram: tgram://bot_token/chat_id
-Ntfy: ntfy://topic_name
-Email: mailtos://user:password@smtp.example.com
-```
-
-### Storage Management
-
-**Global Cleanup Policy:**
-1. Go to **Settings** → **Recording**
-2. Enable automatic cleanup
-3. Set limits:
-   - Maximum age (days)
-   - Maximum storage (GB)
-   - Maximum file count
-4. Choose which limit triggers cleanup (first met or all met)
-
-**Per-Streamer Override:**
-- Edit any streamer's settings
-- Enable custom cleanup policy
-- Set streamer-specific limits
-
-> [!WARNING]
-> Recordings grow quickly (2-8GB per hour at 1080p). Configure cleanup policies early to prevent storage issues.
-
-
-
----
-
-## API Reference
-
-StreamVault provides a REST API for automation and integration. Interactive documentation is available at `https://your-domain.com/docs`.
-
-### Common Endpoints
-
-```bash
-# Streamer Management
-GET    /api/streamers              # List all streamers
-POST   /api/streamers              # Add new streamer
-PUT    /api/streamers/{id}         # Update streamer settings
-DELETE /api/streamers/{id}         # Delete streamer
-
-# Recording Control
-POST   /api/recording/start/{id}   # Start manual recording
-POST   /api/recording/stop/{id}    # Stop recording
-GET    /api/recording/status       # Get recording status
-
-# Video Management
-GET    /api/videos                 # List all recordings
-GET    /api/videos/stream/{streamer}/{filename}  # Stream video
-DELETE /api/videos/{id}            # Delete recording
-
-# Background Queue
-GET    /api/background-queue/stats            # Queue statistics
-GET    /api/background-queue/active-tasks     # Active tasks
-POST   /api/background-queue/cancel-stream/{id}  # Cancel tasks
-
-# System Health
-GET    /api/admin/test/health                 # Health check
-POST   /api/admin/test/recording-workflow     # Test workflow
-```
-
-### Authentication
-
-All API requests require session authentication. Use the same session cookie obtained through web interface login.
-
-
-
----
+| Area | Example paths |
+| --- | --- |
+| Streamers | `/api/streamers` |
+| Recordings | `/api/recording/start/{id}`, `/api/recording/stop/{id}` |
+| Videos | `/api/videos` |
+| Live playback | `/api/live/start/{streamer}`, `/api/live/{session_id}/playlist.m3u8` |
+| Settings | `/api/settings` |
+| Twitch auth | `/api/twitch-auth` |
+| Admin and health | `/health`, `/api/admin/test/health` |
 
 ## Development
 
-### Local Development
+Backend:
 
-StreamVault supports local development without Docker:
-
-**Prerequisites:**
-- Python 3.12+
-- Node.js 20+
-- PostgreSQL 15+ (or use SQLite for testing)
-
-**Backend:**
 ```bash
-# Create virtual environment
 python -m venv venv
-source venv/bin/activate  # Windows: venv\Scripts\activate
-
-# Install dependencies
+source venv/bin/activate
 pip install -r requirements.txt
-
-# Start development server
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-**Frontend:**
+Frontend:
+
 ```bash
 cd app/frontend
-
-# Install dependencies
 npm install
-
-# Start development server (proxies API requests to backend)
 npm run dev
 ```
 
-**Quick start script:**
-```bash
-./dev.sh      # Linux/Mac
-dev.bat       # Windows
-```
-
-### Project Architecture
-
-```
-streamvault/
-├── app/
-│   ├── frontend/              # Vue 3 PWA
-│   │   ├── src/
-│   │   │   ├── components/   # Reusable components
-│   │   │   ├── composables/  # Composition API logic
-│   │   │   ├── views/        # Page components
-│   │   │   └── styles/       # SCSS design system
-│   │   └── dist/             # Built assets
-│   ├── routes/               # FastAPI endpoints
-│   ├── services/             # Business logic
-│   │   ├── recording/        # Recording engine
-│   │   ├── background_queue_service.py
-│   │   └── metadata_service.py
-│   ├── models.py             # SQLAlchemy models
-│   ├── schemas/              # Pydantic schemas
-│   └── utils/                # Utilities
-├── migrations/               # Database migrations
-├── docker/                   # Docker configuration
-└── tests/                    # Test suites
-```
-
-### Technology Stack
-
-**Backend:**
-- FastAPI (Python 3.12+)
-- SQLAlchemy ORM
-- PostgreSQL 15+
-- Streamlink for recording
-- FFmpeg for video processing
-
-**Frontend:**
-- Vue 3.5 with Composition API
-- TypeScript 5.6
-- Vite build system
-- Pinia state management
-- SCSS for styling
-
-**Infrastructure:**
-- Docker & Docker Compose
-- GitHub Actions CI/CD
-- AsyncIO task queue
-
-### Running Tests
+Checks used by CI:
 
 ```bash
-# Backend tests
-pytest tests/ -v
-
-# Frontend type checking
+ruff format --check app tests
+ruff check app tests
+pytest tests/ -q
 cd app/frontend
+npm run lint:tokens
 npm run type-check
-
-# Frontend linting
-npm run lint
+npm run build
 ```
 
+## Tech stack
 
-
----
-
-## System Requirements
-
-### Minimum Specifications
-- **CPU**: 2 cores
-- **RAM**: 2GB
-- **Storage**: 50GB
-- **Network**: Stable internet connection
-
-### Recommended Specifications
-- **CPU**: 4+ cores
-- **RAM**: 4GB
-- **Storage**: 1TB+ SSD
-- **Network**: High-speed connection for concurrent recordings
-
-> [!WARNING]
-> Stream recordings accumulate quickly. A single 4-hour stream at 1080p can be 8-15GB. Plan storage accordingly and configure cleanup policies.
-
----
-
-## Frequently Asked Questions
-
-<details>
-<summary><b>Can I record multiple streams simultaneously?</b></summary>
-
-Yes! StreamVault can record multiple streams at once. Resource usage scales with the number of concurrent recordings. Ensure adequate CPU and RAM for your recording count.
-</details>
-
-<details>
-<summary><b>What quality options are available?</b></summary>
-
-Without browser token: 160p, 360p, 480p, 720p, 1080p (H.264)
-With browser token: All above + 1440p (if available), H.265/HEVC, AV1 codecs
-
-Browser token provides better compression and quality at smaller file sizes.
-</details>
-
-<details>
-<summary><b>Can I run StreamVault without HTTPS?</b></summary>
-
-No. Twitch EventSub webhooks require valid HTTPS with a trusted SSL certificate. Use Let's Encrypt (free) via Traefik, Caddy, Nginx, or Cloudflare Tunnel.
-</details>
-
-<details>
-<summary><b>How do I migrate to a new server?</b></summary>
-
-1. Stop the container: `docker compose down`
-2. Copy the `recordings/` directory and Docker volumes
-3. Transfer `.env` file
-4. Start on new server: `docker compose up -d`
-
-Database and metadata are stored in Docker volumes (`app_data`, `app_logs`, `postgres_data`).
-</details>
-
-<details>
-<summary><b>Can I use this with other platforms like YouTube?</b></summary>
-
-Currently StreamVault only supports Twitch. Multi-platform support is on the roadmap.
-</details>
-
----
+- FastAPI, SQLAlchemy, PostgreSQL, Alembic style migrations.
+- Vue 3, TypeScript, Vite, Pinia, SCSS, hls.js.
+- Streamlink and FFmpeg for recording and live HLS playback.
+- Docker Compose for production style deployment.
+- GitHub Actions, Bandit, pip-audit, npm audit, Gitleaks, Trivy, Hadolint, and CodeQL for automation and scanning.
 
 ## Support
 
-- **Issues & Bugs**: [GitHub Issues](https://github.com/Serph91P/StreamVault/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/Serph91P/StreamVault/discussions)
-
-When reporting issues, please include:
-- StreamVault version
-- Docker/OS version
-- Relevant logs from `docker compose logs app`
-- Steps to reproduce
-
----
-
-## Acknowledgments
-
-StreamVault is built with excellent open-source projects:
-
-- [Streamlink](https://streamlink.github.io/) - Stream extraction
-- [FastAPI](https://fastapi.tiangolo.com/) - Modern Python web framework
-- [Vue.js](https://vuejs.org/) - Progressive JavaScript framework
-- [FFmpeg](https://ffmpeg.org/) - Video processing
-- [PostgreSQL](https://www.postgresql.org/) - Database
-- [Twitch API](https://dev.twitch.tv/docs/api/) - Stream data and webhooks
-
----
+Use [GitHub Issues](https://github.com/Serph91P/StreamVault/issues) for bugs and feature requests. Include the StreamVault version, deployment method, relevant logs, and clear reproduction steps.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
----
-
-<div align="center">
-
-**StreamVault** - Never miss a stream again
-
-[Report Bug](https://github.com/Serph91P/StreamVault/issues) • [Request Feature](https://github.com/Serph91P/StreamVault/discussions)
-
-</div>
+StreamVault is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -1,0 +1,27 @@
+# Configuration
+
+## Required environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `TWITCH_APP_ID` | Twitch application client ID |
+| `TWITCH_APP_SECRET` | Twitch application client secret |
+| `BASE_URL` | Public HTTPS URL for StreamVault |
+| `EVENTSUB_SECRET` | Random secret used for Twitch webhook validation |
+| `POSTGRES_USER` | PostgreSQL user |
+| `POSTGRES_PASSWORD` | PostgreSQL password |
+| `POSTGRES_DB` | PostgreSQL database name |
+
+## Optional browser token
+
+Use **Settings > Twitch Connection** to store a Twitch browser token. StreamVault encrypts the token in the database. `TWITCH_OAUTH_TOKEN` can still be used as a fallback.
+
+The browser token enables higher quality recording variants such as 1440p, H.265, and AV1 when Twitch provides them.
+
+## Recording settings
+
+Configure recording quality, filename templates, cleanup policy, proxy usage, and codec preferences globally or per streamer.
+
+## Notifications
+
+StreamVault supports external notification URLs through Apprise and browser push notifications. Configure them in the web interface under settings.

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,0 +1,41 @@
+# Development
+
+## Backend
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+## Frontend
+
+```bash
+cd app/frontend
+npm install
+npm run dev
+```
+
+## Tests and checks
+
+```bash
+ruff format --check app tests
+ruff check app tests
+pytest tests/ -q
+cd app/frontend
+npm run lint:tokens
+npm run type-check
+npm run build
+```
+
+## Project layout
+
+| Path | Purpose |
+| --- | --- |
+| `app/routes` | FastAPI route modules |
+| `app/services` | Business logic and integration services |
+| `app/frontend` | Vue PWA frontend |
+| `migrations` | Database migrations |
+| `docker` | Compose and container related files |
+| `tests` | Python test suite |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,20 @@
+# StreamVault Wiki
+
+StreamVault is a self-hosted Twitch recorder, live player, and media library. It combines Streamlink, FFmpeg, FastAPI, PostgreSQL, and a Vue PWA to record streams, watch live HLS playback, and manage a media server friendly archive.
+
+## Start here
+
+- [Installation](Installation.md)
+- [Configuration](Configuration.md)
+- [Usage](Usage.md)
+- [Live Streaming](Live-Streaming.md)
+- [Development](Development.md)
+- [Troubleshooting](Troubleshooting.md)
+
+## Core concepts
+
+- **Streamer**: A Twitch channel managed by StreamVault.
+- **Recording**: A saved stream with generated metadata, artwork, and optional chapters.
+- **Live session**: Temporary HLS playback created on demand for a live Twitch stream.
+- **Browser token**: Optional Twitch auth token used for higher quality recording options.
+- **Cleanup policy**: Storage rule that removes old recordings by age, size, or count.

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,0 +1,37 @@
+# Installation
+
+## Requirements
+
+- Docker and Docker Compose.
+- Public HTTPS URL for Twitch EventSub.
+- Twitch developer application.
+- At least 2 GB RAM and enough disk space for recordings.
+
+## Docker Compose
+
+```bash
+git clone https://github.com/Serph91P/StreamVault.git
+cd StreamVault
+```
+
+Edit `.env` and set Twitch, database, base URL, and timezone values. Then start the stack:
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+```
+
+## Reverse proxy
+
+Point your reverse proxy to port `7000`. Twitch EventSub requires HTTPS with a valid certificate.
+
+Example Caddy route:
+
+```caddy
+streamvault.example.com {
+    reverse_proxy localhost:7000
+}
+```
+
+## Persistent data
+
+Keep backups of the PostgreSQL volume and the `recordings` directory. The recordings directory contains the media files and generated artwork used by media servers.

--- a/docs/wiki/Live-Streaming.md
+++ b/docs/wiki/Live-Streaming.md
@@ -1,0 +1,23 @@
+# Live Streaming
+
+StreamVault can play live Twitch streams directly in the web app.
+
+## How it works
+
+1. The frontend starts a live session for a streamer.
+2. Streamlink reads the Twitch stream.
+3. FFmpeg transmuxes the stream into HLS segments.
+4. The frontend plays the playlist with bundled `hls.js`.
+5. Playlist and segment requests are authenticated with playback tokens.
+
+## Codec behavior
+
+Recordings can use high quality codec preferences such as H.265 or AV1. Live browser playback uses browser compatible options when needed so hls.js and Media Source Extensions can play video reliably.
+
+## Temporary files
+
+Live HLS files are written to `/tmp/streamvault-live`. The Docker Compose file mounts this as tmpfs for speed and cleanup.
+
+## Limits
+
+The live streaming service limits concurrent sessions globally and per user. Idle sessions are stopped automatically.

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,0 +1,27 @@
+# Troubleshooting
+
+## EventSub does not trigger recordings
+
+- Confirm `BASE_URL` is public HTTPS.
+- Check the Twitch application redirect URL.
+- Verify `EVENTSUB_SECRET` is set and stable.
+- Check container logs with `docker compose -f docker/docker-compose.yml logs app`.
+
+## Live player buffers forever
+
+- Confirm FFmpeg exists in the container.
+- Check the live session API response for an error message.
+- Verify `/tmp/streamvault-live` is writable by the app user.
+- Check whether Twitch provides a browser compatible stream variant.
+
+## Higher quality options are missing
+
+- Store a browser token in **Settings > Twitch Connection**.
+- Confirm the token status is valid.
+- Remember that Twitch only exposes some codecs and resolutions for some channels.
+
+## Disk fills up
+
+- Configure cleanup policies.
+- Move `recordings` to a larger disk.
+- Review unfinished or orphaned recordings after interrupted streams.

--- a/docs/wiki/Usage.md
+++ b/docs/wiki/Usage.md
@@ -1,0 +1,24 @@
+# Usage
+
+## Add streamers
+
+1. Open the Streamers page.
+2. Add a Twitch username.
+3. Configure recording quality, cleanup policy, and filename template.
+4. Enable automatic recording if the channel should be monitored.
+
+## Record manually
+
+Use the record button on a streamer card or streamer detail page. Manual recordings use the same recording pipeline and metadata generation as automatic recordings.
+
+## Manage videos
+
+The Videos page lists recordings, supports selection mode, and can delete multiple videos after confirmation.
+
+## Import followed channels
+
+Connect a Twitch account in **Settings > Twitch Connection** and import followed channels into StreamVault.
+
+## Storage cleanup
+
+Configure global cleanup limits and optional per streamer overrides. Set this up early because recordings grow quickly.


### PR DESCRIPTION
## Summary

- Refresh README so it matches the current StreamVault feature set.
- Add wiki-ready documentation pages under `docs/wiki`.
- Cover installation, configuration, usage, native live streaming, development, and troubleshooting.

## Validation

- Checked all local Markdown links in README and wiki pages.
- Ran `git diff --check`.
- Checked README and wiki pages for forbidden unicode dashes.
- Commit message checked for forbidden unicode dashes.

## Wiki follow-up

The repository wiki is currently disabled. After this PR is merged, the `docs/wiki` pages can be copied into the GitHub wiki after enabling it in repository settings.
