### PR TITLE
Fix frontend QA polish feedback

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -363,6 +363,16 @@
         <path d="M4 4a16 16 0 0 1 16 16"/>
         <circle cx="5" cy="19" r="1"/>
       </symbol>
+      <symbol id="icon-activity" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></symbol>
+      <symbol id="icon-calendar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></symbol>
+      <symbol id="icon-chevron-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></symbol>
+      <symbol id="icon-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 0 20 15.3 15.3 0 0 1 0-20z"/></symbol>
+      <symbol id="icon-hash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="9" x2="20" y2="9"/><line x1="4" y1="15" x2="20" y2="15"/><line x1="10" y1="3" x2="8" y2="21"/><line x1="16" y1="3" x2="14" y2="21"/></symbol>
+      <symbol id="icon-help-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 1 1 5.83 1c0 2-3 2-3 4"/><line x1="12" y1="17" x2="12.01" y2="17"/></symbol>
+      <symbol id="icon-list-ordered" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" y1="6" x2="21" y2="6"/><line x1="10" y1="12" x2="21" y2="12"/><line x1="10" y1="18" x2="21" y2="18"/><path d="M4 6h1v4"/><path d="M4 10h2"/><path d="M6 18H4c0-1 2-1 2-3 0-1-1-2-2-2"/></symbol>
+      <symbol id="icon-pause-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="10" y1="15" x2="10" y2="9"/><line x1="14" y1="15" x2="14" y2="9"/></symbol>
+      <symbol id="icon-twitch" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 3h17v11l-5 5h-4l-3 3v-3H4z"/><line x1="10" y1="8" x2="10" y2="12"/><line x1="15" y1="8" x2="15" y2="12"/></symbol>
+      <symbol id="icon-x-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></symbol>
     </defs>
     </svg>
   </Teleport>

--- a/app/frontend/src/components/AppShell.vue
+++ b/app/frontend/src/components/AppShell.vue
@@ -430,6 +430,14 @@ onUnmounted(() => {
   gap: var(--spacing-2);
   padding: var(--spacing-2) !important;
 
+  .badge {
+    display: inline-grid;
+    place-items: center;
+    top: 1px;
+    right: 1px;
+    line-height: 1;
+  }
+
   .utility-label {
     display: none;
     font-size: v.$text-sm;

--- a/app/frontend/src/components/NotificationFeed.vue
+++ b/app/frontend/src/components/NotificationFeed.vue
@@ -358,7 +358,7 @@ onMounted(() => {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: var(--spacing-1) 0 var(--spacing-4);
+  padding: var(--spacing-1) var(--spacing-1) var(--spacing-4);
 }
 
 .notification-group + .notification-group {
@@ -391,7 +391,7 @@ onMounted(() => {
 }
 
 .notification-list {
-  padding-bottom: var(--spacing-2);
+  padding: 0 var(--spacing-1) var(--spacing-2);
 }
 
 .notification-groups::-webkit-scrollbar {
@@ -429,6 +429,7 @@ onMounted(() => {
 @include m.respond-below('md') {
   .notification-feed {
     max-height: calc(100dvh - var(--safe-area-inset-top, 0px));
+    overflow: visible;
   }
 
   .feed-header {
@@ -449,6 +450,11 @@ onMounted(() => {
     min-height: 44px;
     padding: 0 var(--spacing-2);
     font-size: var(--text-xs);
+  }
+
+  .notification-groups,
+  .notification-list {
+    padding-inline: var(--spacing-2);
   }
 }
 </style>

--- a/app/frontend/src/components/PWAInstallPrompt.vue
+++ b/app/frontend/src/components/PWAInstallPrompt.vue
@@ -105,11 +105,14 @@ const dismissPrompt = () => {
   bottom: calc(v.$spacing-6 + env(safe-area-inset-bottom, 0px));
   left: v.$spacing-6;
   right: v.$spacing-6;
-  background: var(--background-card);
+  border: 1px solid var(--glass-border-hover);
+  background: linear-gradient(135deg, var(--glass-bg-strong), var(--background-card));
   border-radius: v.$border-radius-lg;
-  box-shadow: v.$shadow-lg;
+  box-shadow: var(--glass-shadow-lg), 0 18px 44px rgba(0, 0, 0, 0.42);
   z-index: 1000;
   animation: slideUp v.$duration-300 v.$vue-ease-out;
+  backdrop-filter: blur(var(--glass-blur-lg));
+  -webkit-backdrop-filter: blur(var(--glass-blur-lg));
 
   @include m.respond-to('md') {
     bottom: v.$spacing-6;
@@ -126,6 +129,13 @@ const dismissPrompt = () => {
 }
 
 .install-prompt__icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(145, 71, 255, 0.42);
+  border-radius: var(--radius-full);
+  background: rgba(145, 71, 255, 0.16);
   color: var(--accent-color);
   flex-shrink: 0;
 }
@@ -168,6 +178,8 @@ const dismissPrompt = () => {
 @include m.respond-below('md') {
   .install-prompt {
     bottom: calc(68px + env(safe-area-inset-bottom, 0px) + v.$spacing-3);
+    left: max(v.$spacing-3, env(safe-area-inset-left, 0px));
+    right: max(v.$spacing-3, env(safe-area-inset-right, 0px));
     margin: v.$spacing-2;
     border-radius: v.$border-radius-lg;
   }

--- a/app/frontend/src/components/cards/StreamCard.vue
+++ b/app/frontend/src/components/cards/StreamCard.vue
@@ -149,6 +149,9 @@
           @click.stop="toggleActions"
           class="btn-action btn-more"
           :class="{ active: showActions }"
+          :aria-label="`Stream actions for ${stream.title || 'untitled stream'}`"
+          aria-haspopup="menu"
+          :aria-expanded="showActions"
         >
           <svg class="icon">
             <use href="#icon-more-vertical" />
@@ -270,7 +273,7 @@ const dropdownStyle = computed(() => {
   return {
     position: 'fixed' as const,
     top: `${rect.bottom + 8}px`,
-    left: `${rect.left - 140}px`,
+    right: `${Math.max(8, window.innerWidth - rect.right)}px`,
     zIndex: 10000
   }
 })
@@ -416,7 +419,8 @@ onUnmounted(() => {
 /* Compact View */
 .stream-compact {
   padding: var(--spacing-4);
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
   align-items: center;
   gap: var(--spacing-3);
   cursor: pointer;
@@ -439,15 +443,18 @@ onUnmounted(() => {
 }
 
 .category-badge {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
+  max-width: 220px;
   padding: var(--spacing-1) var(--spacing-2);
   background: rgba(var(--primary-500-rgb), 0.1);
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
   color: var(--primary-color);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   .icon {
     width: 14px;

--- a/app/frontend/src/components/cards/StreamerCard.vue
+++ b/app/frontend/src/components/cards/StreamerCard.vue
@@ -74,6 +74,10 @@
         </div>
 
         <!-- OFFLINE: Show last stream info if available -->
+        <p v-else-if="streamer.description" class="streamer-description" :title="streamer.description">
+          {{ truncatedDescription }}
+        </p>
+
         <div v-else-if="streamer.last_stream_title" class="offline-last-stream">
           <p class="last-stream-title" :title="streamer.last_stream_title">
             {{ streamer.last_stream_title }}
@@ -83,10 +87,6 @@
           </p>
         </div>
 
-        <!-- OFFLINE: Fallback to description if no last stream info -->
-        <p v-else-if="streamer.description" class="streamer-description">
-          {{ truncatedDescription }}
-        </p>
         <p v-else class="streamer-description no-description">
           No description available
         </p>
@@ -136,6 +136,8 @@
           class="btn-action btn-more"
           :class="{ active: showActions }"
           :aria-label="`Actions for ${streamer.display_name || streamer.username}`"
+          aria-haspopup="menu"
+          :aria-expanded="showActions"
           title="More actions"
         >
           <svg class="icon">
@@ -294,7 +296,7 @@ const dropdownStyle = computed(() => {
   return {
     position: 'fixed' as const,
     top: `${rect.bottom + 8}px`,  // 8px below button
-    left: `${rect.left - 140}px`,  // Align to right edge (180px width - 40px button)
+    right: `${Math.max(8, window.innerWidth - rect.right)}px`,
     zIndex: 10000
   }
 })
@@ -428,6 +430,8 @@ onUnmounted(() => {
 @use '@/styles/variables' as v;
 @use '@/styles/mixins' as m;
 .streamer-card {
+  overflow: visible;
+
   // Card-specific overrides
   :deep(.glass-card-content) {
     padding: var(--spacing-4);

--- a/app/frontend/src/components/navigation/BottomNav.vue
+++ b/app/frontend/src/components/navigation/BottomNav.vue
@@ -270,7 +270,9 @@ const handleTabClick = (route: string) => {
 .nav-badge {
   position: absolute;
   top: 3px;
-  right: 10px;
+  right: calc(50% - 24px);
+  display: inline-grid;
+  place-items: center;
   background: var(--danger-color);
   color: white;
   min-width: 18px;
@@ -279,7 +281,7 @@ const handleTabClick = (route: string) => {
   border-radius: v.$border-radius-full;
   font-size: 10px;
   font-weight: v.$font-bold;
-  line-height: 18px;
+  line-height: 1;
   text-align: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }

--- a/app/frontend/src/components/navigation/NavigationWrapper.vue
+++ b/app/frontend/src/components/navigation/NavigationWrapper.vue
@@ -74,8 +74,8 @@ onMounted(() => {
 
   // Desktop with collapsed sidebar
   &.with-sidebar-collapsed {
-    margin-left: 84px; // 72px sidebar + 12px breathing room
-    width: calc(100% - 84px);
+    margin-left: 72px;
+    width: calc(100% - 72px);
   }
 
   // Mobile with bottom navigation

--- a/app/frontend/src/components/notifications/NotificationFilters.vue
+++ b/app/frontend/src/components/notifications/NotificationFilters.vue
@@ -206,11 +206,12 @@ function updateFilter(value: NotificationFilter) {
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: hidden;
+    margin-inline: calc(-1 * var(--spacing-2));
+    padding-inline: var(--spacing-2);
     padding-bottom: var(--spacing-1);
-    scroll-padding-inline: var(--spacing-4);
+    scroll-padding-inline: var(--spacing-2);
     scrollbar-width: thin;
     -webkit-overflow-scrolling: touch;
-    mask-image: linear-gradient(90deg, transparent 0, rgb(0 0 0) var(--spacing-3), rgb(0 0 0) calc(100% - var(--spacing-3)), transparent 100%);
   }
 
   .filter-chip {

--- a/app/frontend/src/components/notifications/NotificationItem.vue
+++ b/app/frontend/src/components/notifications/NotificationItem.vue
@@ -468,7 +468,7 @@ time {
 @media (max-width: 767px) {
   .notification-item {
     grid-template-columns: auto minmax(0, 1fr);
-    margin: var(--spacing-3);
+    margin: var(--spacing-3) 0;
     padding: var(--spacing-4);
   }
 

--- a/app/frontend/src/components/settings/NotificationSettingsPanel.vue
+++ b/app/frontend/src/components/settings/NotificationSettingsPanel.vue
@@ -554,6 +554,34 @@ const toggleAllStreamers = (enabled: boolean) => {
   .table-wrapper {
     margin-top: v.$spacing-4;  // Space from table controls
   }
+
+  .data-table th,
+  .data-table td {
+    vertical-align: middle;
+  }
+
+  .actions-cell {
+    width: 116px;
+  }
+}
+
+.btn-group {
+  display: inline-flex;
+  align-items: center;
+  min-width: 96px;
+  padding: 2px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full);
+  background: var(--background-darker);
+
+  .btn {
+    min-height: 30px;
+    min-width: 44px;
+    padding: 0 var(--spacing-2);
+    border-radius: var(--radius-full);
+    font-size: var(--text-xs);
+    line-height: 1;
+  }
 }
 
 // ============================================================================

--- a/app/frontend/src/components/settings/ProxySettingsPanel.vue
+++ b/app/frontend/src/components/settings/ProxySettingsPanel.vue
@@ -68,10 +68,11 @@
         <!-- Empty State -->
         <EmptyState
           v-if="proxies.length === 0"
-          icon="icon-server"
+          icon="server"
           title="No Proxies Configured"
           description="Add proxy servers to improve connection reliability and enable failover"
-          action-text="Add First Proxy"
+          action-label="Add First Proxy"
+          action-icon="plus"
           @action="showAddDialog = true"
         />
 

--- a/app/frontend/src/composables/useNavigation.ts
+++ b/app/frontend/src/composables/useNavigation.ts
@@ -20,6 +20,11 @@ export interface NavigationTab {
   requiresAuth?: boolean
 }
 
+// Shared navigation state. Multiple components call useNavigation(), so this
+// must live at module scope rather than creating one ref per component.
+const sidebarExpanded = ref(true)
+const liveBadgeCount = ref<number | null>(null)
+
 // Navigation configuration
 export const navigationTabs: NavigationTab[] = [
   { route: '/', label: 'Dashboard', icon: 'home', description: 'Dashboard overview', badge: null },
@@ -57,12 +62,6 @@ export function useNavigation() {
     if (lgUpQuery.value) return true
     return window.matchMedia('(min-width: 1024px)').matches
   })
-
-  // Sidebar state (desktop only)
-  const sidebarExpanded = ref(true)
-
-  // Badge counts
-  const liveBadgeCount = ref<number | null>(null)
 
   // Check if route is active
   const isActiveRoute = (tabRoute: string): boolean => {

--- a/app/frontend/src/views/HomeView.vue
+++ b/app/frontend/src/views/HomeView.vue
@@ -283,7 +283,14 @@
             </div>
             <div>
               <dt>Workers</dt>
-              <dd>{{ queueStats.workers }}</dd>
+              <dd>{{ workerCount }}</dd>
+            </div>
+          </dl>
+
+          <dl v-if="queueWorkerItems.length" class="queue-worker-state" aria-label="Queue worker configuration">
+            <div v-for="item in queueWorkerItems" :key="item.label">
+              <dt>{{ item.label }}</dt>
+              <dd>{{ item.value }}</dd>
             </div>
           </dl>
 
@@ -449,8 +456,13 @@ interface QueueStats {
   retried_tasks: number
   pending_tasks: number
   active_tasks: number
-  workers: number
+  workers: number | Record<string, unknown> | unknown[]
   is_running: boolean
+}
+
+interface QueueWorkerItem {
+  label: string
+  value: string
 }
 
 const router = useRouter()
@@ -487,6 +499,39 @@ const liveStreamers = computed(() => streamers.value.filter((s) => s.is_live))
 const recordingStreamers = computed(() => streamers.value.filter((s) => s.is_recording))
 const totalStreamers = computed(() => streamers.value.length)
 const isDashboardLoading = computed(() => isLoadingStreamers.value || isLoadingRecordings.value || isLoadingQueue.value)
+
+const workerCount = computed(() => {
+  const workers = queueStats.value.workers
+  if (typeof workers === 'number') return workers
+  if (Array.isArray(workers)) return workers.length
+  if (workers && typeof workers === 'object') {
+    const total = readWorkerNumber(workers, ['total_workers', 'workers', 'worker_count', 'total'])
+    if (total !== null) return total
+    const streamers = readWorkerNumber(workers, ['streamers', 'streamer_count'])
+    if (streamers !== null) return streamers
+  }
+  return 0
+})
+
+const queueWorkerItems = computed<QueueWorkerItem[]>(() => {
+  const workers = queueStats.value.workers
+  if (!workers || typeof workers === 'number') return []
+  if (Array.isArray(workers)) {
+    return [{ label: 'Worker pool', value: `${workers.length} worker${workers.length === 1 ? '' : 's'}` }]
+  }
+
+  const items: QueueWorkerItem[] = []
+  const total = readWorkerNumber(workers, ['total_workers', 'workers', 'worker_count', 'total'])
+  const maxPerStreamer = readWorkerNumber(workers, ['max_per_streamer', 'max_workers_per_streamer'])
+  const streamers = readWorkerNumber(workers, ['streamers', 'streamer_count'])
+  const isolation = readWorkerBoolean(workers, ['isolation_enabled', 'per_streamer_isolation', 'isolated'])
+
+  if (total !== null) items.push({ label: 'Total workers', value: String(total) })
+  if (maxPerStreamer !== null) items.push({ label: 'Max per streamer', value: String(maxPerStreamer) })
+  if (streamers !== null) items.push({ label: 'Streamers', value: String(streamers) })
+  if (isolation !== null) items.push({ label: 'Isolation', value: isolation ? 'Enabled' : 'Disabled' })
+  return items
+})
 
 const recentRecordings = computed(() => {
   return [...videos.value]
@@ -774,6 +819,27 @@ function recordingStreamerLink(recording: ActiveRecording) {
 function recordingLiveLink(recording: ActiveRecording) {
   const target = recording.streamer_name || recording.username || recording.streamer_id
   return target ? `/live/${target}` : '/streamers'
+}
+
+function readWorkerNumber(source: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'number') return value
+    if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) return Number(value)
+  }
+  return null
+}
+
+function readWorkerBoolean(source: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'boolean') return value
+    if (typeof value === 'string') {
+      if (value.toLowerCase() === 'true') return true
+      if (value.toLowerCase() === 'false') return false
+    }
+  }
+  return null
 }
 
 function activityTone(severity: NotificationSeverity): StatusBadgeTone {
@@ -1377,6 +1443,38 @@ onMounted(async () => {
     color: var(--text-primary);
     font-size: var(--text-2xl);
     font-weight: v.$font-bold;
+  }
+}
+
+.queue-worker-state {
+  display: grid;
+  gap: var(--spacing-2);
+  margin: 0 0 var(--spacing-4);
+
+  div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-3);
+    padding: var(--spacing-2) var(--spacing-3);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: rgba(var(--background-darker-rgb, 10, 10, 10), 0.18);
+  }
+
+  dt,
+  dd {
+    margin: 0;
+    font-size: var(--text-sm);
+  }
+
+  dt {
+    color: var(--text-secondary);
+  }
+
+  dd {
+    color: var(--text-primary);
+    font-weight: v.$font-semibold;
   }
 }
 

--- a/app/frontend/src/views/SettingsView.vue
+++ b/app/frontend/src/views/SettingsView.vue
@@ -694,11 +694,12 @@ onMounted(() => {
 }
 
 .nav-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
-  padding: var(--spacing-3);
-  min-height: 44px;
+  padding: var(--spacing-2) var(--spacing-3);
+  min-height: 58px;
   background: transparent;
   border: none;
   border-radius: var(--radius-lg);
@@ -763,6 +764,10 @@ onMounted(() => {
 }
 
 .nav-indicator {
+  position: absolute;
+  right: var(--spacing-2);
+  top: 50%;
+  transform: translateY(-50%);
   width: 16px;
   height: 16px;
   stroke: currentColor;

--- a/app/frontend/src/views/StreamersView.vue
+++ b/app/frontend/src/views/StreamersView.vue
@@ -5,12 +5,6 @@
       icon="users"
       :subtitle="isLoading ? 'Manage your tracked streamers' : `Manage your tracked streamers \u2022 ${liveStreamers.length} live now`"
     >
-      <template #status>
-        <span v-if="autoRefresh" class="auto-refresh-indicator">
-          <span class="pulse-dot"></span>
-          Auto-refresh
-        </span>
-      </template>
       <template #actions>
         <div class="header-actions">
           <BaseButton
@@ -21,7 +15,7 @@
             <svg class="icon" aria-hidden="true">
               <use href="#icon-refresh-cw" />
             </svg>
-            Auto {{ autoRefresh ? 'ON' : 'OFF' }}
+            Auto refresh {{ autoRefresh ? 'On' : 'Off' }}
           </BaseButton>
           <router-link to="/add-streamer" class="btn btn-primary btn-sm add-streamer-link" v-ripple>
             <svg class="icon" aria-hidden="true">
@@ -135,12 +129,18 @@
       </div>
 
       <!-- Sort -->
-      <BaseDropdown
-        v-model="sortBy"
-        class="sort-control"
-        :options="sortOptions"
-        aria-label="Sort streamers"
-      />
+      <div class="sort-control-wrap" aria-label="Sort streamers">
+        <svg class="sort-icon" aria-hidden="true">
+          <use href="#icon-list-ordered" />
+        </svg>
+        <span class="sort-label">Sort</span>
+        <BaseDropdown
+          v-model="sortBy"
+          class="sort-control"
+          :options="sortOptions"
+          aria-label="Sort streamers"
+        />
+      </div>
     </div>
 
     <div class="results-info">
@@ -636,9 +636,15 @@ onUnmounted(() => {
   grid-template-columns: repeat(4, minmax(72px, 1fr));
   gap: var(--spacing-2);
   margin: 0;
+  align-items: stretch;
 }
 
 .brief-stat {
+  display: flex;
+  min-height: 92px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   min-width: 72px;
   padding: var(--spacing-3);
   border: 1px solid var(--border-color);
@@ -650,6 +656,7 @@ onUnmounted(() => {
     color: var(--text-secondary);
     font-size: var(--text-xs);
     font-weight: v.$font-semibold;
+    line-height: 1.2;
   }
 
   dd {
@@ -709,8 +716,14 @@ onUnmounted(() => {
   }
 }
 
+.header-actions :deep(.btn),
 .add-streamer-link {
   min-height: 44px;
+  min-width: 148px;
+  justify-content: center;
+}
+
+.add-streamer-link {
   text-decoration: none;
 }
 
@@ -941,8 +954,33 @@ onUnmounted(() => {
   }
 }
 
+.sort-control-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  min-height: 44px;
+  padding: 0 var(--spacing-2) 0 var(--spacing-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--background-card);
+}
+
+.sort-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--text-secondary);
+  stroke: currentColor;
+  fill: none;
+}
+
+.sort-label {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: v.$font-semibold;
+}
+
 .sort-control {
-  min-width: 180px;
+  min-width: 132px;
   margin: 0;
 
   :deep(.form-group) {
@@ -950,20 +988,17 @@ onUnmounted(() => {
   }
 
   :deep(select) {
+    width: auto;
     min-height: 44px;
-    padding: var(--spacing-3) var(--spacing-4);
-    background: var(--background-card);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
+    padding: var(--spacing-2) var(--spacing-8) var(--spacing-2) var(--spacing-2);
+    background: transparent;
+    border: 0;
+    border-radius: var(--radius-md);
     color: var(--text-primary);
     font-size: var(--text-sm);
     font-weight: v.$font-medium;
     cursor: pointer;
     transition: all v.$duration-200 v.$ease-out;
-  }
-
-  :deep(select:hover) {
-    border-color: var(--primary-color);
   }
 
   :deep(select:focus) {

--- a/app/frontend/src/views/VideoPlayerView.vue
+++ b/app/frontend/src/views/VideoPlayerView.vue
@@ -29,7 +29,7 @@
     </div>
 
     <!-- Video Player - Main Content -->
-    <div v-else class="player-layout">
+    <div v-else class="player-layout" :class="{ 'theater-mode': theaterMode }">
       <!-- Main Content: Video + Sidebar -->
       <div class="player-main">
         <!-- Video Player with Header -->
@@ -44,6 +44,18 @@
             </button>
 
             <h1 class="video-title">{{ streamTitle }}</h1>
+
+            <button
+              type="button"
+              class="theater-toggle"
+              :aria-pressed="theaterMode"
+              @click="theaterMode = !theaterMode"
+            >
+              <svg class="icon" aria-hidden="true">
+                <use :href="theaterMode ? '#icon-grid' : '#icon-film'" />
+              </svg>
+              {{ theaterMode ? 'Show details' : 'Theater' }}
+            </button>
 
             <div v-if="streamerName" class="streamer-badge" :aria-label="`Streamed by ${streamerName}`">
               <svg class="icon-streamer" aria-hidden="true">
@@ -240,6 +252,7 @@ const isLoading = ref(true)
 const error = ref<string | null>(null)
 const playerReady = ref(false)
 const playerError = ref<string | null>(null)
+const theaterMode = ref(false)
 
 const currentPlayerState = computed(() => {
   if (isLoading.value) return 'loading'
@@ -602,6 +615,20 @@ onMounted(() => {
   overflow: hidden;
 }
 
+.player-layout.theater-mode {
+  .player-main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .info-sidebar {
+    display: none;
+  }
+
+  .player-card :deep(video) {
+    max-height: calc(100dvh - var(--app-header-height, 56px) - 132px);
+  }
+}
+
 // ============================================================================
 // MAIN CONTENT: Video + Sidebar side by side
 // ============================================================================
@@ -639,6 +666,11 @@ onMounted(() => {
     display: flex;
     flex-direction: column;
   }
+}
+
+.player-card :deep(video) {
+  max-height: calc(100dvh - var(--app-header-height, 56px) - 168px);
+  object-fit: contain;
 }
 
 .player-header {
@@ -686,6 +718,36 @@ onMounted(() => {
     min-height: 44px;  // Touch-friendly
     padding: var(--spacing-2) var(--spacing-4);
     font-size: var(--text-sm);
+  }
+}
+
+.theater-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  min-height: 40px;
+  padding: var(--spacing-2) var(--spacing-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--background-darker);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: v.$font-medium;
+  cursor: pointer;
+  white-space: nowrap;
+
+  .icon {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+    fill: none;
+  }
+
+  &[aria-pressed="true"] {
+    border-color: var(--primary-color);
+    background: rgba(var(--primary-500-rgb), 0.16);
+    color: var(--primary-color);
   }
 }
 

--- a/app/frontend/src/views/VideosView.vue
+++ b/app/frontend/src/views/VideosView.vue
@@ -870,9 +870,13 @@ onMounted(() => {
   border-radius: var(--radius-lg);
   padding: var(--spacing-1);
   border: 1px solid var(--border-color);
+  min-height: 44px;
 }
 
 .toggle-btn {
+  width: 40px;
+  min-width: 40px;
+  min-height: 36px;
   padding: var(--spacing-2);
   background: transparent;
   border: none;
@@ -943,7 +947,11 @@ onMounted(() => {
 }
 
 .sort-select {
-  padding: var(--spacing-3) var(--spacing-4);
+  width: auto;
+  min-width: 156px;
+  min-height: 44px;
+  flex: 0 0 auto;
+  padding: var(--spacing-3) var(--spacing-8) var(--spacing-3) var(--spacing-4);
   background: var(--background-card);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
@@ -1079,12 +1087,14 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-3);
-  margin-bottom: var(--spacing-4);
-  padding: var(--spacing-3) var(--spacing-4);
-  background: var(--background-card);
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 0 var(--spacing-4) auto;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: rgba(var(--background-card-rgb, 20, 22, 29), 0.72);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  font-size: var(--text-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 
   .selected-count {
@@ -1256,8 +1266,8 @@ onMounted(() => {
   }
 
   .controls-bar {
-    flex-direction: column;
-    align-items: stretch;
+    flex-wrap: wrap;
+    align-items: center;
   }
 
   .search-box {


### PR DESCRIPTION
## Summary
- Fixes desktop polish feedback across dashboard, streamers, videos, settings, player, shell collapse, and stream history controls.
- Restores missing icon references, compacts duplicated controls, improves queue worker display, and adds player theater mode.
- Includes mobile follow-up polish for notification drawer spacing, top badge centering, install prompt separation, and live card recording border clipping.

## Verification
- cd app/frontend && npm run lint:tokens && npm run type-check && npm run build && npm run lint
- git diff --check
- grep dash check on touched Vue and TS files
- Browser smoke checks against local mock app for dashboard, streamers, videos, settings notifications, and stored video theater mode.

## Notes
- Push notification OS delivery remains a manual environment gate as requested.
