### PR TITLE
fix(security): resolve dependency and path handling alerts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -80,6 +80,7 @@ coverage/
 
 # Node.js & Frontend (built separately in CI/CD)
 node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -37,13 +37,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -62,21 +62,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -92,6 +92,55 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -103,14 +152,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -237,9 +286,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -384,9 +433,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -409,26 +458,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1677,33 +1726,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1711,13 +1760,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3974,34 +4023,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-core/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@vue/compiler-core/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.40",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
@@ -4027,34 +4048,6 @@
         "magic-string": "^0.30.21",
         "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
@@ -4414,34 +4407,6 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
-    "node_modules/ast-walker-scope/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ast-walker-scope/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -4548,11 +4513,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.18",
@@ -4581,13 +4549,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5617,9 +5588,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -5657,26 +5628,16 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-2.0.2.tgz",
+      "integrity": "sha512-qiTS+zFS40hGcaPnunc1VBkcaiEBdMSughI6Jfm5ojSNUnn28vpfftIm/q7SIjLf6Ws+l8DMWlnzlZV/f8GKAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/fill-range": {
@@ -6107,9 +6068,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6652,14 +6613,14 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-12.10.1.tgz",
+      "integrity": "sha512-Wtih7aVgTZrLOEC6TmSJVHo69aODsUWyC+NbtNY+Zyp8hesupTw9Hl1lkCiO8bPPUJmlLnNxvRXNPfHIkJ1rnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.6",
-        "filelist": "^1.0.4",
+        "filelist": "^2.0.2",
         "picocolors": "^1.1.1"
       },
       "bin": {
@@ -7183,29 +7144,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minipass": {
@@ -8367,9 +8305,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -48,6 +48,12 @@
     "serialize-javascript": "^7.0.3",
     "vite-plugin-pwa": {
       "vite": "$vite"
-    }
+    },
+    "@babel/core": "7.29.7",
+    "fast-uri": "3.1.4",
+    "immutable": "5.1.9",
+    "shell-quote": "1.10.0",
+    "brace-expansion@5": "5.0.8",
+    "jake": "12.10.1"
   }
 }

--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -32,6 +32,13 @@ from app.services.core.auth_service import AuthService
 
 logger = logging.getLogger("streamvault")
 
+
+def _path_check_error_message(context: str, error: Exception) -> str:
+    """Log filesystem details server-side and return a stable client message."""
+    logger.warning("Unable to verify %s: %s", context, error, exc_info=True)
+    return f"Unable to verify {context}"
+
+
 # SECURITY: Debug endpoints are only available in development mode
 _IS_DEVELOPMENT = os.getenv("ENVIRONMENT", "").lower() == "development"
 
@@ -1578,7 +1585,7 @@ async def stream_video_by_filename(
 async def test_video_access(
     stream_id: int, request: Request, db: Session = Depends(get_db)
 ):
-    """Test endpoint to debug video access issues — DEVELOPMENT ONLY"""
+    """Test endpoint to debug video access issues - DEVELOPMENT ONLY"""
     # SECURITY: Gate debug endpoints behind environment check (CWE-489)
     if not _IS_DEVELOPMENT:
         raise HTTPException(status_code=404, detail="Not found")
@@ -1764,7 +1771,7 @@ async def debug_videos_database(
         None, description="Filter by specific streamer username"
     ),
 ):
-    """Debug endpoint to see what's in the database vs filesystem — DEVELOPMENT ONLY"""
+    """Debug endpoint to see what's in the database vs filesystem - DEVELOPMENT ONLY"""
     # SECURITY: Gate debug endpoints behind environment check (CWE-489)
     if not _IS_DEVELOPMENT:
         raise HTTPException(status_code=404, detail="Not found")
@@ -1814,7 +1821,9 @@ async def debug_videos_database(
                 if path.exists():
                     stream_info["recording_path_size"] = path.stat().st_size
             except Exception as e:
-                stream_info["recording_path_error"] = str(e)
+                stream_info["recording_path_error"] = _path_check_error_message(
+                    "recording path", e
+                )
 
         result["streams"].append(stream_info)
 
@@ -1865,7 +1874,9 @@ async def debug_videos_database(
                     recording_info["mp4_path"] = str(mp4_path)
 
             except Exception as e:
-                recording_info["path_check_error"] = str(e)
+                recording_info["path_check_error"] = _path_check_error_message(
+                    "recording path", e
+                )
 
         result["recordings"].append(recording_info)
 
@@ -1956,7 +1967,7 @@ async def debug_recordings_directory(
         None, description="Filter by specific streamer username"
     ),
 ):
-    """Debug endpoint to list contents of recordings directory — DEVELOPMENT ONLY"""
+    """Debug endpoint to list contents of recordings directory - DEVELOPMENT ONLY"""
     # SECURITY: Gate debug endpoints behind environment check (CWE-489)
     if not _IS_DEVELOPMENT:
         raise HTTPException(status_code=404, detail="Not found")

--- a/app/services/images/category_image_service.py
+++ b/app/services/images/category_image_service.py
@@ -75,6 +75,35 @@ class CategoryImageService:
         # This is a simplified approach - in production you might want a mapping file
         return filename.replace("_", " ").replace("-", " ")
 
+    def _category_image_path(self, category_name: str) -> Path:
+        """Build a category image path contained by the categories directory."""
+        normalized_name = category_name.replace("\\", "/") if category_name else ""
+        name_parts = normalized_name.split("/")
+        if (
+            not category_name
+            or normalized_name.startswith("/")
+            or any(part in {".", ".."} for part in name_parts)
+        ):
+            raise ValueError("Invalid category name")
+
+        safe_name = self.download_service.sanitize_filename(category_name)
+        if not safe_name or not safe_name.strip("."):
+            raise ValueError("Invalid category name")
+
+        self._ensure_categories_dir()
+        if self.categories_dir is None:
+            raise ValueError("Categories directory is not initialized")
+
+        categories_dir = Path(self.categories_dir).resolve()
+        destination = (categories_dir / f"{safe_name}.jpg").resolve()
+        try:
+            destination.relative_to(categories_dir)
+        except ValueError as exc:
+            raise ValueError(
+                "Category image path is outside the categories directory"
+            ) from exc
+        return destination
+
     async def download_category_image(
         self, category_name: str, box_art_url: str = None
     ) -> Optional[str]:
@@ -92,6 +121,13 @@ class CategoryImageService:
 
         if not category_name:
             return None
+
+        try:
+            file_path = self._category_image_path(category_name)
+        except ValueError as e:
+            logger.warning(f"Invalid category image path for {category_name}: {e}")
+            return None
+        filename = file_path.name
 
         # If no box_art_url provided, try to get it from database
         if not box_art_url:
@@ -118,10 +154,6 @@ class CategoryImageService:
         # Check if the box_art_url is already a local path (cached)
         if box_art_url.startswith("/api/media/categories/"):
             # This is already a local cached path, check if file exists
-            safe_name = self.download_service.sanitize_filename(category_name)
-            filename = f"{safe_name}.jpg"
-            file_path = self.categories_dir / filename
-
             if file_path.exists():
                 # File exists, update cache and return path
                 self._category_cache[category_name] = box_art_url
@@ -149,10 +181,6 @@ class CategoryImageService:
             if self.categories_dir is None:
                 logger.error("Categories directory not initialized")
                 return None
-
-            safe_name = self.download_service.sanitize_filename(category_name)
-            filename = f"{safe_name}.jpg"
-            file_path = self.categories_dir / filename
 
             success = await self.download_service.download_image(box_art_url, file_path)
             if success:
@@ -186,12 +214,13 @@ class CategoryImageService:
                 if category and category.box_art_url:
                     # If it's already a local path, check if file exists
                     if category.box_art_url.startswith("/api/media/categories/"):
-                        safe_name = self.download_service.sanitize_filename(
-                            category_name
-                        )
-                        filename = f"{safe_name}.jpg"
-                        self._ensure_categories_dir()
-                        file_path = self.categories_dir / filename
+                        try:
+                            file_path = self._category_image_path(category_name)
+                        except ValueError as e:
+                            logger.warning(
+                                f"Invalid category image path for {category_name}: {e}"
+                            )
+                            return None
 
                         if file_path.exists():
                             # Cache it and return

--- a/app/services/images/image_download_service.py
+++ b/app/services/images/image_download_service.py
@@ -84,9 +84,25 @@ class ImageDownloadService:
         safe_name = re.sub(r"_+", "_", safe_name)
         return safe_name.strip("_").lower()
 
+    def _resolve_destination_path(self, file_path: Path) -> Path:
+        """Resolve a download destination and enforce media directory containment."""
+        self._ensure_initialized()
+        if self.images_base_dir is None:
+            raise ValueError("Media directory is not initialized")
+
+        media_dir = Path(self.images_base_dir).resolve()
+        destination = Path(file_path).resolve()
+        try:
+            destination.relative_to(media_dir)
+        except ValueError as exc:
+            raise ValueError(
+                "Download destination is outside the media directory"
+            ) from exc
+        return destination
+
     def create_filename_hash(self, url: str) -> str:
         """Create a hash-based filename for an image URL"""
-        return hashlib.md5(url.encode()).hexdigest()
+        return hashlib.md5(url.encode(), usedforsecurity=False).hexdigest()
 
     async def download_image(
         self, url: str, file_path: Path, expected_content_types: list = None
@@ -117,6 +133,7 @@ class ImageDownloadService:
             expected_content_types = ["image"]
 
         try:
+            file_path = self._resolve_destination_path(file_path)
             session = await self.get_session()
             async with session.get(url) as response:
                 if response.status == 200:

--- a/app/services/processing/recording_task_factory.py
+++ b/app/services/processing/recording_task_factory.py
@@ -19,6 +19,21 @@ class RecordingTaskFactory:
     """Factory for creating recording post-processing task chains"""
 
     @staticmethod
+    def _validated_recording_path(file_path: str) -> Path:
+        """Resolve a recording path and enforce recording directory containment."""
+        from app.config.settings import settings
+
+        recording_dir = Path(settings.RECORDING_DIRECTORY).resolve()
+        resolved_path = Path(file_path).resolve()
+        try:
+            resolved_path.relative_to(recording_dir)
+        except ValueError as exc:
+            raise ValueError(
+                "Recording path is outside the recording directory"
+            ) from exc
+        return resolved_path
+
+    @staticmethod
     def create_post_processing_chain(
         stream_id: int,
         recording_id: int,
@@ -100,18 +115,21 @@ class RecordingTaskFactory:
         thumbnail_task_id = f"{base_id}_thumbnail"
         cleanup_task_id = f"{base_id}_cleanup"
 
+        validated_ts_path = RecordingTaskFactory._validated_recording_path(ts_file_path)
+        validated_ts_file_path = str(validated_ts_path)
+
         # Common payload data
         common_payload = {
             "stream_id": stream_id,
             "recording_id": recording_id,
-            "ts_file_path": ts_file_path,
+            "ts_file_path": validated_ts_file_path,
             "output_dir": output_dir,
             "streamer_name": streamer_name,
             "started_at": started_at,
         }
 
         # Calculate MP4 output path
-        ts_path = Path(ts_file_path)
+        ts_path = validated_ts_path
         mp4_path = str(ts_path.with_suffix(".mp4"))
 
         # 1. Metadata Generation Task (no dependencies)
@@ -176,7 +194,6 @@ class RecordingTaskFactory:
                 payload={
                     **common_payload,
                     "mp4_path": mp4_path,
-                    "ts_file_path": ts_file_path,
                     "validate_size_ratio": True,
                     "min_size_mb": 1,  # Minimum 1MB
                 },
@@ -207,10 +224,10 @@ class RecordingTaskFactory:
         # 6. Cleanup Task (depends on MP4 validation, only if cleanup_ts_file is True)
         if cleanup_ts_file and "cleanup" not in completed:
             # Prepare files to remove: .ts file and potential segments directory
-            files_to_remove = [ts_file_path]
+            files_to_remove = [validated_ts_file_path]
 
             # Check if there's a corresponding segments directory that should be cleaned up
-            ts_path = Path(ts_file_path)
+            ts_path = validated_ts_path
             segments_dir = ts_path.parent / f"{ts_path.stem}_segments"
             # is_dir() already returns False if the path does not exist
             if segments_dir.is_dir():

--- a/tests/test_security_alert_regressions.py
+++ b/tests/test_security_alert_regressions.py
@@ -1,0 +1,212 @@
+from pathlib import Path
+
+import pytest
+
+import app.routes.videos as videos
+from app.services.images.category_image_service import CategoryImageService
+from app.services.images.image_download_service import ImageDownloadService
+from app.services.processing.recording_task_factory import RecordingTaskFactory
+
+
+def _image_download_service(media_dir: Path) -> ImageDownloadService:
+    service = ImageDownloadService.__new__(ImageDownloadService)
+    service._initialized = True
+    service.images_base_dir = media_dir
+    return service
+
+
+def _category_image_service(categories_dir: Path) -> CategoryImageService:
+    download_service = _image_download_service(categories_dir.parent)
+    service = CategoryImageService.__new__(CategoryImageService)
+    service.download_service = download_service
+    service.categories_dir = categories_dir
+    return service
+
+
+def test_image_destination_accepts_path_inside_media_directory(tmp_path: Path) -> None:
+    media_dir = tmp_path / ".media"
+    media_dir.mkdir()
+    destination = media_dir / "categories" / "game.jpg"
+    service = _image_download_service(media_dir)
+
+    assert service._resolve_destination_path(destination) == destination.resolve()
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        Path("../outside.jpg"),
+        Path("/tmp/outside.jpg"),
+    ],
+)
+def test_image_destination_rejects_path_outside_media_directory(
+    tmp_path: Path, destination: Path
+) -> None:
+    media_dir = tmp_path / ".media"
+    media_dir.mkdir()
+    service = _image_download_service(media_dir)
+    candidate = (
+        media_dir / destination if not destination.is_absolute() else destination
+    )
+
+    with pytest.raises(ValueError, match="outside the media directory"):
+        service._resolve_destination_path(candidate)
+
+
+def test_image_destination_rejects_symlink_escape(tmp_path: Path) -> None:
+    media_dir = tmp_path / ".media"
+    categories_dir = media_dir / "categories"
+    outside_dir = tmp_path / "outside"
+    categories_dir.mkdir(parents=True)
+    outside_dir.mkdir()
+    (categories_dir / "escape").symlink_to(outside_dir, target_is_directory=True)
+    service = _image_download_service(media_dir)
+
+    with pytest.raises(ValueError, match="outside the media directory"):
+        service._resolve_destination_path(categories_dir / "escape" / "game.jpg")
+
+
+def test_category_image_path_preserves_normal_filename(tmp_path: Path) -> None:
+    categories_dir = tmp_path / ".media" / "categories"
+    categories_dir.mkdir(parents=True)
+    service = _category_image_service(categories_dir)
+
+    assert (
+        service._category_image_path("Just Chatting")
+        == (categories_dir / "just_chatting.jpg").resolve()
+    )
+
+
+@pytest.mark.parametrize("category_name", ["", ".", "..", "../secret", "/tmp/secret"])
+def test_category_image_path_rejects_unsafe_names(
+    tmp_path: Path, category_name: str
+) -> None:
+    categories_dir = tmp_path / ".media" / "categories"
+    categories_dir.mkdir(parents=True)
+    service = _category_image_service(categories_dir)
+
+    with pytest.raises(ValueError, match="Invalid category name"):
+        service._category_image_path(category_name)
+
+
+def test_category_image_path_rejects_symlink_escape(tmp_path: Path) -> None:
+    categories_dir = tmp_path / ".media" / "categories"
+    outside_file = tmp_path / "outside.jpg"
+    categories_dir.mkdir(parents=True)
+    outside_file.touch()
+    (categories_dir / "unsafe.jpg").symlink_to(outside_file)
+    service = _category_image_service(categories_dir)
+
+    with pytest.raises(ValueError, match="outside the categories directory"):
+        service._category_image_path("unsafe")
+
+
+def test_recording_path_accepts_file_inside_recording_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    recording_path = recordings_dir / "stream.ts"
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+
+    assert (
+        RecordingTaskFactory._validated_recording_path(str(recording_path))
+        == recording_path.resolve()
+    )
+
+
+def test_recording_path_rejects_file_outside_recording_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+
+    with pytest.raises(ValueError, match="outside the recording directory"):
+        RecordingTaskFactory._validated_recording_path(str(tmp_path / "outside.ts"))
+
+
+def test_recording_path_rejects_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    outside_dir = tmp_path / "outside"
+    recordings_dir.mkdir()
+    outside_dir.mkdir()
+    (recordings_dir / "escape").symlink_to(outside_dir, target_is_directory=True)
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+
+    with pytest.raises(ValueError, match="outside the recording directory"):
+        RecordingTaskFactory._validated_recording_path(
+            str(recordings_dir / "escape" / "stream.ts")
+        )
+
+
+def test_recording_chain_uses_canonical_path_in_payloads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    recording_path = recordings_dir / "folder" / ".." / "stream.ts"
+    canonical_path = str((recordings_dir / "stream.ts").resolve())
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+
+    tasks = RecordingTaskFactory.create_post_processing_chain(
+        stream_id=1,
+        recording_id=1,
+        ts_file_path=str(recording_path),
+        output_dir=str(recordings_dir),
+        streamer_name="test",
+        started_at="2026-01-01T00:00:00",
+    )
+
+    assert all(task.payload["ts_file_path"] == canonical_path for task in tasks)
+    cleanup_task = next(task for task in tasks if task.type == "cleanup")
+    assert cleanup_task.payload["files_to_remove"][0] == canonical_path
+
+
+def test_recording_chain_rejects_outside_path_before_filesystem_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+    filesystem_probes = []
+
+    def record_is_dir(path: Path) -> bool:
+        filesystem_probes.append(path)
+        return False
+
+    monkeypatch.setattr(Path, "is_dir", record_is_dir)
+
+    with pytest.raises(ValueError, match="outside the recording directory"):
+        RecordingTaskFactory.create_post_processing_chain(
+            stream_id=1,
+            recording_id=1,
+            ts_file_path=str(tmp_path / "outside.ts"),
+            output_dir=str(recordings_dir),
+            streamer_name="test",
+            started_at="2026-01-01T00:00:00",
+        )
+
+    assert filesystem_probes == []
+
+
+def test_path_check_error_message_does_not_expose_exception_text(caplog) -> None:
+    secret = "sensitive filesystem detail"
+
+    message = videos._path_check_error_message("recording path", RuntimeError(secret))
+
+    assert message == "Unable to verify recording path"
+    assert secret not in message
+    assert secret in caplog.text


### PR DESCRIPTION
## Summary

- update vulnerable transitive frontend dependencies to patched releases
- remove the legacy `brace-expansion` 2.x chain through a compatible `jake` override
- enforce canonical path containment for image downloads, category images, and recording post-processing
- prevent filesystem exception details from being returned by debug API responses
- exclude nested `node_modules` directories from Docker build contexts so stale development packages cannot enter runtime images

## Security findings addressed

- Dependabot alerts for `immutable`, `shell-quote`, `brace-expansion`, `fast-uri`, and `@babel/core`
- Trivy findings for the same vulnerable frontend packages
- CodeQL `py/path-injection` findings in image and recording services
- CodeQL `py/stack-trace-exposure` in the videos debug route
- Bandit B324 in URL-derived cache hashing by explicitly marking MD5 as non-security use

## Verification

- `pytest tests/ -q --tb=short`: 158 passed
- `ruff check app/`: passed
- `ruff format --check app/`: passed
- Python migration check: passed
- Node 24 `npm ci`: passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- frontend lint, design-token lint, type-check, and production build: passed
- `pip-audit -r requirements.txt`: 0 vulnerabilities
- Bandit on touched Python files: 0 Medium/High findings
- Docker image build and runtime smoke: healthy, health endpoint 200, frontend 200
- runtime image contains no `node_modules` directories
- Trivy image scan with High/Critical exit gate: 0 vulnerabilities

## Notes

- Existing frontend lint warnings and informational Mypy findings are unchanged and remain non-blocking under the current CI contract.
- Alerts currently attached to `main` will close after this change is promoted from `develop` to `main` and the default-branch scans run again.
