### PR TITLE
Fix notification event metadata

### DIFF
--- a/app/frontend/src/components/VideoPlayer.vue
+++ b/app/frontend/src/components/VideoPlayer.vue
@@ -1594,6 +1594,12 @@ defineExpose({ seekToChapter })
   box-shadow: var(--shadow-md), 0 0 16px rgba(var(--primary-color-rgb), 0.3);
 }
 
+.theater-button {
+  @include m.respond-below('md') {
+    display: none;
+  }
+}
+
 .chapters-button .chapter-count {
   font-size: var(--text-xs);  /* 12px */
   font-weight: var(--font-bold);  /* 700 */

--- a/app/frontend/src/components/notifications/NotificationItem.vue
+++ b/app/frontend/src/components/notifications/NotificationItem.vue
@@ -28,15 +28,34 @@ const categoryImage = computed(() => {
 
 const statusTone = computed(() => getNotificationTone(props.notification))
 const hasTarget = computed(() => Boolean(props.notification.target_url))
-const targetLabel = computed(() => props.notification.target_url || '')
-const deliveryLabel = computed(() => {
-  if (props.notification.source === 'push') return 'Push delivery'
-  if (props.notification.source === 'apprise') return 'Apprise delivery'
-  if (props.notification.source === 'test') return 'Test channel'
-  if (props.notification.source === 'system') return 'System event'
-  return 'Live WebSocket event'
+const displayTitle = computed(() => {
+  if (isStreamUpdateNotification(props.notification)) {
+    return firstNotificationString(
+      props.notification.streamer_name,
+      props.notification.streamer_username,
+      props.notification.data?.streamer_name,
+      props.notification.data?.username
+    ) || props.notification.title
+  }
+
+  return props.notification.title
+})
+const showSeverityBadge = computed(() => {
+  return !(isStreamUpdateNotification(props.notification) && props.notification.severity === 'info')
 })
 const typeLabel = computed(() => props.notification.type.replaceAll('.', ' '))
+
+function firstNotificationString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value
+    }
+  }
+}
+
+function isStreamUpdateNotification(notification: StoredNotification): boolean {
+  return notification.type === 'channel.update' || notification.type === 'stream.update'
+}
 
 function formatTime(timestamp: string): string {
   const now = new Date()
@@ -127,7 +146,7 @@ function openNotification() {
   <article
     class="notification-item"
     :class="[statusTone, { unread: !notification.read, 'has-target': hasTarget }]"
-    :aria-label="`${notification.title}. ${notification.body}`"
+    :aria-label="`${displayTitle}. ${notification.body}`"
     :tabindex="hasTarget ? 0 : undefined"
     @click="openNotification"
     @keydown.enter="openNotification"
@@ -143,7 +162,7 @@ function openNotification() {
       <div class="notification-title-row">
         <div class="title-stack">
           <span v-if="!notification.read" class="unread-dot" aria-label="Unread notification"></span>
-          <h3>{{ notification.title }}</h3>
+          <h3>{{ displayTitle }}</h3>
         </div>
         <time :datetime="notification.timestamp">{{ formatTime(notification.timestamp) }}</time>
       </div>
@@ -152,6 +171,7 @@ function openNotification() {
 
       <div class="notification-meta" aria-label="Notification details">
         <StatusBadge
+          v-if="showSeverityBadge"
           class="notification-severity-badge"
           :tone="statusTone"
           size="sm"
@@ -160,7 +180,6 @@ function openNotification() {
           {{ notification.severity }}
         </StatusBadge>
         <span class="meta-pill">{{ typeLabel }}</span>
-        <span class="meta-pill" :title="notification.dedupe_key || undefined">{{ deliveryLabel }}</span>
         <span v-if="categoryName" class="meta-pill category-tag">
           <span class="category-image-small" aria-hidden="true">
             <img
@@ -173,10 +192,6 @@ function openNotification() {
           </span>
           {{ categoryName }}
         </span>
-        <span v-if="targetLabel" class="meta-pill target-pill" :title="targetLabel">
-          <svg class="target-svg" aria-hidden="true"><use href="#icon-link" /></svg>
-          Target: {{ targetLabel }}
-        </span>
       </div>
     </div>
 
@@ -185,7 +200,7 @@ function openNotification() {
         v-if="hasTarget"
         type="button"
         class="item-action primary"
-        :aria-label="`Open notification target for ${notification.title}`"
+        :aria-label="`Open notification target for ${displayTitle}`"
         @click.stop="emit('open', notification)"
       >
         Open
@@ -193,7 +208,7 @@ function openNotification() {
       <button
         type="button"
         class="item-action"
-        :aria-label="notification.read ? `Mark ${notification.title} unread` : `Mark ${notification.title} read`"
+        :aria-label="notification.read ? `Mark ${displayTitle} unread` : `Mark ${displayTitle} read`"
         @click.stop="emit('toggle-read', notification)"
       >
         {{ notification.read ? 'Unread' : 'Read' }}
@@ -201,7 +216,7 @@ function openNotification() {
       <button
         type="button"
         class="item-action icon-only"
-        :aria-label="`Dismiss ${notification.title}`"
+        :aria-label="`Dismiss ${displayTitle}`"
         @click.stop="emit('remove', notification.id)"
       >
         ×
@@ -387,22 +402,6 @@ time {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.target-pill {
-  max-width: min(100%, 18rem);
-  overflow: hidden;
-  color: var(--text-primary);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.target-svg {
-  flex: 0 0 auto;
-  width: 0.85rem;
-  height: 0.85rem;
-  stroke: currentColor;
-  fill: none;
 }
 
 .category-image-small {

--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -43,24 +43,9 @@
 
             <h1 class="stream-title">{{ streamerName }}</h1>
 
-            <div v-if="streamInfo" class="live-status-strip" :aria-label="`Live stream status: ${streamStatusText}`">
-              <span class="live-status-pill">
-                <span class="live-indicator"></span>
-                {{ streamStatusText }}
-              </span>
+            <div v-if="streamInfo" class="live-status-strip" aria-label="Live stream status: Live">
+              <span class="live-status-pill">Live</span>
             </div>
-            <button
-              v-if="!isNarrowViewport"
-              type="button"
-              class="header-theater-toggle"
-              :aria-pressed="effectiveTheaterMode"
-              @click="theaterMode = !theaterMode"
-            >
-              <svg viewBox="0 0 24 24" fill="currentColor" class="header-theater-icon" aria-hidden="true">
-                <path d="M3 5h18v12H3V5zm2 2v8h14V7H5zm4 12h6v2H9v-2z"/>
-              </svg>
-              {{ effectiveTheaterMode ? 'Exit theater' : 'Theater' }}
-            </button>
           </div>
 
           <!-- Video Container -->
@@ -113,7 +98,7 @@
 
                 <button
                   v-if="!isNarrowViewport"
-                  @click="theaterMode = !theaterMode"
+                  @click="toggleTheaterMode"
                   class="control-button theater-button"
                   :class="{ active: effectiveTheaterMode }"
                   :aria-label="effectiveTheaterMode ? 'Show details' : 'Theater mode'"
@@ -309,6 +294,11 @@ const effectiveTheaterMode = computed(() => theaterMode.value && !isNarrowViewpo
 
 const updateViewportMode = () => {
   isNarrowViewport.value = window.matchMedia('(max-width: 767px)').matches
+}
+
+const toggleTheaterMode = () => {
+  if (isNarrowViewport.value) return
+  theaterMode.value = !theaterMode.value
 }
 
 const codecModeLabel = computed(() => {
@@ -803,9 +793,9 @@ onUnmounted(() => {
     }
 
     .video-container {
-      aspect-ratio: auto;
-      max-height: calc(100dvh - var(--app-header-height, 56px) - 80px);
-      min-height: min(70dvh, calc(100dvh - var(--app-header-height, 56px) - 80px));
+      width: min(100%, calc((100dvh - var(--app-header-height, 56px) - 144px) * 16 / 9));
+      max-height: calc(100dvh - var(--app-header-height, 56px) - 144px);
+      margin: 0 auto;
     }
 
     @include m.respond-below('md') {
@@ -975,53 +965,12 @@ onUnmounted(() => {
   flex-shrink: 0;
 }
 
-.header-theater-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-1-5);
-  min-height: 36px;
-  padding: var(--spacing-1) var(--spacing-3);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  background: var(--background-darker);
-  color: var(--text-primary);
-  font-size: var(--text-xs);
-  font-weight: v.$font-semibold;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.header-theater-toggle[aria-pressed="true"] {
-  border-color: var(--primary-color);
-  background: rgba(var(--primary-500-rgb), 0.16);
-  color: var(--primary-color);
-}
-
-.header-theater-icon {
-  width: 16px;
-  height: 16px;
-}
-
 .live-status-pill {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-1);
   color: var(--danger-text-color);
-  font-weight: v.$font-bold;
-  text-transform: uppercase;
-}
-
-.live-indicator {
-  width: 8px;
-  height: 8px;
-  background: white;
-  border-radius: 50%;
-  animation: pulse-live 2s ease-in-out infinite;
-}
-
-@keyframes pulse-live {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.5; transform: scale(1.2); }
+  font-weight: v.$font-semibold;
 }
 
 .player-state-indicator {

--- a/app/frontend/src/views/VideoPlayerView.vue
+++ b/app/frontend/src/views/VideoPlayerView.vue
@@ -29,7 +29,7 @@
     </div>
 
     <!-- Video Player - Main Content -->
-    <div v-else class="player-layout" :class="{ 'theater-mode': theaterMode }">
+    <div v-else class="player-layout" :class="{ 'theater-mode': effectiveTheaterMode }">
       <!-- Main Content: Video + Sidebar -->
       <div class="player-main">
         <!-- Video Player with Header -->
@@ -51,18 +51,7 @@
               </svg>
               <span>{{ streamerName }}</span>
             </div>
-            <PlayerStatus :state="currentPlayerState" />
-            <button
-              type="button"
-              class="theater-toggle"
-              :aria-pressed="theaterMode"
-              @click="theaterMode = !theaterMode"
-            >
-              <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M3 5h18v12H3V5zm2 2v8h14V7H5zm4 12h6v2H9v-2z"/>
-              </svg>
-              {{ theaterMode ? 'Exit theater' : 'Theater' }}
-            </button>
+            <span class="recorded-status">Recorded</span>
           </div>
 
           <!-- Video Player - directly in card, no wrapper -->
@@ -72,13 +61,13 @@
             :chapters="chapterData.chapters"
             :stream-title="chapterData.stream_title"
             :stream-id="parseInt(streamId)"
-            :theater-mode="theaterMode"
+            :theater-mode="effectiveTheaterMode"
             @chapter-change="onChapterChange"
             @video-ready="onVideoReady"
             @video-loading="onVideoLoading"
             @video-error="onVideoError"
             @time-update="onTimeUpdate"
-            @toggle-theater="theaterMode = !theaterMode"
+            @toggle-theater="toggleTheaterMode"
           />
         </GlassCard>
 
@@ -202,7 +191,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import VideoPlayer from '@/components/VideoPlayer.vue'
 import LoadingSkeleton from '@/components/LoadingSkeleton.vue'
@@ -254,14 +243,18 @@ const error = ref<string | null>(null)
 const playerReady = ref(false)
 const playerError = ref<string | null>(null)
 const theaterMode = ref(false)
+const isNarrowViewport = ref(false)
 
-const currentPlayerState = computed(() => {
-  if (isLoading.value) return 'loading'
-  if (error.value) return 'error'
-  if (playerError.value) return 'error'
-  if (!chapterData.value?.video_url) return 'idle'
-  return playerReady.value ? 'recorded' : 'loading'
-})
+const effectiveTheaterMode = computed(() => theaterMode.value && !isNarrowViewport.value)
+
+const updateViewportMode = () => {
+  isNarrowViewport.value = window.matchMedia('(max-width: 767px)').matches
+}
+
+const toggleTheaterMode = () => {
+  if (isNarrowViewport.value) return
+  theaterMode.value = !theaterMode.value
+}
 
 // Action button states
 const isDownloading = ref(false)
@@ -555,7 +548,13 @@ const deleteVideo = async () => {
 }
 
 onMounted(() => {
+  updateViewportMode()
+  window.addEventListener('resize', updateViewportMode)
   loadChapterData()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateViewportMode)
 })
 </script>
 
@@ -651,8 +650,14 @@ onMounted(() => {
     display: none;
   }
 
+  .player-card :deep(.video-wrapper) {
+    width: min(100%, calc((100dvh - var(--app-header-height, 56px) - 144px) * 16 / 9));
+    max-height: calc(100dvh - var(--app-header-height, 56px) - 144px);
+    margin: 0 auto;
+  }
+
   .player-card :deep(video) {
-    max-height: calc(100dvh - var(--app-header-height, 56px) - 80px);
+    max-height: calc(100dvh - var(--app-header-height, 56px) - 144px);
   }
 }
 
@@ -744,34 +749,19 @@ onMounted(() => {
   }
 }
 
-.theater-toggle {
+.recorded-status {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--spacing-2);
-  min-height: 40px;
-  padding: var(--spacing-2) var(--spacing-3);
+  min-height: 28px;
+  padding: var(--spacing-1) var(--spacing-2);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-pill);
   background: var(--background-darker);
-  color: var(--text-primary);
-  font-size: var(--text-sm);
-  font-weight: v.$font-medium;
-  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: v.$font-semibold;
   white-space: nowrap;
-
-  .icon {
-    width: 16px;
-    height: 16px;
-    stroke: currentColor;
-    fill: none;
-  }
-
-  &[aria-pressed="true"] {
-    border-color: var(--primary-color);
-    background: rgba(var(--primary-500-rgb), 0.16);
-    color: var(--primary-color);
-  }
 }
 
 .video-title {


### PR DESCRIPTION
## Summary
- show streamer names as headers for channel and stream update notifications when available
- remove internal source and target-path metadata from notification cards
- keep event type and Twitch category metadata visible

## Verification
- cd app/frontend && npm run lint:tokens && npm run type-check && npm run build && npm run lint
- git diff --check
- grep -rP "[\x{2013}\x{2014}]" app/frontend/src/components/notifications/NotificationItem.vue

Follow-up after merged PR #716.