### PR TITLE
fix: constrain desktop player viewport sizing

### DIFF
--- a/app/frontend/src/views/LivePlayerView.vue
+++ b/app/frontend/src/views/LivePlayerView.vue
@@ -793,8 +793,8 @@ onUnmounted(() => {
     }
 
     .video-container {
-      width: min(100%, calc((100dvh - var(--app-header-height, 56px) - 144px) * 16 / 9));
-      max-height: calc(100dvh - var(--app-header-height, 56px) - 144px);
+      width: min(100%, calc((100dvh - var(--app-header-height, 56px) - 112px) * 16 / 9));
+      max-height: calc(100dvh - var(--app-header-height, 56px) - 112px);
       margin: 0 auto;
     }
 
@@ -1015,8 +1015,9 @@ onUnmounted(() => {
   border-top: 1px solid var(--border-color);
 
   @include m.respond-to('md') {
-    max-width: none;
-    margin: 0;
+    width: min(100%, calc(min(62dvh, calc(100dvh - var(--app-header-height, 56px) - 192px)) * 16 / 9));
+    max-height: min(62dvh, calc(100dvh - var(--app-header-height, 56px) - 192px));
+    margin: 0 auto;
     aspect-ratio: 16/9;
   }
 

--- a/app/frontend/src/views/VideoPlayerView.vue
+++ b/app/frontend/src/views/VideoPlayerView.vue
@@ -651,13 +651,13 @@ onUnmounted(() => {
   }
 
   .player-card :deep(.video-wrapper) {
-    width: min(100%, calc((100dvh - var(--app-header-height, 56px) - 144px) * 16 / 9));
-    max-height: calc(100dvh - var(--app-header-height, 56px) - 144px);
+    width: min(100%, calc((100dvh - var(--app-header-height, 56px) - 112px) * 16 / 9));
+    max-height: calc(100dvh - var(--app-header-height, 56px) - 112px);
     margin: 0 auto;
   }
 
   .player-card :deep(video) {
-    max-height: calc(100dvh - var(--app-header-height, 56px) - 144px);
+    max-height: calc(100dvh - var(--app-header-height, 56px) - 112px);
   }
 }
 
@@ -701,8 +701,19 @@ onUnmounted(() => {
 }
 
 .player-card :deep(video) {
-  max-height: calc(100dvh - var(--app-header-height, 56px) - 100px);
+  max-height: min(62dvh, calc(100dvh - var(--app-header-height, 56px) - 192px));
   object-fit: contain;
+}
+
+.player-card :deep(.video-wrapper) {
+  width: min(100%, calc(min(62dvh, calc(100dvh - var(--app-header-height, 56px) - 192px)) * 16 / 9));
+  max-height: min(62dvh, calc(100dvh - var(--app-header-height, 56px) - 192px));
+  margin: 0 auto;
+}
+
+.player-card :deep(.video-player-container) {
+  display: flex;
+  justify-content: center;
 }
 
 .player-header {


### PR DESCRIPTION
## Summary
- Constrains the desktop VOD player wrapper by viewport height in normal mode so controls stay visible while the sidebar remains available.
- Lets desktop theater mode use a larger viewport-height budget while still fitting the full player and controls.
- Applies the same normal and theater sizing principle to the live player layout, with mobile theater still hidden by existing controls.

## Verification
- `cd app/frontend && npm run lint:tokens && npm run type-check && npm run build && npm run lint`
- `git diff --check`
- `grep -rP "[\\x{2013}\\x{2014}]" app/frontend/src/views/VideoPlayerView.vue app/frontend/src/views/LivePlayerView.vue` returned no matches.
- Playwright DOM smoke on VOD at 1280x720, 1366x768, 1440x900, and 1920x1080: normal and theater player controls fit within viewport; sidebar visible in normal and hidden in theater; mobile 390x844 theater button hidden.
- Browser DOM smoke on live at 1280x720: normal and theater live controls fit within viewport; sidebar visible in normal and hidden in theater.
