### PR TITLE
fix(db): enforce uniqueness of streams.twitch_stream_id

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -171,7 +171,7 @@ class Stream(Base):
     language = Column(String, nullable=True)
     started_at = Column(DateTime(timezone=True), nullable=True, index=True)
     ended_at = Column(DateTime(timezone=True), nullable=True, index=True)
-    twitch_stream_id = Column(String, nullable=True, index=True)
+    twitch_stream_id = Column(String, nullable=True, unique=True, index=True)
     recording_path = Column(String, nullable=True)  # Path to the recorded MP4 file
     episode_number = Column(Integer, nullable=True)  # Episode number for this stream
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/migrations/039_add_unique_twitch_stream_id.py
+++ b/migrations/039_add_unique_twitch_stream_id.py
@@ -1,0 +1,233 @@
+"""
+Migration: 039_add_unique_twitch_stream_id
+
+Deduplicates streams sharing the same twitch_stream_id and enforces
+uniqueness with a UNIQUE index on streams.twitch_stream_id.
+
+Background:
+- stream.online dedup in app/events/handler_registry.py relies on
+  twitch_stream_id being unique per Stream row, but the schema only had a
+  non-unique index. Duplicate webhook deliveries could create multiple
+  Stream rows for the same Twitch stream.
+
+Cleanup semantics (per set of rows sharing a non-NULL twitch_stream_id):
+- Survivor selection: prefer the row with Recordings attached, then the row
+  with StreamEvents attached, then the lowest id.
+- NULL columns on the survivor (title, category, timestamps, recording_path,
+  episode_number) are filled from the duplicates in id order.
+- stream_events, recordings and recording_processing_state rows are
+  repointed to the survivor.
+- One-row-per-stream tables (stream_metadata, active_recordings_state) keep
+  the survivor's row if it exists; otherwise one duplicate row is repointed.
+  Leftover rows are deleted together with the duplicate streams.
+
+Index:
+- Drops the old non-unique indexes (idx_streams_twitch_stream_id from
+  migration 004, ix_streams_twitch_stream_id from SQLAlchemy create_all)
+  and creates a UNIQUE index named ix_streams_twitch_stream_id to match the
+  model definition. twitch_stream_id stays nullable; both PostgreSQL and
+  SQLite allow multiple NULLs in a unique index.
+"""
+
+import logging
+
+from sqlalchemy import bindparam, inspect, text
+from app.database import engine
+
+logger = logging.getLogger("streamvault")
+
+SCRIPT_NAME = __name__.split(".")[-1] + ".py"
+
+# Nullable scalar columns merged from duplicates into the survivor
+MERGE_COLUMNS = (
+    "title",
+    "category_name",
+    "language",
+    "started_at",
+    "ended_at",
+    "recording_path",
+    "episode_number",
+)
+
+# Tables with a many-to-one FK to streams.id: all rows are repointed
+MANY_PER_STREAM_TABLES = (
+    "stream_events",
+    "recordings",
+    "recording_processing_state",
+)
+
+# Tables with at most one row per stream: repoint only if the survivor has none
+ONE_PER_STREAM_TABLES = (
+    "stream_metadata",
+    "active_recordings_state",
+)
+
+SQL_DROP_OLD_INDEXES = (
+    "DROP INDEX IF EXISTS idx_streams_twitch_stream_id",
+    "DROP INDEX IF EXISTS ix_streams_twitch_stream_id",
+)
+
+SQL_CREATE_UNIQUE_INDEX = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS ix_streams_twitch_stream_id "
+    "ON streams (twitch_stream_id)"
+)
+
+
+def _existing_tables(conn, table_names):
+    """Return only the table names that actually exist in this database."""
+    present = set(inspect(conn).get_table_names())
+    return [name for name in table_names if name in present]
+
+
+def _pick_survivor(conn, twitch_stream_id):
+    """Return (survivor_id, duplicate_ids) for one set of duplicate streams."""
+    rows = conn.execute(
+        text(
+            """
+            SELECT s.id,
+                   (SELECT COUNT(*) FROM recordings r WHERE r.stream_id = s.id) AS rec_count,
+                   (SELECT COUNT(*) FROM stream_events e WHERE e.stream_id = s.id) AS ev_count
+            FROM streams s
+            WHERE s.twitch_stream_id = :tsid
+            ORDER BY s.id
+            """
+        ),
+        {"tsid": twitch_stream_id},
+    ).fetchall()
+
+    ranked = sorted(rows, key=lambda r: (r.rec_count == 0, r.ev_count == 0, r.id))
+    survivor_id = ranked[0].id
+    duplicate_ids = [r.id for r in rows if r.id != survivor_id]
+    return survivor_id, duplicate_ids
+
+
+def _merge_scalar_columns(conn, survivor_id, duplicate_ids):
+    """Fill NULL columns on the survivor from the duplicates (in id order)."""
+    columns = ", ".join(MERGE_COLUMNS)
+    survivor = conn.execute(
+        text(f"SELECT {columns} FROM streams WHERE id = :sid"),
+        {"sid": survivor_id},
+    ).mappings().one()
+
+    missing = [col for col in MERGE_COLUMNS if survivor[col] is None]
+    if not missing:
+        return
+
+    updates = {}
+    for dup_id in duplicate_ids:
+        dup = conn.execute(
+            text(f"SELECT {columns} FROM streams WHERE id = :sid"),
+            {"sid": dup_id},
+        ).mappings().one()
+        for col in missing:
+            if col not in updates and dup[col] is not None:
+                updates[col] = dup[col]
+
+    if updates:
+        assignments = ", ".join(f"{col} = :{col}" for col in updates)
+        conn.execute(
+            text(f"UPDATE streams SET {assignments} WHERE id = :sid"),
+            {**updates, "sid": survivor_id},
+        )
+
+
+def _repoint_children(conn, survivor_id, duplicate_ids):
+    """Repoint child-table FKs from the duplicates to the survivor."""
+    params = {"sid": survivor_id, "dup_ids": duplicate_ids}
+
+    for table in _existing_tables(conn, MANY_PER_STREAM_TABLES):
+        conn.execute(
+            text(
+                f"UPDATE {table} SET stream_id = :sid WHERE stream_id IN :dup_ids"
+            ).bindparams(bindparam("dup_ids", expanding=True)),
+            params,
+        )
+
+    for table in _existing_tables(conn, ONE_PER_STREAM_TABLES):
+        survivor_has_row = conn.execute(
+            text(f"SELECT 1 FROM {table} WHERE stream_id = :sid LIMIT 1"),
+            {"sid": survivor_id},
+        ).first()
+        if not survivor_has_row:
+            candidate = conn.execute(
+                text(
+                    f"SELECT id FROM {table} WHERE stream_id IN :dup_ids "
+                    "ORDER BY id LIMIT 1"
+                ).bindparams(bindparam("dup_ids", expanding=True)),
+                {"dup_ids": duplicate_ids},
+            ).first()
+            if candidate:
+                conn.execute(
+                    text(f"UPDATE {table} SET stream_id = :sid WHERE id = :row_id"),
+                    {"sid": survivor_id, "row_id": candidate.id},
+                )
+        # Delete leftovers explicitly: SQLite test databases don't enforce
+        # FK cascades, so relying on ON DELETE CASCADE is not enough.
+        conn.execute(
+            text(f"DELETE FROM {table} WHERE stream_id IN :dup_ids").bindparams(
+                bindparam("dup_ids", expanding=True)
+            ),
+            {"dup_ids": duplicate_ids},
+        )
+
+
+def _deduplicate_streams(conn):
+    duplicate_ids_rows = conn.execute(
+        text(
+            """
+            SELECT twitch_stream_id
+            FROM streams
+            WHERE twitch_stream_id IS NOT NULL
+            GROUP BY twitch_stream_id
+            HAVING COUNT(*) > 1
+            """
+        )
+    ).fetchall()
+
+    if not duplicate_ids_rows:
+        logger.info("Migration 039: no duplicate twitch_stream_id rows found")
+        return
+
+    logger.info(
+        f"Migration 039: found {len(duplicate_ids_rows)} twitch_stream_id values "
+        "with duplicate stream rows, merging..."
+    )
+
+    for row in duplicate_ids_rows:
+        tsid = row.twitch_stream_id
+        survivor_id, duplicate_ids = _pick_survivor(conn, tsid)
+        logger.info(
+            f"Migration 039: twitch_stream_id={tsid} keeping stream {survivor_id}, "
+            f"merging duplicates {duplicate_ids}"
+        )
+        _merge_scalar_columns(conn, survivor_id, duplicate_ids)
+        _repoint_children(conn, survivor_id, duplicate_ids)
+        conn.execute(
+            text("DELETE FROM streams WHERE id IN :dup_ids").bindparams(
+                bindparam("dup_ids", expanding=True)
+            ),
+            {"dup_ids": duplicate_ids},
+        )
+
+
+def upgrade(target_engine=None):
+    eng = target_engine or engine
+    with eng.begin() as conn:
+        _deduplicate_streams(conn)
+        for statement in SQL_DROP_OLD_INDEXES:
+            conn.execute(text(statement))
+        conn.execute(text(SQL_CREATE_UNIQUE_INDEX))
+    logger.info("✅ Migration 039: unique index on streams.twitch_stream_id created")
+
+
+def downgrade(target_engine=None):
+    """Restore the non-unique index. The duplicate-row merge is irreversible."""
+    eng = target_engine or engine
+    with eng.begin() as conn:
+        conn.execute(text("DROP INDEX IF EXISTS ix_streams_twitch_stream_id"))
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_streams_twitch_stream_id "
+                "ON streams (twitch_stream_id)"
+            )
+        )

--- a/tests/test_migration_039_unique_twitch_stream_id.py
+++ b/tests/test_migration_039_unique_twitch_stream_id.py
@@ -1,0 +1,190 @@
+"""
+Tests for migration 039: unique index on streams.twitch_stream_id.
+
+The stream.online dedup in app/events/handler_registry.py relies on
+twitch_stream_id being unique per Stream row; these tests verify the
+migration is discovered by the MigrationService, that it merges duplicate
+rows correctly, and that the resulting index enforces uniqueness while
+still allowing multiple NULLs.
+"""
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models import Recording, Stream, StreamEvent, Streamer
+
+MIGRATION_NAME = "039_add_unique_twitch_stream_id.py"
+MIGRATION_PATH = Path(__file__).resolve().parents[1] / "migrations" / MIGRATION_NAME
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_039", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def db_engine(tmp_path):
+    """File-based SQLite engine with the pre-migration schema (no unique index)."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'migration_039.db'}", future=True)
+    Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        # The updated model creates the index as UNIQUE; drop it to recreate
+        # the old production schema so duplicate rows can be inserted.
+        conn.execute(text("DROP INDEX IF EXISTS ix_streams_twitch_stream_id"))
+        conn.execute(
+            text(
+                "CREATE INDEX ix_streams_twitch_stream_id "
+                "ON streams (twitch_stream_id)"
+            )
+        )
+    yield engine
+    engine.dispose()
+
+
+def test_migration_is_registered():
+    """The migration file must be discovered by the MigrationService."""
+    from app.services.system.migration_service import MigrationService
+
+    scripts = [Path(p).name for p in MigrationService.get_all_migration_scripts()]
+    assert MIGRATION_NAME in scripts
+
+    migration = _load_migration()
+    # run_migration_script() requires an upgrade() or run_migration() function
+    assert hasattr(migration, "upgrade")
+
+
+def test_model_declares_twitch_stream_id_unique():
+    column = Stream.__table__.c.twitch_stream_id
+    assert column.unique is True
+    assert column.nullable is True
+
+
+def test_upgrade_merges_duplicates_and_enforces_uniqueness(db_engine):
+    started = datetime(2026, 7, 1, 18, 0, tzinfo=timezone.utc)
+    Session = sessionmaker(bind=db_engine, future=True)
+
+    with Session() as session:
+        streamer = Streamer(twitch_id="1000", username="teststreamer")
+        session.add(streamer)
+        session.flush()
+
+        # Three duplicates of the same Twitch stream: the middle one has a
+        # StreamEvent and a Recording attached and must survive, even though
+        # another row has a lower id.
+        dup_plain = Stream(
+            streamer_id=streamer.id,
+            twitch_stream_id="42",
+            started_at=started,
+            ended_at=started,
+            recording_path="/recordings/keep-this-path.mp4",
+        )
+        dup_with_children = Stream(
+            streamer_id=streamer.id,
+            twitch_stream_id="42",
+            started_at=started,
+            title="live title",
+        )
+        dup_late = Stream(streamer_id=streamer.id, twitch_stream_id="42")
+        # Multiple NULL twitch_stream_ids must stay valid after the migration
+        null_a = Stream(streamer_id=streamer.id, started_at=started)
+        null_b = Stream(streamer_id=streamer.id, started_at=started)
+        unique_other = Stream(streamer_id=streamer.id, twitch_stream_id="43")
+        session.add_all(
+            [dup_plain, dup_with_children, dup_late, null_a, null_b, unique_other]
+        )
+        session.flush()
+
+        session.add(
+            StreamEvent(
+                stream_id=dup_with_children.id,
+                event_type="stream.online",
+                timestamp=started,
+            )
+        )
+        session.add(
+            Recording(
+                stream_id=dup_with_children.id, start_time=started, status="completed"
+            )
+        )
+        # A child row on a doomed duplicate must be repointed to the survivor
+        session.add(
+            StreamEvent(
+                stream_id=dup_plain.id, event_type="channel.update", timestamp=started
+            )
+        )
+        session.commit()
+        survivor_id = dup_with_children.id
+        merged_ids = {dup_plain.id, dup_late.id}
+
+    migration = _load_migration()
+    migration.upgrade(db_engine)
+
+    with Session() as session:
+        survivors = session.query(Stream).filter_by(twitch_stream_id="42").all()
+        assert [s.id for s in survivors] == [survivor_id]
+
+        # NULL fields on the survivor were filled from the merged duplicates
+        assert survivors[0].ended_at is not None
+        assert survivors[0].recording_path == "/recordings/keep-this-path.mp4"
+        assert survivors[0].title == "live title"
+
+        # All child rows now point at the survivor
+        event_stream_ids = {e.stream_id for e in session.query(StreamEvent).all()}
+        assert event_stream_ids == {survivor_id}
+        recording_stream_ids = {r.stream_id for r in session.query(Recording).all()}
+        assert recording_stream_ids == {survivor_id}
+
+        # Duplicates are gone, unrelated rows untouched
+        remaining_ids = {s.id for s in session.query(Stream).all()}
+        assert not (merged_ids & remaining_ids)
+        null_rows = (
+            session.query(Stream).filter(Stream.twitch_stream_id.is_(None)).count()
+        )
+        assert null_rows == 2
+
+    indexes = inspect(db_engine).get_indexes("streams")
+    unique_index = next(
+        idx for idx in indexes if idx["column_names"] == ["twitch_stream_id"]
+    )
+    assert unique_index["unique"]
+
+    # The index must actually reject a second row with the same value
+    with Session() as session:
+        streamer_id = session.query(Streamer).one().id
+        session.add(Stream(streamer_id=streamer_id, twitch_stream_id="42"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_upgrade_is_idempotent_and_allows_multiple_nulls(db_engine):
+    Session = sessionmaker(bind=db_engine, future=True)
+    with Session() as session:
+        streamer = Streamer(twitch_id="2000", username="nulltester")
+        session.add(streamer)
+        session.flush()
+        session.add_all(
+            [Stream(streamer_id=streamer.id), Stream(streamer_id=streamer.id)]
+        )
+        session.commit()
+
+    migration = _load_migration()
+    migration.upgrade(db_engine)
+    # Second run must be a no-op, not an error
+    migration.upgrade(db_engine)
+
+    with Session() as session:
+        assert session.query(Stream).count() == 2
+        # A third NULL row is still allowed under the unique index
+        streamer_id = session.query(Streamer).one().id
+        session.add(Stream(streamer_id=streamer_id))
+        session.commit()
+        assert session.query(Stream).count() == 3


### PR DESCRIPTION
## Summary

The `stream.online` dedup logic relies on `Stream.twitch_stream_id` being unique, but the schema only had a non-unique index — duplicate webhook deliveries could create multiple `Stream` rows for the same Twitch stream. This makes the invariant durable at the DB level.

- **Migration `039_add_unique_twitch_stream_id.py`** (auto-discovered by `MigrationService` via the numbered-file glob), in one transaction:
  1. **Duplicate cleanup** — for each set of streams sharing a non-NULL `twitch_stream_id`: the survivor is the row with Recordings attached, then StreamEvents, then the lowest id. NULL scalar fields on the survivor are coalesced from duplicates in id order. FKs in `stream_events`, `recordings` and `recording_processing_state` are repointed; one-row-per-stream tables (`stream_metadata`, `active_recordings_state`) keep the survivor's row if present, otherwise one duplicate row is repointed. Leftover child rows are deleted explicitly (SQLite doesn't enforce cascades by default), then the duplicate stream rows are removed.
  2. **Index** — drops the old non-unique indexes (`idx_streams_twitch_stream_id` from migration 004, `ix_streams_twitch_stream_id` from `create_all`) and creates a UNIQUE index named `ix_streams_twitch_stream_id`, matching the model. Valid on both PostgreSQL and SQLite; both allow multiple NULLs, so the column stays nullable.
- **Model**: `Stream.twitch_stream_id` now declares `unique=True, index=True`.
- **Tests**: verify the migration is discovered and exposes `upgrade()`, the model declares the column unique, duplicates are merged with the expected survivor/repointing semantics, multiple NULLs survive, the index rejects duplicate inserts, and a second `upgrade()` run is a no-op.

## Notes

- The migration is independent of the `fix/event-routing-wrong-streamer-bookmarks` branch and can merge in either order.
- Merge semantics assume the duplicate-webhook case (second row mostly empty, same streamer). If prod duplicates stem from the wrong-streamer routing bug, a quick sanity query against prod before deploying is worthwhile.
- `downgrade()` restores the non-unique index; the row merge itself is irreversible.

## Test plan

- [x] `pytest tests/test_migration_039_unique_twitch_stream_id.py` — 4 passed
- [x] Full suite: no new failures (12 pre-existing failures in twitch-token tests unrelated to this change, reproducible on a clean tree)