### PR TITLE
Fix frontend polish feedback round 3

### DIFF
--- a/app/frontend/src/components/VideoPlayer.vue
+++ b/app/frontend/src/components/VideoPlayer.vue
@@ -133,6 +133,12 @@
                 </svg>
               </button>
 
+              <!-- Current Chapter Info inline -->
+              <div v-if="currentChapter" class="current-chapter-inline">
+                <span class="chapter-inline-title">{{ currentChapter.title }}</span>
+                <span class="chapter-inline-time">{{ formatTime(currentTime - currentChapter.startTime) }} / {{ formatDuration(currentChapter.duration) }}</span>
+              </div>
+
               <!-- Chapters Button (Toggle List) -->
               <button
                 @click="toggleChapterUI"
@@ -162,7 +168,7 @@
             </template>
 
             <button
-              @click="$emit('toggle-theater')"
+              @click="emit('toggle-theater')"
               class="control-button theater-button"
               :class="{ active: theaterMode }"
               :aria-label="theaterMode ? 'Show details' : 'Theater mode'"
@@ -259,16 +265,6 @@
       </transition>
     </div>
 
-    <!-- Video Controls Extension (below video) -->
-    <div class="video-controls-extension" v-if="currentChapter">
-      <!-- Current Chapter Info -->
-      <div class="current-chapter-info">
-        <div class="current-chapter-title">{{ currentChapter.title }}</div>
-        <div class="current-chapter-progress">
-          {{ formatTime(currentTime - currentChapter.startTime) }} / {{ formatDuration(currentChapter.duration) }}
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -1013,47 +1009,32 @@ defineExpose({ seekToChapter })
   box-shadow: var(--shadow-lg);
 }
 
-/* Video Controls Extension - Current Chapter Info Display */
-.video-controls-extension {
-  background: rgba(var(--background-card-rgb), 0.95);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  padding: var(--spacing-3) var(--spacing-4);  /* 12px 16px */
+/* Current Chapter Info inline in controls */
+.current-chapter-inline {
   display: flex;
-  justify-content: flex-end;  /* Right-aligned */
-  align-items: center;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.current-chapter-info {
-  text-align: right;
-  color: var(--text-primary);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
   min-width: 0;
+  max-width: 200px;
 }
 
-.current-chapter-title {
-  font-weight: var(--font-semibold);  /* 600 */
-  font-size: var(--text-sm);  /* 14px */
-  margin-bottom: var(--spacing-1);  /* 4px */
+.chapter-inline-title {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: var(--leading-tight);
-
-  @include m.respond-below('md') {  // < 768px (mobile)
-    font-size: var(--text-base);  /* 16px on mobile */
-  }
+  width: 100%;
+  line-height: 1.2;
 }
 
-.current-chapter-progress {
-  font-size: var(--text-xs);  /* 12px */
-  color: var(--text-secondary);
+.chapter-inline-time {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.6);
   font-family: var(--font-mono);
-  font-weight: var(--font-medium);  /* 500 */
-
-  @include m.respond-below('md') {  // < 768px (mobile)
-    font-size: var(--text-sm);  /* 14px on mobile */
-  }
+  white-space: nowrap;
 }
 
 /* Chapter List Panel - Overlay positioned inside video */
@@ -1732,43 +1713,13 @@ defineExpose({ seekToChapter })
 
 /* Mobile Responsive - Use SCSS mixins for breakpoints */
 @include m.respond-below('md') {  // < 768px
-  .video-controls-extension {
-    flex-direction: column;
-    gap: var(--spacing-3);  /* 12px */
-    padding: var(--spacing-3);  /* 12px */
+  .current-chapter-inline {
+    display: none;
   }
 
-  .chapter-controls {
-    justify-content: center;
-    width: 100%;
-  }
-
-  .control-btn {
-    flex: 1;
-    justify-content: center;
-    padding: var(--spacing-2-5) var(--spacing-2);  /* 10px 8px */
-    font-size: var(--text-xs);  /* 12px */
-  }
-
-  .current-chapter-info {
-    text-align: center;
-    width: 100%;
-  }
-
-  .current-chapter-title {
-    white-space: normal;
-    overflow: visible;
-    text-overflow: unset;
-  }
-
-  /* Chapter item mobile layout - keep horizontal layout */
   .chapter-item {
-    /* Don't override flex-direction, keep horizontal */
     text-align: left;
-    /* Padding and gap already set in base styles */
   }
-
-  /* Thumbnails already sized in base styles */
 
   .chapter-info {
     width: auto;

--- a/app/frontend/src/components/cards/StreamerCard.vue
+++ b/app/frontend/src/components/cards/StreamerCard.vue
@@ -436,19 +436,15 @@ onUnmounted(() => {
   :deep(.glass-card-content) {
     padding: var(--spacing-4);
     min-height: 240px;
-    max-height: 320px;  /* Status row and 3-line titles fit without clipping */
     overflow: visible;
     display: flex;
     flex-direction: column;
   }
 
-  // LIVE indicator: REMOVED - Red border now only on avatar (line 377)
-  // Keeps card cleaner and less overwhelming
-
   // RECORDING indicator: Pulsing border animation on the card itself
   &.is-recording {
     animation: pulse-recording 2s ease-in-out infinite;
-    border-radius: var(--radius-xl);  /* Ensure rounded during animation */
+    border-radius: var(--radius-xl);
   }
 
   // When actions dropdown is open, increase z-index to appear above other cards
@@ -459,14 +455,13 @@ onUnmounted(() => {
 }
 
 .streamer-card-content {
-  /* VERTICAL LAYOUT: Stack everything vertically */
   display: flex;
   flex-direction: column;
-  align-items: center;  /* Center horizontally */
-  gap: var(--spacing-3);
+  align-items: center;
+  gap: var(--spacing-2);
   flex: 1;
   min-height: 0;
-  position: relative;  /* For absolute positioning of actions button */
+  position: relative;
   cursor: pointer;
 }
 
@@ -490,7 +485,7 @@ onUnmounted(() => {
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-bottom: var(--spacing-2);
+  margin-bottom: var(--spacing-1);
 }
 
 .streamer-avatar {
@@ -598,7 +593,7 @@ onUnmounted(() => {
   flex-direction: column;
   justify-content: flex-start;
   overflow: hidden;
-  padding: var(--spacing-2) 0;  /* Add vertical spacing */
+  padding: var(--spacing-1) 0;
 }
 
 .streamer-description {
@@ -632,26 +627,21 @@ onUnmounted(() => {
 }
 
 .stream-title {
-  font-size: var(--text-base);  /* INCREASED: Better readability */
+  font-size: var(--text-base);
   font-weight: v.$font-medium;
   color: var(--text-primary);
-  line-height: 1.45;  /* FIX: bumped from 1.4 to give descenders (g, j, p, y) room */
+  line-height: 1.5;
   margin: 0;
   width: 100%;
 
-  /* CRITICAL: Max 4 lines for live title (more important than description) */
-  /* FIX: -webkit-line-clamp + overflow:hidden clips descenders on the last line.
-     Use padding-bottom + matching max-height so descenders are not cut off, and
-     keep ellipsis behaviour. */
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 4;  /* 4 lines for live streams */
-  line-clamp: 4;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   word-break: break-word;
-  padding-bottom: 0.2em;  /* descender safe-area */
-  max-height: calc(1.45em * 4 + 0.2em);  /* 4 lines * line-height + descender pad */
+  padding-bottom: 0.15em;
 
   &.no-title {
     font-style: italic;
@@ -701,12 +691,12 @@ onUnmounted(() => {
 /* Stats - AT BOTTOM, CENTERED */
 .streamer-stats {
   display: flex;
-  gap: var(--spacing-3);  /* REDUCED: Smaller gap for better fit */
+  gap: var(--spacing-2);
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
   margin-top: auto;
-  padding-top: var(--spacing-3);
+  padding-top: var(--spacing-2);
   width: 100%;
 }
 
@@ -913,25 +903,27 @@ onUnmounted(() => {
 // ============================================================================
 
 .streamer-card.list-mode {
+  max-width: none;
+  min-height: 0;
+
   :deep(.glass-card-content) {
     display: flex;
     flex-direction: row;
     align-items: center;
     min-height: auto;
-    max-height: none;
     padding: 0;
     gap: 0;
   }
 
   .streamer-card-content {
     display: grid;
-    grid-template-columns: auto minmax(12rem, 0.7fr) minmax(18rem, 1.3fr) auto;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: auto 1fr auto auto;
+    grid-template-rows: auto auto;
     align-items: center;
-    gap: var(--spacing-2) var(--spacing-4);
+    gap: var(--spacing-1) var(--spacing-4);
     width: 100%;
-    min-height: 104px;
-    padding: var(--spacing-3);
+    min-height: 80px;
+    padding: var(--spacing-3) var(--spacing-10) var(--spacing-3) var(--spacing-3);
   }
 
   .streamer-avatar-container {
@@ -943,8 +935,8 @@ onUnmounted(() => {
   }
 
   .streamer-avatar {
-    width: 56px;
-    height: 56px;
+    width: 48px;
+    height: 48px;
   }
 
   .streamer-name-link {
@@ -969,7 +961,7 @@ onUnmounted(() => {
     grid-column: 2;
     align-self: start;
     justify-content: flex-start;
-    min-height: 24px;
+    min-height: 22px;
     align-content: flex-start;
   }
 
@@ -980,6 +972,7 @@ onUnmounted(() => {
     text-align: left;
     min-width: 0;
     padding: 0;
+    max-width: 320px;
 
     .stream-title,
     .last-stream-title,
@@ -1003,10 +996,10 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
-    gap: var(--spacing-2) var(--spacing-3);
+    gap: var(--spacing-1);
     margin-top: 0;
-    padding: 0 var(--spacing-12) 0 0;
-    align-items: flex-start;
+    padding: 0;
+    align-items: flex-end;
     justify-content: center;
     width: auto;
 
@@ -1025,7 +1018,7 @@ onUnmounted(() => {
   .streamer-actions {
     position: absolute;
     top: 50%;
-    right: var(--spacing-3);
+    right: var(--spacing-2);
     transform: translateY(-50%);
     padding-right: 0;
     align-self: center;

--- a/app/frontend/src/components/notifications/NotificationFilters.vue
+++ b/app/frontend/src/components/notifications/NotificationFilters.vue
@@ -143,7 +143,7 @@ function updateFilter(value: NotificationFilter) {
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-4);
   border-bottom: 1px solid var(--glass-border);
-  background: linear-gradient(180deg, var(--glass-bg-medium), transparent);
+  background: transparent;
 }
 
 .filter-summary-row {
@@ -218,9 +218,8 @@ function updateFilter(value: NotificationFilter) {
   align-items: center;
   gap: var(--spacing-2);
   min-width: 0;
+  width: auto;
   min-height: 2.25rem;
-  width: 100%;
-  justify-content: space-between;
   padding: 0 var(--spacing-3);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-full);

--- a/app/frontend/src/components/player/PlayerStatus.vue
+++ b/app/frontend/src/components/player/PlayerStatus.vue
@@ -19,7 +19,7 @@
 import { computed } from 'vue'
 import StatusBadge, { type StatusBadgeTone } from '@/components/base/StatusBadge.vue'
 
-export type PlayerState = 'loading' | 'buffering' | 'connecting' | 'live' | 'offline' | 'idle' | 'stopped' | 'error'
+export type PlayerState = 'loading' | 'buffering' | 'connecting' | 'live' | 'recorded' | 'offline' | 'idle' | 'stopped' | 'error'
 
 interface Props {
   state: PlayerState
@@ -35,6 +35,7 @@ const label = computed(() => ({
   buffering: 'Buffering',
   connecting: 'Connecting',
   live: 'Live',
+  recorded: 'Recorded',
   offline: 'Offline',
   idle: 'Idle',
   stopped: 'Stopped',
@@ -47,6 +48,7 @@ const statusBadgeTone = computed<StatusBadgeTone>(() => {
     buffering: 'warning',
     connecting: 'info',
     live: 'live',
+    recorded: 'neutral',
     offline: 'offline',
     idle: 'neutral',
     stopped: 'offline',

--- a/app/frontend/src/styles/_layout.scss
+++ b/app/frontend/src/styles/_layout.scss
@@ -506,30 +506,31 @@
   }
 }
 
-// Streamer card grid - uses auto-fill for responsive columns
+// Streamer card grid - uses auto-fit for responsive columns
 // Match grid-scroll-hybrid sizing for consistent appearance
 .grid-streamers {
   display: grid;
   gap: v.$spacing-4;
   width: 100%;
+  justify-content: center;
   
   // Base: match scroll-hybrid desktop sizing
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   
   // Tablet+
   @media (min-width: map.get(v.$breakpoints, 'sm')) {
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   }
   
   // Desktop: same as grid-scroll-hybrid
   @media (min-width: map.get(v.$breakpoints, 'md')) {
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: v.$spacing-5;
   }
   
   // Large desktop: same as grid-scroll-hybrid
   @media (min-width: map.get(v.$breakpoints, 'xl')) {
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: v.$spacing-6;
   }
 }

--- a/app/frontend/src/views/HomeView.vue
+++ b/app/frontend/src/views/HomeView.vue
@@ -36,16 +36,18 @@
           <p>{{ dashboardStateDescription }}</p>
           <p class="brief-status-line">{{ dashboardStatusLine }}</p>
         </div>
-        <button type="button" class="brief-primary-action" @click="handleDashboardPrimaryAction">
-          <svg aria-hidden="true"><use :href="primaryAction.icon" /></svg>
-          {{ primaryAction.label }}
-        </button>
+        <div class="brief-actions">
+          <button type="button" class="brief-primary-action" @click="handleDashboardPrimaryAction">
+            <svg aria-hidden="true"><use :href="primaryAction.icon" /></svg>
+            {{ primaryAction.label }}
+          </button>
+        </div>
       </div>
-
       <div class="brief-grid" aria-label="Dashboard status snapshot">
-        <article
+        <router-link
           v-for="item in dashboardBriefItems"
           :key="item.label"
+          :to="item.route"
           class="brief-item"
           :class="`brief-item-${item.tone}`"
         >
@@ -57,7 +59,10 @@
             <strong>{{ item.value }}</strong>
             <span class="brief-item-detail">{{ item.detail }}</span>
           </span>
-        </article>
+          <span class="brief-item-arrow" aria-hidden="true">
+            <svg><use href="#icon-chevron-right" /></svg>
+          </span>
+        </router-link>
       </div>
     </section>
 
@@ -114,7 +119,7 @@
             v-else-if="liveStreamers.length === 0"
             variant="compact"
             title="No Live Streams"
-            description="No tracked streamer is live right now. Recent recordings and queue state stay available below."
+            description="No tracked streamer is live right now. Recent recordings and the dashboard summary stay available below."
             icon="video-off"
             :show-decoration="false"
           />
@@ -244,121 +249,6 @@
         </BasePanel>
       </div>
 
-      <aside class="dashboard-sidebar" aria-label="Dashboard side content">
-        <BasePanel labelled-by="queue-section-title" class="dashboard-panel queue-panel">
-          <template #title>
-            <span id="queue-section-title">Queue</span>
-          </template>
-          <template #description>
-            Background work for recordings and processing.
-          </template>
-          <template #actions>
-            <StatusBadge :tone="queueBadgeTone" size="sm" dot>
-              {{ queueStateLabel }}
-            </StatusBadge>
-          </template>
-
-          <div class="queue-progress" aria-label="Average active task progress">
-            <div class="queue-progress-header">
-              <span>Active progress</span>
-              <strong>{{ Math.round(totalProgress) }}%</strong>
-            </div>
-            <div class="queue-progress-bar">
-              <span :style="{ width: `${Math.round(totalProgress)}%` }" />
-            </div>
-          </div>
-
-          <dl class="queue-stats">
-            <div>
-              <dt>Active</dt>
-              <dd>{{ queueStats.active_tasks }}</dd>
-            </div>
-            <div>
-              <dt>Pending</dt>
-              <dd>{{ queueStats.pending_tasks }}</dd>
-            </div>
-            <div>
-              <dt>Failed</dt>
-              <dd>{{ queueStats.failed_tasks }}</dd>
-            </div>
-            <div>
-              <dt>Workers</dt>
-              <dd>{{ workerCount }}</dd>
-            </div>
-          </dl>
-
-          <dl v-if="queueWorkerItems.length" class="queue-worker-state" aria-label="Queue worker configuration">
-            <div v-for="item in queueWorkerItems" :key="item.label">
-              <dt>{{ item.label }}</dt>
-              <dd>{{ item.value }}</dd>
-            </div>
-          </dl>
-
-          <div v-if="isLoadingQueue" class="muted-row">Loading queue status.</div>
-          <div v-if="queueError" class="muted-row">{{ queueError }}</div>
-          <button type="button" class="panel-text-button" @click="refreshQueueFromAPI">
-            Refresh queue status
-          </button>
-        </BasePanel>
-
-        <BasePanel labelled-by="failures-section-title" class="dashboard-panel failures-panel">
-          <template #title>
-            <span id="failures-section-title">Failures and Alerts</span>
-          </template>
-          <template #description>
-            Critical recording and queue events that may need attention.
-          </template>
-
-          <EmptyState
-            v-if="failureItems.length === 0"
-            variant="compact"
-            title="No Failures"
-            description="Queue and realtime events do not report active failures."
-            icon="check-circle"
-            :show-decoration="false"
-          />
-
-          <ul v-else class="activity-list">
-            <li v-for="item in failureItems" :key="item.id" class="activity-item danger-item">
-              <StatusBadge tone="danger" size="sm">{{ item.kind }}</StatusBadge>
-              <div>
-                <strong>{{ item.title }}</strong>
-                <p>{{ item.body }}</p>
-              </div>
-            </li>
-          </ul>
-        </BasePanel>
-
-        <BasePanel labelled-by="activity-section-title" class="dashboard-panel activity-panel">
-          <template #title>
-            <span id="activity-section-title">Realtime Activity</span>
-          </template>
-          <template #description>
-            Latest product events from the central realtime store.
-          </template>
-
-          <EmptyState
-            v-if="recentActivity.length === 0"
-            variant="compact"
-            title="Waiting for Events"
-            description="Realtime stream, recording and notification updates will appear here."
-            icon="activity"
-            :show-decoration="false"
-          />
-
-          <ul v-else class="activity-list">
-            <li v-for="event in recentActivity" :key="event.event_id" class="activity-item">
-              <StatusBadge :tone="activityTone(event.severity)" size="sm">
-                {{ event.severity }}
-              </StatusBadge>
-              <div>
-                <strong>{{ event.title }}</strong>
-                <p>{{ event.body }}</p>
-              </div>
-            </li>
-          </ul>
-        </BasePanel>
-      </aside>
     </div>
   </div>
 </template>
@@ -372,8 +262,7 @@ import { useForceRecording } from '@/composables/useForceRecording'
 import {
   hasRealtimeEventType,
   toCanonicalNotificationEvent,
-  type CanonicalNotificationEvent,
-  type NotificationSeverity
+  type CanonicalNotificationEvent
 } from '@/types/events'
 import LoadingSkeleton from '@/components/LoadingSkeleton.vue'
 import EmptyState from '@/components/EmptyState.vue'
@@ -424,13 +313,13 @@ interface DashboardBriefItem {
   detail: string
   icon: string
   tone: 'live' | 'recording' | 'queue' | 'danger' | 'success' | 'info'
+  route: string
 }
 
 interface DashboardPrimaryAction {
   label: string
   icon: string
-  route?: string
-  targetId?: string
+  route: string
 }
 
 interface FailureItem {
@@ -458,11 +347,6 @@ interface QueueStats {
   active_tasks: number
   workers: number | Record<string, unknown> | unknown[]
   is_running: boolean
-}
-
-interface QueueWorkerItem {
-  label: string
-  value: string
 }
 
 const router = useRouter()
@@ -500,39 +384,6 @@ const recordingStreamers = computed(() => streamers.value.filter((s) => s.is_rec
 const totalStreamers = computed(() => streamers.value.length)
 const isDashboardLoading = computed(() => isLoadingStreamers.value || isLoadingRecordings.value || isLoadingQueue.value)
 
-const workerCount = computed(() => {
-  const workers = queueStats.value.workers
-  if (typeof workers === 'number') return workers
-  if (Array.isArray(workers)) return workers.length
-  if (workers && typeof workers === 'object') {
-    const total = readWorkerNumber(workers, ['total_workers', 'workers', 'worker_count', 'total'])
-    if (total !== null) return total
-    const streamers = readWorkerNumber(workers, ['streamers', 'streamer_count'])
-    if (streamers !== null) return streamers
-  }
-  return 0
-})
-
-const queueWorkerItems = computed<QueueWorkerItem[]>(() => {
-  const workers = queueStats.value.workers
-  if (!workers || typeof workers === 'number') return []
-  if (Array.isArray(workers)) {
-    return [{ label: 'Worker pool', value: `${workers.length} worker${workers.length === 1 ? '' : 's'}` }]
-  }
-
-  const items: QueueWorkerItem[] = []
-  const total = readWorkerNumber(workers, ['total_workers', 'workers', 'worker_count', 'total'])
-  const maxPerStreamer = readWorkerNumber(workers, ['max_per_streamer', 'max_workers_per_streamer'])
-  const streamers = readWorkerNumber(workers, ['streamers', 'streamer_count'])
-  const isolation = readWorkerBoolean(workers, ['isolation_enabled', 'per_streamer_isolation', 'isolated'])
-
-  if (total !== null) items.push({ label: 'Total workers', value: String(total) })
-  if (maxPerStreamer !== null) items.push({ label: 'Max per streamer', value: String(maxPerStreamer) })
-  if (streamers !== null) items.push({ label: 'Streamers', value: String(streamers) })
-  if (isolation !== null) items.push({ label: 'Isolation', value: isolation ? 'Enabled' : 'Disabled' })
-  return items
-})
-
 const recentRecordings = computed(() => {
   return [...videos.value]
     .sort((a, b) => {
@@ -544,12 +395,6 @@ const recentRecordings = computed(() => {
 })
 
 const visibleActiveRecordings = computed(() => activeRecordings.value.slice(0, 5))
-
-const totalProgress = computed(() => {
-  if (activeTasks.value.length === 0) return 0
-  const sum = activeTasks.value.reduce((total, task) => total + (task.progress || 0), 0)
-  return sum / activeTasks.value.length
-})
 
 const recentActivity = computed<CanonicalNotificationEvent[]>(() => {
   return realtime.recentEvents
@@ -617,16 +462,16 @@ const dashboardStatusLine = computed(() => {
 
 const primaryAction = computed<DashboardPrimaryAction>(() => {
   if (failureItems.value.length > 0) {
-    return { label: 'Review alerts', icon: '#icon-alert-triangle', targetId: 'failures-section-title' }
+    return { label: 'Review alerts', icon: '#icon-alert-triangle', route: '/videos' }
   }
   if (liveStreamers.value.length > 0) {
-    return { label: 'Open live list', icon: '#icon-radio', targetId: 'live-section-title' }
+    return { label: 'Open live list', icon: '#icon-radio', route: '/streamers?filter=live' }
   }
   if (activeRecordings.value.length > 0) {
-    return { label: 'Follow recording', icon: '#icon-video', targetId: 'recordings-section-title' }
+    return { label: 'Follow recording', icon: '#icon-video', route: '/streamers?filter=recording' }
   }
   if (queueStats.value.active_tasks + queueStats.value.pending_tasks > 0) {
-    return { label: 'Check queue', icon: '#icon-activity', targetId: 'queue-section-title' }
+    return { label: 'Check queue', icon: '#icon-activity', route: '/videos' }
   }
   return { label: 'Open library', icon: '#icon-film', route: '/videos' }
 })
@@ -637,35 +482,40 @@ const dashboardBriefItems = computed<DashboardBriefItem[]>(() => [
     value: isLoadingStreamers.value ? 'Checking' : `${liveStreamers.value.length} online`,
     detail: `${totalStreamers.value} tracked`,
     icon: '#icon-radio',
-    tone: liveStreamers.value.length > 0 ? 'live' : 'info'
+    tone: liveStreamers.value.length > 0 ? 'live' : 'info',
+    route: '/streamers?filter=live'
   },
   {
     label: 'Recording',
     value: isLoadingRecordings.value ? 'Checking' : `${activeRecordings.value.length} active`,
     detail: `${recordingStreamers.value.length} streamer${recordingStreamers.value.length === 1 ? '' : 's'} marked`,
     icon: '#icon-video',
-    tone: activeRecordings.value.length > 0 ? 'recording' : 'success'
+    tone: activeRecordings.value.length > 0 ? 'recording' : 'success',
+    route: '/streamers?filter=recording'
   },
   {
     label: 'Queue',
     value: isLoadingQueue.value ? 'Checking' : queueStateLabel.value,
     detail: `${queueStats.value.active_tasks} active, ${queueStats.value.pending_tasks} pending`,
     icon: '#icon-activity',
-    tone: queueStats.value.failed_tasks > 0 ? 'danger' : 'queue'
+    tone: queueStats.value.failed_tasks > 0 ? 'danger' : 'queue',
+    route: '/videos'
   },
   {
     label: 'Errors',
     value: `${failureItems.value.length} alert${failureItems.value.length === 1 ? '' : 's'}`,
     detail: failureItems.value.length > 0 ? 'Needs review' : 'No active alerts',
     icon: failureItems.value.length > 0 ? '#icon-alert-triangle' : '#icon-check-circle',
-    tone: failureItems.value.length > 0 ? 'danger' : 'success'
+    tone: failureItems.value.length > 0 ? 'danger' : 'success',
+    route: '/videos'
   },
   {
     label: 'Recent activity',
     value: recentActivity.value.length > 0 ? `${recentActivity.value.length} event${recentActivity.value.length === 1 ? '' : 's'}` : 'Quiet',
     detail: latestActivitySummary.value,
     icon: '#icon-clock',
-    tone: recentActivity.value.length > 0 ? 'info' : 'success'
+    tone: recentActivity.value.length > 0 ? 'info' : 'success',
+    route: '/videos'
   }
 ])
 
@@ -692,13 +542,6 @@ const queueStateLabel = computed(() => {
   if (queueStats.value.pending_tasks > 0) return 'Queued'
   if (queueStats.value.failed_tasks > 0) return 'Needs attention'
   return queueStats.value.is_running ? 'Idle' : 'Paused'
-})
-
-const queueBadgeTone = computed<StatusBadgeTone>(() => {
-  if (queueStats.value.failed_tasks > 0) return 'danger'
-  if (queueStats.value.active_tasks > 0) return 'processing'
-  if (queueStats.value.pending_tasks > 0) return 'warning'
-  return queueStats.value.is_running ? 'success' : 'neutral'
 })
 
 async function fetchStreamers() {
@@ -776,16 +619,7 @@ function playVideo(video: VideoSummary) {
 }
 
 function handleDashboardPrimaryAction() {
-  if (primaryAction.value.route) {
-    router.push(primaryAction.value.route)
-    return
-  }
-
-  if (!primaryAction.value.targetId) return
-  document.getElementById(primaryAction.value.targetId)?.scrollIntoView({
-    behavior: 'smooth',
-    block: 'start'
-  })
+  router.push(primaryAction.value.route)
 }
 
 async function handleForceRecord(streamer: { id: number }) {
@@ -819,34 +653,6 @@ function recordingStreamerLink(recording: ActiveRecording) {
 function recordingLiveLink(recording: ActiveRecording) {
   const target = recording.streamer_name || recording.username || recording.streamer_id
   return target ? `/live/${target}` : '/streamers'
-}
-
-function readWorkerNumber(source: Record<string, unknown>, keys: string[]) {
-  for (const key of keys) {
-    const value = source[key]
-    if (typeof value === 'number') return value
-    if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) return Number(value)
-  }
-  return null
-}
-
-function readWorkerBoolean(source: Record<string, unknown>, keys: string[]) {
-  for (const key of keys) {
-    const value = source[key]
-    if (typeof value === 'boolean') return value
-    if (typeof value === 'string') {
-      if (value.toLowerCase() === 'true') return true
-      if (value.toLowerCase() === 'false') return false
-    }
-  }
-  return null
-}
-
-function activityTone(severity: NotificationSeverity): StatusBadgeTone {
-  if (severity === 'critical' || severity === 'error') return 'danger'
-  if (severity === 'warning') return 'warning'
-  if (severity === 'success') return 'success'
-  return 'info'
 }
 
 onMounted(() => {
@@ -1155,6 +961,11 @@ onMounted(async () => {
   text-transform: uppercase;
 }
 
+.brief-actions {
+  display: flex;
+  flex: 0 0 auto;
+}
+
 .brief-primary-action {
   display: inline-flex;
   align-items: center;
@@ -1186,13 +997,16 @@ onMounted(async () => {
 
 .brief-item {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: var(--spacing-3);
   min-width: 0;
   padding: var(--spacing-4);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   background: rgba(var(--background-card-rgb, 20, 22, 29), 0.58);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color v.$duration-200 v.$ease-out, transform v.$duration-200 v.$ease-out, box-shadow v.$duration-200 v.$ease-out;
 
   strong,
   .brief-item-detail {
@@ -1206,6 +1020,36 @@ onMounted(async () => {
     color: var(--text-primary);
     font-size: var(--text-lg);
     font-weight: v.$font-bold;
+  }
+
+  &:hover {
+    border-color: var(--primary-color);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(var(--primary-color-rgb), 0.15);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+}
+
+.brief-item-arrow {
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary);
+  opacity: 0;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+    fill: none;
+  }
+
+  .brief-item:hover & {
+    opacity: 1;
+    color: var(--primary-color);
   }
 }
 
@@ -1259,14 +1103,12 @@ onMounted(async () => {
 }
 
 .dashboard-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.38fr);
+  display: flex;
+  flex-direction: column;
   gap: var(--spacing-6);
-  align-items: start;
 }
 
-.dashboard-main,
-.dashboard-sidebar {
+.dashboard-main {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-6);
@@ -1387,112 +1229,9 @@ onMounted(async () => {
   fill: none;
 }
 
-.queue-progress {
-  margin-bottom: var(--spacing-4);
-}
 
-.queue-progress-header {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--spacing-3);
-  margin-bottom: var(--spacing-2);
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-
-  strong {
-    color: var(--text-primary);
-  }
-}
-
-.queue-progress-bar {
-  height: 8px;
-  overflow: hidden;
-  border-radius: var(--radius-full);
-  background: var(--background-darker);
-
-  span {
-    display: block;
-    height: 100%;
-    border-radius: inherit;
-    background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-    transition: width v.$duration-300 v.$ease-out;
-  }
-}
-
-.queue-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--spacing-3);
-  margin: 0 0 var(--spacing-4);
-
-  div {
-    padding: var(--spacing-3);
-    border-radius: var(--radius-md);
-    background: rgba(var(--background-darker-rgb, 10, 10, 10), 0.26);
-  }
-
-  dt {
-    color: var(--text-secondary);
-    font-size: var(--text-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-  }
-
-  dd {
-    margin: var(--spacing-1) 0 0;
-    color: var(--text-primary);
-    font-size: var(--text-2xl);
-    font-weight: v.$font-bold;
-  }
-}
-
-.queue-worker-state {
-  display: grid;
-  gap: var(--spacing-2);
-  margin: 0 0 var(--spacing-4);
-
-  div {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-3);
-    padding: var(--spacing-2) var(--spacing-3);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    background: rgba(var(--background-darker-rgb, 10, 10, 10), 0.18);
-  }
-
-  dt,
-  dd {
-    margin: 0;
-    font-size: var(--text-sm);
-  }
-
-  dt {
-    color: var(--text-secondary);
-  }
-
-  dd {
-    color: var(--text-primary);
-    font-weight: v.$font-semibold;
-  }
-}
-
-.muted-row {
-  margin-bottom: var(--spacing-3);
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-}
-
-.danger-item {
-  border-color: rgba(var(--danger-color-rgb), 0.24);
-}
 
 @include m.respond-below('xl') {
-  .dashboard-layout {
-    grid-template-columns: 1fr;
-  }
-
   .brief-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -1557,10 +1296,6 @@ onMounted(async () => {
 
   .hero-copy p {
     font-size: var(--text-base);
-  }
-
-  .queue-stats {
-    grid-template-columns: 1fr;
   }
 }
 

--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page-view live-player-view fade-in">
+  <div class="page-view live-player-view fade-in" :class="{ 'theater-mode': theaterMode }">
     <!-- Loading State -->
     <div v-if="isLoading" class="content-state">
       <LoadingSkeleton type="video" />
@@ -46,11 +46,20 @@
             <div v-if="streamInfo" class="live-status-strip" :aria-label="`Live stream status: ${streamStatusText}`">
               <span class="live-status-pill">
                 <span class="live-indicator"></span>
-                Live
+                {{ streamStatusText }}
               </span>
-              <span>{{ streamStatusText }}</span>
-              <span>{{ selectedQualityLabel }}</span>
             </div>
+            <button
+              type="button"
+              class="header-theater-toggle"
+              :aria-pressed="theaterMode"
+              @click="theaterMode = !theaterMode"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" class="header-theater-icon" aria-hidden="true">
+                <path d="M3 5h18v12H3V5zm2 2v8h14V7H5zm4 12h6v2H9v-2z"/>
+              </svg>
+              {{ theaterMode ? 'Exit theater' : 'Theater' }}
+            </button>
           </div>
 
           <!-- Video Container -->
@@ -101,6 +110,11 @@
                   <span class="meta-status">{{ streamStatusText }}</span>
                 </div>
 
+                <button @click="theaterMode = !theaterMode" class="control-button theater-button" :class="{ active: theaterMode }" :aria-label="theaterMode ? 'Show details' : 'Theater mode'">
+                  <svg viewBox="0 0 24 24" fill="currentColor" class="control-icon">
+                    <path d="M3 5h18v12H3V5zm2 2v8h14V7H5zm4 12h6v2H9v-2z"/>
+                  </svg>
+                </button>
                 <button @click="toggleFullscreen" class="control-button fullscreen-button" :aria-label="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'">
                   <svg v-if="!isFullscreen" viewBox="0 0 24 24" fill="currentColor" class="control-icon">
                     <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
@@ -240,6 +254,7 @@ const isPlaying = ref(false)
 const isRetrying = ref(false)
 const isMuted = ref(true)
 const isFullscreen = ref(false)
+const theaterMode = ref(false)
 const showControls = ref(true)
 const controlsTimeout = ref<number | null>(null)
 const hlsInstance = ref<any>(null)
@@ -740,6 +755,41 @@ onUnmounted(() => {
   @include m.respond-below('sm') {
     padding: var(--spacing-2) var(--spacing-2);
   }
+
+  &.theater-mode {
+    .player-main {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .info-sidebar {
+      display: none;
+    }
+
+    .player-header {
+      min-height: 0;
+      padding: var(--spacing-2) var(--spacing-3);
+    }
+
+    .stream-title {
+      font-size: var(--text-base);
+    }
+
+    .back-button {
+      min-height: 36px;
+      padding: var(--spacing-1) var(--spacing-3);
+      font-size: var(--text-xs);
+    }
+
+    .live-status-strip {
+      display: none;
+    }
+
+    .video-container {
+      aspect-ratio: auto;
+      max-height: calc(100dvh - var(--app-header-height, 56px) - 80px);
+      min-height: min(70dvh, calc(100dvh - var(--app-header-height, 56px) - 80px));
+    }
+  }
 }
 
 .fade-in {
@@ -897,6 +947,33 @@ onUnmounted(() => {
   font-size: var(--text-xs);
   font-weight: v.$font-semibold;
   flex-shrink: 0;
+}
+
+.header-theater-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  min-height: 36px;
+  padding: var(--spacing-1) var(--spacing-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--background-darker);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: v.$font-semibold;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.header-theater-toggle[aria-pressed="true"] {
+  border-color: var(--primary-color);
+  background: rgba(var(--primary-500-rgb), 0.16);
+  color: var(--primary-color);
+}
+
+.header-theater-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .live-status-pill {
@@ -1115,6 +1192,10 @@ onUnmounted(() => {
     width: 20px;
     height: 20px;
   }
+}
+
+.theater-button.active {
+  background: var(--primary-color);
 }
 
 .fullscreen-button {

--- a/app/frontend/src/views/StreamersView.vue
+++ b/app/frontend/src/views/StreamersView.vue
@@ -223,7 +223,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { streamersApi } from '@/services/api'
 import { useRealtimeStore } from '@/stores/realtime'
 import { hasRealtimeEventType } from '@/types/events'
@@ -236,6 +237,7 @@ import StreamerCard from '@/components/cards/StreamerCard.vue'
 
 // Real-time store for live updates
 const realtime = useRealtimeStore()
+const route = useRoute()
 
 // Force recording composable
 const { forceStartRecording } = useForceRecording()  // NEW: Use composable
@@ -251,6 +253,15 @@ const activeFilter = ref('all')
 const autoRefresh = ref(true)
 const lastUpdateTime = ref<Date | null>(null)
 const fetchError = ref('')
+
+const validFilters = new Set(['all', 'live', 'recording', 'offline'])
+
+function applyFilterFromRoute() {
+  const routeFilter = Array.isArray(route.query.filter) ? route.query.filter[0] : route.query.filter
+  if (typeof routeFilter === 'string' && validFilters.has(routeFilter)) {
+    activeFilter.value = routeFilter
+  }
+}
 
 // Auto-refresh interval
 let refreshInterval: number | null = null
@@ -490,6 +501,7 @@ const realtimeCleanups: (() => void)[] = []
 
 // Lifecycle
 onMounted(async () => {
+  applyFilterFromRoute()
   await loadStreamers()
   if (autoRefresh.value) {
     startAutoRefresh()
@@ -581,6 +593,11 @@ onMounted(async () => {
     }),
   )
 })
+
+watch(
+  () => route.query.filter,
+  () => applyFilterFromRoute()
+)
 
 onUnmounted(() => {
   stopAutoRefresh()
@@ -786,32 +803,35 @@ onUnmounted(() => {
 
 // Controls Bar
 .controls-bar {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(180px, auto);
   gap: var(--spacing-3);
-  margin-bottom: var(--spacing-4);
-  flex-wrap: wrap;
   align-items: center;
+  margin-bottom: var(--spacing-4);
 }
 
+$ctrl-h: 40px;
+
 .search-box {
+  grid-column: 1 / -1;
   position: relative;
-  flex: 1;
-  min-width: 280px;
+  min-width: 0;
 
   .icon {
     position: absolute;
     left: var(--spacing-3);
     top: 50%;
     transform: translateY(-50%);
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     pointer-events: none;
     z-index: 10;
   }
 
   .search-input {
     width: 100%;
-    padding: var(--spacing-3) var(--spacing-10) var(--spacing-3) var(--spacing-10);
+    min-height: $ctrl-h;
+    padding: 0 var(--spacing-10);
     background: var(--background-card);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-lg);
@@ -851,6 +871,8 @@ onUnmounted(() => {
       height: 16px;
       stroke: var(--text-secondary);
       fill: none;
+      position: static;
+      transform: none;
     }
 
     &:hover {
@@ -868,16 +890,16 @@ onUnmounted(() => {
   gap: var(--spacing-1);
   background: var(--background-card);
   border-radius: var(--radius-lg);
-  padding: var(--spacing-1);
+  padding: 3px;
   border: 1px solid var(--border-color);
 }
 
 .filter-tab {
   display: inline-flex;
   align-items: center;
-  gap: var(--spacing-2);
-  min-height: 44px;
-  padding: var(--spacing-2) var(--spacing-3);
+  gap: var(--spacing-1-5);
+  min-height: $ctrl-h;
+  padding: 0 var(--spacing-3);
   background: transparent;
   border: none;
   border-radius: var(--radius-md);
@@ -922,14 +944,14 @@ onUnmounted(() => {
   gap: var(--spacing-1);
   background: var(--background-card);
   border-radius: var(--radius-lg);
-  padding: var(--spacing-1);
+  padding: 3px;
   border: 1px solid var(--border-color);
 }
 
 .toggle-btn {
-  min-width: 44px;
-  min-height: 44px;
-  padding: var(--spacing-2);
+  width: $ctrl-h;
+  min-height: $ctrl-h;
+  padding: 0;
   background: transparent;
   border: none;
   cursor: pointer;
@@ -937,8 +959,8 @@ onUnmounted(() => {
   transition: all v.$duration-200 v.$ease-out;
 
   .icon {
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     stroke: var(--text-secondary);
     fill: none;
   }
@@ -957,11 +979,13 @@ onUnmounted(() => {
 }
 
 .sort-control-wrap {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-2);
-  min-height: 44px;
-  padding: 0 var(--spacing-3);
+  min-height: $ctrl-h;
+  min-width: 180px;
+  padding: 0 var(--spacing-8) 0 var(--spacing-3);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   background: var(--background-card);
@@ -969,28 +993,45 @@ onUnmounted(() => {
   overflow: hidden;
 }
 
+.sort-control-wrap::after {
+  content: '';
+  position: absolute;
+  right: var(--spacing-3);
+  width: 0.45rem;
+  height: 0.45rem;
+  border-right: 2px solid var(--text-secondary);
+  border-bottom: 2px solid var(--text-secondary);
+  pointer-events: none;
+  transform: translateY(-15%) rotate(45deg);
+}
+
 .sort-icon {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: var(--text-secondary);
   stroke: currentColor;
   fill: none;
+  flex-shrink: 0;
 }
 
 .sort-label {
   color: var(--text-secondary);
   font-size: var(--text-sm);
   font-weight: v.$font-semibold;
+  white-space: nowrap;
 }
 
 .sort-control {
-  min-width: 132px;
-  min-height: 40px;
+  min-width: 0;
+  min-height: $ctrl-h;
   margin: 0;
-  padding: 0 var(--spacing-6) 0 0;
+  padding: 0;
   appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   background: transparent;
   background-color: transparent;
+  background-image: none;
   border: 0;
   box-shadow: none;
   color: var(--text-primary);
@@ -1012,14 +1053,11 @@ onUnmounted(() => {
 .results-info {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-3);
-  flex: 0 1 auto;
-  margin-left: auto;
-  min-height: 44px;
-  padding: 0 var(--spacing-2) 0 var(--spacing-3);
-  background: transparent;
-  border: 0;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+  grid-column: 1 / -1;
+  min-height: $ctrl-h;
+  padding: 0 var(--spacing-2);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -1032,8 +1070,8 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: $ctrl-h;
+  min-height: $ctrl-h;
   padding: 0;
   background: transparent;
   border: none;
@@ -1110,18 +1148,11 @@ onUnmounted(() => {
   }
 
   .controls-bar {
-    flex-wrap: wrap;
-  }
-
-  .search-box {
-    order: -1;
-    width: 100%;
-    flex-basis: 100%;
-    min-width: unset;
+    grid-template-columns: minmax(0, 1fr) auto minmax(204px, auto);
   }
 
   .filter-tabs {
-    flex: 1;
+    min-width: 0;
   }
 }
 
@@ -1165,11 +1196,6 @@ onUnmounted(() => {
     min-width: 0;
   }
 
-  .results-info {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
   .btn-action {
     flex: 1;
     justify-content: center;
@@ -1178,13 +1204,14 @@ onUnmounted(() => {
 
   .controls-bar {
     gap: var(--spacing-2);
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .search-box {
     .search-input {
       min-height: 44px;  // Touch-friendly
       font-size: 16px;  // Prevent iOS zoom
-      padding: var(--spacing-3) var(--spacing-10);
+      padding: 0 var(--spacing-10);
     }
 
     .clear-btn {
@@ -1199,9 +1226,9 @@ onUnmounted(() => {
   }
 
   .filter-tabs {
+    grid-column: 1 / -1;
     width: 100%;
     justify-content: stretch;
-    flex: none;  // Don't shrink
 
     .filter-tab {
       flex: 1;
@@ -1233,17 +1260,20 @@ onUnmounted(() => {
     }
   }
 
-  .sort-control {
-    flex: 1;
-    min-width: 0;
-
-    :deep(select) {
-      min-height: 44px;
-      font-size: 16px;
-      padding: var(--spacing-3);
-      padding-left: var(--spacing-4);
-    }
+  .sort-control-wrap {
+    grid-column: 1 / -1;
+    min-height: 44px;
   }
 
+  .sort-control {
+    min-width: 0;
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .results-info {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }
 </style>

--- a/app/frontend/src/views/VideoPlayerView.vue
+++ b/app/frontend/src/views/VideoPlayerView.vue
@@ -52,6 +52,17 @@
               <span>{{ streamerName }}</span>
             </div>
             <PlayerStatus :state="currentPlayerState" />
+            <button
+              type="button"
+              class="theater-toggle"
+              :aria-pressed="theaterMode"
+              @click="theaterMode = !theaterMode"
+            >
+              <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M3 5h18v12H3V5zm2 2v8h14V7H5zm4 12h6v2H9v-2z"/>
+              </svg>
+              {{ theaterMode ? 'Exit theater' : 'Theater' }}
+            </button>
           </div>
 
           <!-- Video Player - directly in card, no wrapper -->
@@ -249,7 +260,7 @@ const currentPlayerState = computed(() => {
   if (error.value) return 'error'
   if (playerError.value) return 'error'
   if (!chapterData.value?.video_url) return 'idle'
-  return playerReady.value ? 'live' : 'loading'
+  return playerReady.value ? 'recorded' : 'loading'
 })
 
 // Action button states
@@ -621,8 +632,27 @@ onMounted(() => {
     display: none;
   }
 
+  .player-header {
+    min-height: 0;
+    padding: var(--spacing-2) var(--spacing-3);
+  }
+
+  .player-header .video-title {
+    font-size: var(--text-base);
+  }
+
+  .player-header .back-button {
+    min-height: 36px;
+    padding: var(--spacing-1) var(--spacing-3);
+    font-size: var(--text-xs);
+  }
+
+  .player-header .streamer-badge {
+    display: none;
+  }
+
   .player-card :deep(video) {
-    max-height: calc(100dvh - var(--app-header-height, 56px) - 132px);
+    max-height: calc(100dvh - var(--app-header-height, 56px) - 80px);
   }
 }
 
@@ -666,27 +696,29 @@ onMounted(() => {
 }
 
 .player-card :deep(video) {
-  max-height: calc(100dvh - var(--app-header-height, 56px) - 168px);
+  max-height: calc(100dvh - var(--app-header-height, 56px) - 100px);
   object-fit: contain;
 }
 
 .player-header {
   display: flex;
   align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-3) var(--spacing-4);
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  min-height: 48px;
 
   @include m.respond-below('md') {
     flex-wrap: wrap;
-    padding: var(--spacing-3);
+    padding: var(--spacing-2);
+    gap: var(--spacing-2);
   }
 }
 
 .back-button {
   display: inline-flex;
   align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-4);
+  gap: var(--spacing-1-5);
+  padding: var(--spacing-1) var(--spacing-3);
   background: var(--background-darker);
   color: var(--text-primary);
   border: 1px solid var(--border-color);
@@ -696,11 +728,11 @@ onMounted(() => {
   cursor: pointer;
   transition: all v.$duration-200 v.$ease-out;
   flex-shrink: 0;
-  min-height: 44px;
+  min-height: 36px;
 
   .icon {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     stroke: currentColor;
     fill: none;
   }
@@ -709,12 +741,6 @@ onMounted(() => {
     background: var(--primary-color);
     border-color: var(--primary-color);
     color: white;
-  }
-
-  @include m.respond-below('md') {
-    min-height: 44px;  // Touch-friendly
-    padding: var(--spacing-2) var(--spacing-4);
-    font-size: var(--text-sm);
   }
 }
 
@@ -751,7 +777,7 @@ onMounted(() => {
 .video-title {
   flex: 1;
   margin: 0;
-  font-size: var(--text-lg);
+  font-size: var(--text-sm);
   font-weight: v.$font-semibold;
   color: var(--text-primary);
   white-space: nowrap;
@@ -762,35 +788,37 @@ onMounted(() => {
     white-space: normal;
     overflow: visible;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
     -webkit-box-orient: vertical;
   }
 
   @include m.respond-below('md') {
-    font-size: var(--text-base);
-    order: 3;
+    order: 100;
     flex-basis: 100%;
-    margin-top: var(--spacing-2);
+    margin-top: var(--spacing-1);
+    white-space: normal;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
   }
 }
 
 .streamer-badge {
   display: inline-flex;
   align-items: center;
-  gap: var(--spacing-2);
+  gap: var(--spacing-1);
   background: rgba(var(--primary-500-rgb), 0.15);
   border: 1px solid rgba(var(--primary-500-rgb), 0.3);
   border-radius: var(--radius-pill);
-  padding: var(--spacing-1) var(--spacing-3);
-  font-size: var(--text-sm);
+  padding: var(--spacing-0-5) var(--spacing-2);
+  font-size: var(--text-xs);
   font-weight: v.$font-medium;
   color: var(--primary-color);
   flex-shrink: 0;
 
   .icon-streamer {
-    width: 14px;
-    height: 14px;
+    width: 12px;
+    height: 12px;
     stroke: currentColor;
     fill: none;
   }


### PR DESCRIPTION
## Summary
- Reworks dashboard into an overview-first layout with compact status cards, live streamers, active recordings, and latest videos.
- Tightens notification filters, streamer toolbar rhythm, grid/list cards, and title clamping.
- Updates stored and live watch layouts with real theater controls, viewport-fit video areas, and non-duplicated live/VOD status chips.

## Verification
- npm run lint:tokens
- npm run type-check
- npm run build
- npm run lint
- git diff --check
- grep -rP "[\x{2013}\x{2014}]" touched frontend files
- Browser smoke on mock dev server: Dashboard, Notifications empty state, Streamers grid/list, VOD normal/theater, Live normal/theater

Do not merge until Max reviews.