### PR TITLE
chore: update streamlink to 8.4.0

### DIFF
--- a/app/frontend/src/mocks/mockData.ts
+++ b/app/frontend/src/mocks/mockData.ts
@@ -449,5 +449,5 @@ export const mockVersionInfo = {
   version: '1.2.3',
   build_date: '2025-11-15',
   python_version: '3.12.0',
-  streamlink_version: '8.0.0'
+  streamlink_version: '8.4.0'
 }

--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -12,6 +12,7 @@ import subprocess
 import json
 from typing import List, Optional, Dict, Any, Tuple
 from pathlib import Path
+from urllib.parse import urlparse
 
 from app.models import GlobalSettings
 
@@ -426,6 +427,29 @@ def get_proxy_settings_from_db() -> Dict[str, str]:
     return proxy_settings
 
 
+def _validate_twitch_video_id(video_id: str) -> str:
+    normalized = video_id.strip()
+    if not normalized.isdigit():
+        raise ValueError("Twitch video ID must contain digits only")
+
+    return normalized
+
+
+def _validate_twitch_clip_url(clip_url: str) -> str:
+    parsed = urlparse(clip_url.strip())
+    host = parsed.netloc.lower()
+    allowed_hosts = {"clips.twitch.tv", "www.twitch.tv", "twitch.tv"}
+
+    if (
+        parsed.scheme != "https"
+        or host not in allowed_hosts
+        or not parsed.path.strip("/")
+    ):
+        raise ValueError("Clip URL must be an https Twitch clip URL")
+
+    return parsed.geturl()
+
+
 def get_streamlink_vod_command(
     video_id: str,
     quality: str,
@@ -447,6 +471,7 @@ def get_streamlink_vod_command(
         List of command arguments for streamlink
     """
     # Find ffmpeg binary path (use env var or default)
+    normalized_video_id = _validate_twitch_video_id(video_id)
     ffmpeg_bin: str = os.environ.get("FFMPEG_PATH") or "ffmpeg"
 
     # Core command for VOD download
@@ -459,14 +484,14 @@ def get_streamlink_vod_command(
         "--stream-segment-threads",
         "10",
         "--url",
-        f"https://www.twitch.tv/videos/{video_id}",
+        f"https://www.twitch.tv/videos/{normalized_video_id}",
         "--default-stream",
         quality,
     ]
 
     # Add logging level
     log_dir = Path(output_path).parent
-    log_file = os.path.join(log_dir, f"streamlink_vod_{video_id}.log")
+    log_file = os.path.join(log_dir, f"streamlink_vod_{normalized_video_id}.log")
     cmd.extend(["--loglevel", "debug", "--logfile", log_file])
 
     # Add proxy settings if provided
@@ -495,6 +520,7 @@ def get_streamlink_clip_command(
         List of command arguments for streamlink
     """
     # Find ffmpeg binary path (use env var or default)
+    normalized_clip_url = _validate_twitch_clip_url(clip_url)
     ffmpeg_bin: str = os.environ.get("FFMPEG_PATH") or "ffmpeg"
 
     # Core command for clip download
@@ -507,7 +533,7 @@ def get_streamlink_clip_command(
         "--stream-segment-threads",
         "10",
         "--url",
-        clip_url,
+        normalized_clip_url,
         "--default-stream",
         quality,
     ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,7 @@ COPY requirements.txt ./
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir streamlink==8.2.1
+    pip install --no-cache-dir streamlink==8.4.0
 
 # =============================================================================
 # Stage 2: Frontend Build (only rebuilt when frontend changes)

--- a/docs/BROWSER_TOKEN_SETUP.md
+++ b/docs/BROWSER_TOKEN_SETUP.md
@@ -156,5 +156,5 @@ The UI provides:
 ---
 
 **Last Updated**: November 20, 2025  
-**Streamlink Version**: 8.0.0  
+**Streamlink Version**: 8.4.0
 **Related Commits**: 0dcd6f4b (Streamlink format fix), 3d85055d (UI guide)

--- a/tests/utils/test_streamlink_utils.py
+++ b/tests/utils/test_streamlink_utils.py
@@ -24,7 +24,10 @@ class TestStreamlinkUtils:
         so we only check the essential command structure.
         """
         cmd = get_streamlink_command(
-            streamer_name="teststreamer", quality="best", output_path="/tmp/output.mp4", log_path="/tmp/streamlink.log"
+            streamer_name="teststreamer",
+            quality="best",
+            output_path="/tmp/output.mp4",
+            log_path="/tmp/streamlink.log",
         )
 
         # Check basic command structure
@@ -48,7 +51,10 @@ class TestStreamlinkUtils:
         # Since proxy settings are now in config file, this test checks
         # that the command structure is still valid
         cmd = get_streamlink_command(
-            streamer_name="teststreamer", quality="best", output_path="/tmp/output.mp4", log_path="/tmp/streamlink.log"
+            streamer_name="teststreamer",
+            quality="best",
+            output_path="/tmp/output.mp4",
+            log_path="/tmp/streamlink.log",
         )
 
         # Basic structure should be valid
@@ -78,7 +84,9 @@ class TestStreamlinkUtils:
     def test_get_streamlink_vod_command(self):
         """Test VOD download command generation."""
         with patch.dict(os.environ, {"FFMPEG_PATH": "/usr/bin/ffmpeg"}):
-            cmd = get_streamlink_vod_command(video_id="123456789", quality="best", output_path="/tmp/vod.mp4")
+            cmd = get_streamlink_vod_command(
+                video_id="123456789", quality="best", output_path="/tmp/vod.mp4"
+            )
 
             assert cmd[0] == "streamlink"
             assert "--ffmpeg-ffmpeg" in cmd
@@ -90,7 +98,9 @@ class TestStreamlinkUtils:
         """Test clip download command generation."""
         with patch.dict(os.environ, {"FFMPEG_PATH": "/usr/bin/ffmpeg"}):
             cmd = get_streamlink_clip_command(
-                clip_url="https://clips.twitch.tv/test123", quality="best", output_path="/tmp/clip.mp4"
+                clip_url="https://clips.twitch.tv/test123",
+                quality="best",
+                output_path="/tmp/clip.mp4",
             )
 
             assert cmd[0] == "streamlink"
@@ -98,6 +108,34 @@ class TestStreamlinkUtils:
             assert "https://clips.twitch.tv/test123" in cmd
             assert "--default-stream" in cmd
             assert "best" in cmd
+
+    @pytest.mark.parametrize("video_id", ["../secret", "123abc", "file:///etc/passwd"])
+    def test_get_streamlink_vod_command_rejects_invalid_video_ids(self, video_id):
+        """Reject non-numeric VOD IDs before passing them to Streamlink."""
+        with pytest.raises(ValueError, match="digits only"):
+            get_streamlink_vod_command(
+                video_id=video_id,
+                quality="best",
+                output_path="/tmp/vod.mp4",
+            )
+
+    @pytest.mark.parametrize(
+        "clip_url",
+        [
+            "file:///etc/passwd",
+            "http://clips.twitch.tv/test123",
+            "https://example.com/test123",
+            "https://clips.twitch.tv/",
+        ],
+    )
+    def test_get_streamlink_clip_command_rejects_unsafe_urls(self, clip_url):
+        """Reject unsafe clip URLs before passing them to Streamlink."""
+        with pytest.raises(ValueError, match="https Twitch clip URL"):
+            get_streamlink_clip_command(
+                clip_url=clip_url,
+                quality="best",
+                output_path="/tmp/clip.mp4",
+            )
 
     @patch("app.database.SessionLocal")
     def test_get_proxy_settings_from_db(self, mock_session):


### PR DESCRIPTION
## Summary
- Update the Docker Streamlink pin from 8.2.1 to 8.4.0.
- Refresh Streamlink version references in docs and frontend mock data.
- Add VOD and clip input validation before building Streamlink commands so unsafe local file URL schemes never reach Streamlink.

## Release impact review
Checked every Streamlink release after the current 8.2.1 pin:

### 8.3.0
- `--interface` by name on non-Windows systems: StreamVault does not expose or pass `--interface`, so no code change needed.
- `HLSStream.parse_variant_playlist(check_streams="segments")`: StreamVault uses Streamlink CLI, not Streamlink's Python HLS API, so no code change needed.
- `ProcessOutput` stdout/stderr line buffering fix: StreamVault manages Streamlink via subprocesses and log files, so this is beneficial from the version bump but needs no integration change.
- Plugin updates are for non-Twitch services and do not affect StreamVault's Twitch-only command builders.

### 8.4.0
- Security fix for arbitrary local file reads through file URL schemes in HLS and DASH handling. The version bump is the required upstream fix.
- Added local validation for Twitch VOD IDs and Twitch clip URLs so unsafe inputs, including file URLs, are rejected before being passed to Streamlink.
- `--stream-passthrough-encrypted` is not used by StreamVault.
- `--interface` fixes are not relevant because StreamVault does not pass `--interface`.

## Tested
- `ruff format --check app/`
- `ruff check app/`
- `pytest tests/ -q --tb=short`
- `python -m app.migrations_init`
- `npm ci --prefer-offline`
- `npm run lint`
- `npm run lint:tokens`
- `npm run type-check`
- `npm run build`
- `streamlink --version` -> `streamlink 8.4.0`

Docker daemon was not available locally, so the Docker build could not be run here. GitHub CI runs Docker build and integration tests.
