### PR TITLE
fix: correct video delete and twitch token status follow up

### DIFF
--- a/app/frontend/src/components/cards/VideoCard.vue
+++ b/app/frontend/src/components/cards/VideoCard.vue
@@ -170,6 +170,7 @@ const formatFileSize = (bytes: number) => {
 
 const handleClick = () => {
   if (props.disableNavigation) {
+    emit('select', props.video)
     return
   }
 

--- a/app/frontend/src/components/settings/TwitchConnectionPanel.vue
+++ b/app/frontend/src/components/settings/TwitchConnectionPanel.vue
@@ -18,7 +18,7 @@
           <div class="detail-item">
             <span class="detail-label">Status:</span>
             <span class="detail-value" :class="{ 'text-success': connectionStatus.valid, 'text-warning': !connectionStatus.valid }">
-              {{ connectionStatus.valid ? 'Active & Valid' : 'Token Expired or Needs Refresh' }}
+              {{ statusDetailText }}
             </span>
           </div>
           <div v-if="connectionStatus.source" class="detail-item">
@@ -213,17 +213,34 @@ const statusClass = computed(() => ({
 
 const statusTitle = computed(() => {
   if (!connectionStatus.value.connected) return 'Twitch Connection'
-  if (!connectionStatus.value.valid) return 'Connected (Token Expiring)'
-  return 'Connected to Twitch'
+  if (connectionStatus.value.valid) return 'Connected to Twitch'
+  if (connectionStatus.value.source === 'database_manual') return 'Connected (Browser Token Expired)'
+  if (connectionStatus.value.source === 'database_oauth' || connectionStatus.value.source === 'oauth_refresh') {
+    return 'Connected (Refresh Needed)'
+  }
+  return 'Connected (Token Needs Attention)'
 })
 
 const statusDescription = computed(() => {
   if (!connectionStatus.value.connected) return 'No Twitch token is configured yet'
   if (connectionStatus.value.source === 'environment') return 'Using TWITCH_OAUTH_TOKEN environment fallback. You can save a replacement below.'
-  if (!connectionStatus.value.valid) {
-    return 'Your token will be automatically refreshed on next recording'
+  if (!connectionStatus.value.valid && connectionStatus.value.source === 'database_manual') {
+    return 'Save a fresh browser token below. Manual browser tokens cannot auto-refresh.'
   }
+  if (!connectionStatus.value.valid && (connectionStatus.value.source === 'database_oauth' || connectionStatus.value.source === 'oauth_refresh')) {
+    return 'The OAuth app token will be refreshed on the next recording.'
+  }
+  if (!connectionStatus.value.valid) return 'The configured Twitch token needs attention.'
   return 'Your account is connected and tokens are valid'
+})
+
+const statusDetailText = computed(() => {
+  if (connectionStatus.value.valid) return 'Active & Valid'
+  if (connectionStatus.value.source === 'database_manual') return 'Browser Token Expired'
+  if (connectionStatus.value.source === 'database_oauth' || connectionStatus.value.source === 'oauth_refresh') {
+    return 'Refresh Needed'
+  }
+  return 'Token Needs Attention'
 })
 
 onMounted(async () => {

--- a/app/frontend/src/views/VideosView.vue
+++ b/app/frontend/src/views/VideosView.vue
@@ -211,7 +211,7 @@
           :video="video"
           :view-mode="viewMode"
           :disable-navigation="selectMode"
-          @click="selectMode ? toggleSelection(video.id) : playVideo(video)"
+          @play="playVideo"
           @select="toggleSelection(video.id)"
         />
       </div>
@@ -392,17 +392,10 @@ const filteredAndSortedVideos = computed(() => {
 async function fetchVideos() {
   isLoading.value = true
   try {
-    console.log('[VideosView] Fetching all videos...')
     const response = await videoApi.getAll()
-    console.log('[VideosView] API response:', response)
     
     // Backend returns array directly (not wrapped in { data: [] })
     videos.value = Array.isArray(response) ? response : (response.data || [])
-    console.log('[VideosView] Loaded videos count:', videos.value.length)
-    
-    if (videos.value.length > 0) {
-      console.log('[VideosView] Sample video:', videos.value[0])
-    }
   } catch (error: any) {
     console.error('[VideosView] Failed to fetch videos:', error)
     console.error('[VideosView] Error details:', {

--- a/app/routes/twitch_auth.py
+++ b/app/routes/twitch_auth.py
@@ -24,6 +24,73 @@ class ConnectionStatusResponse(BaseModel):
     has_env_token: bool = False
 
 
+def _normalize_expires_at(expires_at):
+    if not expires_at:
+        return None, False
+
+    from datetime import datetime, timezone
+
+    expires_at_utc = expires_at
+    if expires_at_utc.tzinfo is None:
+        expires_at_utc = expires_at_utc.replace(tzinfo=timezone.utc)
+
+    return expires_at.isoformat(), datetime.now(timezone.utc) < expires_at_utc
+
+
+def _build_connection_status(global_settings, env_token: Optional[str]) -> dict:
+    """Return status for the token source StreamVault will actually use."""
+    has_env_token = bool(env_token and env_token.strip())
+    has_db_token = bool(
+        global_settings
+        and global_settings.twitch_access_token
+        and global_settings.twitch_access_token.strip()
+    )
+    has_refresh_token = bool(
+        global_settings
+        and global_settings.twitch_refresh_token
+        and global_settings.twitch_refresh_token.strip()
+    )
+
+    expires_at_value = None
+    is_db_token_valid = False
+    if global_settings:
+        expires_at_value, is_db_token_valid = _normalize_expires_at(
+            global_settings.twitch_token_expires_at
+        )
+
+    source = None
+    is_valid = False
+    effective_expires_at = None
+
+    # Manual browser tokens in the DB are preferred only while they are still
+    # valid. If the saved browser token expired, status should reflect the env
+    # fallback (when present) rather than stale expired database state.
+    if has_db_token and not has_refresh_token and is_db_token_valid:
+        source = "database_manual"
+        is_valid = True
+        effective_expires_at = expires_at_value
+    elif has_env_token:
+        source = "environment"
+        is_valid = True
+    elif has_db_token and has_refresh_token:
+        source = "database_oauth"
+        is_valid = is_db_token_valid
+        effective_expires_at = expires_at_value
+    elif has_refresh_token:
+        source = "oauth_refresh"
+    elif has_db_token:
+        source = "database_manual"
+        effective_expires_at = expires_at_value
+
+    return {
+        "connected": has_db_token or has_refresh_token or has_env_token,
+        "valid": is_valid,
+        "expires_at": effective_expires_at,
+        "source": source,
+        "has_env_token": has_env_token,
+    }
+
+
 def get_twitch_oauth_service(
     streamer_service: StreamerService = Depends(get_streamer_service),
 ) -> TwitchOAuthService:
@@ -177,8 +244,6 @@ async def get_callback_url():
 @router.get("/connection-status", response_model=ConnectionStatusResponse)
 async def get_connection_status():
     """Check if a Twitch token is available in DB or env fallback."""
-    from datetime import datetime, timezone
-
     from app.config.settings import settings
     from app.database import SessionLocal
     from app.models import GlobalSettings
@@ -186,49 +251,9 @@ async def get_connection_status():
     with SessionLocal() as db:
         try:
             global_settings = db.query(GlobalSettings).first()
-
-            has_db_token = bool(
-                global_settings
-                and global_settings.twitch_access_token
-                and global_settings.twitch_access_token.strip()
+            return _build_connection_status(
+                global_settings, settings.TWITCH_OAUTH_TOKEN
             )
-            has_refresh_token = bool(
-                global_settings
-                and global_settings.twitch_refresh_token
-                and global_settings.twitch_refresh_token.strip()
-            )
-            has_env_token = bool(
-                settings.TWITCH_OAUTH_TOKEN and settings.TWITCH_OAUTH_TOKEN.strip()
-            )
-
-            is_valid = False
-            expires_at_value = None
-            if global_settings and global_settings.twitch_token_expires_at:
-                now_utc = datetime.now(timezone.utc)
-                expires_at = global_settings.twitch_token_expires_at
-                if expires_at.tzinfo is None:
-                    expires_at = expires_at.replace(tzinfo=timezone.utc)
-                is_valid = now_utc < expires_at
-                expires_at_value = global_settings.twitch_token_expires_at.isoformat()
-
-            source = None
-            if has_db_token and not has_refresh_token:
-                source = "database_manual"
-            elif has_db_token:
-                source = "database_oauth"
-            elif has_env_token:
-                source = "environment"
-                is_valid = True
-            elif has_refresh_token:
-                source = "oauth_refresh"
-
-            return {
-                "connected": has_db_token or has_refresh_token or has_env_token,
-                "valid": is_valid,
-                "expires_at": expires_at_value,
-                "source": source,
-                "has_env_token": has_env_token,
-            }
         except Exception as e:
             logger.error(f"Error checking connection status: {e}")
             return {

--- a/tests/test_twitch_connection_status.py
+++ b/tests/test_twitch_connection_status.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from app.routes.twitch_auth import _build_connection_status
+
+
+def test_connection_status_uses_env_when_manual_database_token_is_expired():
+    stored = SimpleNamespace(
+        twitch_access_token="encrypted-old-browser-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=datetime.utcnow() - timedelta(minutes=5),
+    )
+
+    status = _build_connection_status(stored, "env-browser-token")
+
+    assert status == {
+        "connected": True,
+        "valid": True,
+        "expires_at": None,
+        "source": "environment",
+        "has_env_token": True,
+    }
+
+
+def test_connection_status_reports_fresh_manual_database_token():
+    expires_at = datetime.utcnow() + timedelta(days=30)
+    stored = SimpleNamespace(
+        twitch_access_token="encrypted-new-browser-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=expires_at,
+    )
+
+    status = _build_connection_status(stored, "env-browser-token")
+
+    assert status["connected"] is True
+    assert status["valid"] is True
+    assert status["expires_at"] == expires_at.isoformat()
+    assert status["source"] == "database_manual"
+    assert status["has_env_token"] is True
+
+
+def test_connection_status_keeps_expired_manual_database_status_without_env_fallback():
+    expires_at = datetime.utcnow() - timedelta(days=1)
+    stored = SimpleNamespace(
+        twitch_access_token="encrypted-old-browser-token",
+        twitch_refresh_token=None,
+        twitch_token_expires_at=expires_at,
+    )
+
+    status = _build_connection_status(stored, None)
+
+    assert status["connected"] is True
+    assert status["valid"] is False
+    assert status["expires_at"] == expires_at.isoformat()
+    assert status["source"] == "database_manual"
+    assert status["has_env_token"] is False

--- a/tests/test_twitch_token_service.py
+++ b/tests/test_twitch_token_service.py
@@ -6,8 +6,7 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 _module_path = (
-    Path(__file__).resolve().parents[1]
-    / "app/services/system/twitch_token_service.py"
+    Path(__file__).resolve().parents[1] / "app/services/system/twitch_token_service.py"
 )
 _spec = importlib.util.spec_from_file_location(
     "twitch_token_service_under_test", _module_path
@@ -74,7 +73,9 @@ async def test_manual_database_token_preferred_over_environment_token(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_environment_token_used_as_fallback_when_database_token_expired(monkeypatch):
+async def test_environment_token_used_as_fallback_when_database_token_expired(
+    monkeypatch,
+):
     stored = SimpleNamespace(
         twitch_access_token="enc:expired-token",
         twitch_refresh_token=None,
@@ -138,4 +139,5 @@ async def test_store_manual_access_token_encrypts_and_clears_refresh_token(monke
     assert stored.twitch_access_token == "enc:manual-token"
     assert stored.twitch_refresh_token is None
     assert stored.twitch_token_expires_at is not None
+    assert service.settings.TWITCH_OAUTH_TOKEN is None
     assert service.db.committed is True


### PR DESCRIPTION
Fix the remaining video select mode and Twitch token status issues reported after the first batch delete change.

- remove stale video debug logging from the overview fetch path
- make VideoCard emit an explicit select event when navigation is disabled
- show the effective Twitch token source instead of stale expired DB state when env fallback is active
- avoid claiming manual browser tokens auto refresh
- cover the connection status source selection with tests