### PR TITLE
fix(security): use CodeQL-safe path sanitizers

### DIFF
--- a/app/services/images/category_image_service.py
+++ b/app/services/images/category_image_service.py
@@ -7,6 +7,7 @@ Handles downloading, caching, and serving of category/game images.
 
 import asyncio
 import logging
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Optional, List, Set
@@ -94,15 +95,17 @@ class CategoryImageService:
         if self.categories_dir is None:
             raise ValueError("Categories directory is not initialized")
 
-        categories_dir = Path(self.categories_dir).resolve()
-        destination = (categories_dir / f"{safe_name}.jpg").resolve()
+        categories_dir = os.path.realpath(os.fspath(self.categories_dir))
+        destination = os.path.realpath(os.path.join(categories_dir, f"{safe_name}.jpg"))
         try:
-            destination.relative_to(categories_dir)
-        except ValueError as exc:
-            raise ValueError(
-                "Category image path is outside the categories directory"
-            ) from exc
-        return destination
+            is_contained = (
+                os.path.commonpath((categories_dir, destination)) == categories_dir
+            )
+        except ValueError:
+            is_contained = False
+        if not is_contained:
+            raise ValueError("Category image path is outside the categories directory")
+        return Path(destination)
 
     async def download_category_image(
         self, category_name: str, box_art_url: str = None

--- a/app/services/images/image_download_service.py
+++ b/app/services/images/image_download_service.py
@@ -8,6 +8,7 @@ Handles HTTP sessions, downloads, and common image operations.
 import aiohttp
 import hashlib
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Optional, Set
@@ -90,15 +91,15 @@ class ImageDownloadService:
         if self.images_base_dir is None:
             raise ValueError("Media directory is not initialized")
 
-        media_dir = Path(self.images_base_dir).resolve()
-        destination = Path(file_path).resolve()
+        media_dir = os.path.realpath(os.fspath(self.images_base_dir))
+        destination = os.path.realpath(os.path.abspath(os.fspath(file_path)))
         try:
-            destination.relative_to(media_dir)
-        except ValueError as exc:
-            raise ValueError(
-                "Download destination is outside the media directory"
-            ) from exc
-        return destination
+            is_contained = os.path.commonpath((media_dir, destination)) == media_dir
+        except ValueError:
+            is_contained = False
+        if not is_contained:
+            raise ValueError("Download destination is outside the media directory")
+        return Path(destination)
 
     def create_filename_hash(self, url: str) -> str:
         """Create a hash-based filename for an image URL"""

--- a/app/services/processing/recording_task_factory.py
+++ b/app/services/processing/recording_task_factory.py
@@ -4,6 +4,7 @@ Creates task chains for recording post-processing with proper dependencies
 """
 
 import logging
+import os
 from typing import List
 from datetime import datetime
 from pathlib import Path
@@ -23,15 +24,17 @@ class RecordingTaskFactory:
         """Resolve a recording path and enforce recording directory containment."""
         from app.config.settings import settings
 
-        recording_dir = Path(settings.RECORDING_DIRECTORY).resolve()
-        resolved_path = Path(file_path).resolve()
+        recording_dir = os.path.realpath(settings.RECORDING_DIRECTORY)
+        resolved_path = os.path.realpath(os.path.abspath(file_path))
         try:
-            resolved_path.relative_to(recording_dir)
-        except ValueError as exc:
-            raise ValueError(
-                "Recording path is outside the recording directory"
-            ) from exc
-        return resolved_path
+            is_contained = (
+                os.path.commonpath((recording_dir, resolved_path)) == recording_dir
+            )
+        except ValueError:
+            is_contained = False
+        if not is_contained:
+            raise ValueError("Recording path is outside the recording directory")
+        return Path(resolved_path)
 
     @staticmethod
     def create_post_processing_chain(

--- a/tests/test_security_alert_regressions.py
+++ b/tests/test_security_alert_regressions.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,23 @@ def test_image_destination_accepts_path_inside_media_directory(tmp_path: Path) -
     service = _image_download_service(media_dir)
 
     assert service._resolve_destination_path(destination) == destination.resolve()
+
+
+def test_image_destination_does_not_use_pathlib_resolve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_dir = tmp_path / ".media"
+    media_dir.mkdir()
+    destination = media_dir / "categories" / "game.jpg"
+    expected = Path(os.path.realpath(destination))
+    service = _image_download_service(media_dir)
+    monkeypatch.setattr(
+        Path,
+        "resolve",
+        lambda *_args, **_kwargs: pytest.fail("Path.resolve must not handle input"),
+    )
+
+    assert service._resolve_destination_path(destination) == expected
 
 
 @pytest.mark.parametrize(
@@ -77,6 +95,22 @@ def test_category_image_path_preserves_normal_filename(tmp_path: Path) -> None:
     )
 
 
+def test_category_image_path_does_not_use_pathlib_resolve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    categories_dir = tmp_path / ".media" / "categories"
+    categories_dir.mkdir(parents=True)
+    expected = Path(os.path.realpath(categories_dir / "just_chatting.jpg"))
+    service = _category_image_service(categories_dir)
+    monkeypatch.setattr(
+        Path,
+        "resolve",
+        lambda *_args, **_kwargs: pytest.fail("Path.resolve must not handle input"),
+    )
+
+    assert service._category_image_path("Just Chatting") == expected
+
+
 @pytest.mark.parametrize("category_name", ["", ".", "..", "../secret", "/tmp/secret"])
 def test_category_image_path_rejects_unsafe_names(
     tmp_path: Path, category_name: str
@@ -114,6 +148,27 @@ def test_recording_path_accepts_file_inside_recording_directory(
     assert (
         RecordingTaskFactory._validated_recording_path(str(recording_path))
         == recording_path.resolve()
+    )
+
+
+def test_recording_path_does_not_use_pathlib_resolve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    recording_path = recordings_dir / "stream.ts"
+    expected = Path(os.path.realpath(recording_path))
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+    monkeypatch.setattr(
+        Path,
+        "resolve",
+        lambda *_args, **_kwargs: pytest.fail("Path.resolve must not handle input"),
+    )
+
+    assert (
+        RecordingTaskFactory._validated_recording_path(str(recording_path)) == expected
     )
 
 


### PR DESCRIPTION
## Summary

- replace direct `Path.resolve()` calls on tainted path values with same-function `realpath` and `commonpath` containment checks
- preserve traversal and symlink escape protection for image and recording paths
- add focused regressions proving the flagged path flow no longer uses `Path.resolve()`

## Reason

CodeQL reported three `py/path-injection` alerts on the security promotion PR because direct `Path.resolve()` calls were treated as path sinks before the subsequent containment checks.

## Verification

- focused security tests: 20 passed
- full backend suite: 161 passed
- migration initialization: passed
- Ruff check and format check: passed
- frontend lint, token lint, type-check, build, and npm audit: passed
- Bandit Medium/High gate: passed
- pip-audit: no known vulnerabilities
- Docker build and runtime smoke: healthy, health endpoint 200, frontend 200

## Follow-up

After this PR merges into `develop`, PR #744 will rerun CodeQL against the updated promotion head.
