### PR TITLE
fix(security): guard filesystem path sinks

### DIFF
--- a/app/routes/admin_post_processing.py
+++ b/app/routes/admin_post_processing.py
@@ -448,6 +448,15 @@ async def enqueue_manual_post_processing(
         normalized_path = validate_path_security(
             os.path.join(RECORDINGS_ROOT, ts_file_path), "read"
         )
+        from app.config.settings import get_settings
+
+        recordings_root = os.path.realpath(get_settings().RECORDING_DIRECTORY)
+        normalized_path = os.path.realpath(os.path.abspath(normalized_path))
+        if not normalized_path.startswith(recordings_root + os.sep):
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied: Path outside allowed directory",
+            )
 
         # Validate file exists
         if not Path(normalized_path).exists():

--- a/app/services/images/category_image_service.py
+++ b/app/services/images/category_image_service.py
@@ -132,13 +132,7 @@ class CategoryImageService:
             return None
         categories_dir = os.path.realpath(os.fspath(self.categories_dir))
         destination = os.path.realpath(os.path.abspath(os.fspath(file_path)))
-        try:
-            is_contained = (
-                os.path.commonpath((categories_dir, destination)) == categories_dir
-            )
-        except ValueError:
-            is_contained = False
-        if not is_contained:
+        if not destination.startswith(categories_dir + os.sep):
             logger.warning(f"Invalid category image path for {category_name}")
             return None
         file_path = Path(destination)
@@ -243,14 +237,7 @@ class CategoryImageService:
                         destination = os.path.realpath(
                             os.path.abspath(os.fspath(file_path))
                         )
-                        try:
-                            is_contained = (
-                                os.path.commonpath((categories_dir, destination))
-                                == categories_dir
-                            )
-                        except ValueError:
-                            is_contained = False
-                        if not is_contained:
+                        if not destination.startswith(categories_dir + os.sep):
                             logger.warning(
                                 f"Invalid category image path for {category_name}"
                             )

--- a/app/services/images/category_image_service.py
+++ b/app/services/images/category_image_service.py
@@ -130,6 +130,18 @@ class CategoryImageService:
         except ValueError as e:
             logger.warning(f"Invalid category image path for {category_name}: {e}")
             return None
+        categories_dir = os.path.realpath(os.fspath(self.categories_dir))
+        destination = os.path.realpath(os.path.abspath(os.fspath(file_path)))
+        try:
+            is_contained = (
+                os.path.commonpath((categories_dir, destination)) == categories_dir
+            )
+        except ValueError:
+            is_contained = False
+        if not is_contained:
+            logger.warning(f"Invalid category image path for {category_name}")
+            return None
+        file_path = Path(destination)
         filename = file_path.name
 
         # If no box_art_url provided, try to get it from database
@@ -224,6 +236,26 @@ class CategoryImageService:
                                 f"Invalid category image path for {category_name}: {e}"
                             )
                             return None
+
+                        categories_dir = os.path.realpath(
+                            os.fspath(self.categories_dir)
+                        )
+                        destination = os.path.realpath(
+                            os.path.abspath(os.fspath(file_path))
+                        )
+                        try:
+                            is_contained = (
+                                os.path.commonpath((categories_dir, destination))
+                                == categories_dir
+                            )
+                        except ValueError:
+                            is_contained = False
+                        if not is_contained:
+                            logger.warning(
+                                f"Invalid category image path for {category_name}"
+                            )
+                            return None
+                        file_path = Path(destination)
 
                         if file_path.exists():
                             # Cache it and return

--- a/app/services/images/image_download_service.py
+++ b/app/services/images/image_download_service.py
@@ -137,11 +137,7 @@ class ImageDownloadService:
             file_path = self._resolve_destination_path(file_path)
             media_dir = os.path.realpath(os.fspath(self.images_base_dir))
             destination = os.path.realpath(os.path.abspath(os.fspath(file_path)))
-            try:
-                is_contained = os.path.commonpath((media_dir, destination)) == media_dir
-            except ValueError:
-                is_contained = False
-            if not is_contained:
+            if not destination.startswith(media_dir + os.sep):
                 raise ValueError("Download destination is outside the media directory")
             file_path = Path(destination)
             session = await self.get_session()

--- a/app/services/images/image_download_service.py
+++ b/app/services/images/image_download_service.py
@@ -135,6 +135,15 @@ class ImageDownloadService:
 
         try:
             file_path = self._resolve_destination_path(file_path)
+            media_dir = os.path.realpath(os.fspath(self.images_base_dir))
+            destination = os.path.realpath(os.path.abspath(os.fspath(file_path)))
+            try:
+                is_contained = os.path.commonpath((media_dir, destination)) == media_dir
+            except ValueError:
+                is_contained = False
+            if not is_contained:
+                raise ValueError("Download destination is outside the media directory")
+            file_path = Path(destination)
             session = await self.get_session()
             async with session.get(url) as response:
                 if response.status == 200:

--- a/app/services/processing/recording_task_factory.py
+++ b/app/services/processing/recording_task_factory.py
@@ -125,13 +125,7 @@ class RecordingTaskFactory:
         resolved_ts_path = os.path.realpath(
             os.path.abspath(os.fspath(validated_ts_path))
         )
-        try:
-            is_contained = (
-                os.path.commonpath((recording_dir, resolved_ts_path)) == recording_dir
-            )
-        except ValueError:
-            is_contained = False
-        if not is_contained:
+        if not resolved_ts_path.startswith(recording_dir + os.sep):
             raise ValueError("Recording path is outside the recording directory")
         validated_ts_path = Path(resolved_ts_path)
         validated_ts_file_path = str(validated_ts_path)

--- a/app/services/processing/recording_task_factory.py
+++ b/app/services/processing/recording_task_factory.py
@@ -119,6 +119,21 @@ class RecordingTaskFactory:
         cleanup_task_id = f"{base_id}_cleanup"
 
         validated_ts_path = RecordingTaskFactory._validated_recording_path(ts_file_path)
+        from app.config.settings import settings
+
+        recording_dir = os.path.realpath(settings.RECORDING_DIRECTORY)
+        resolved_ts_path = os.path.realpath(
+            os.path.abspath(os.fspath(validated_ts_path))
+        )
+        try:
+            is_contained = (
+                os.path.commonpath((recording_dir, resolved_ts_path)) == recording_dir
+            )
+        except ValueError:
+            is_contained = False
+        if not is_contained:
+            raise ValueError("Recording path is outside the recording directory")
+        validated_ts_path = Path(resolved_ts_path)
         validated_ts_file_path = str(validated_ts_path)
 
         # Common payload data

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -244,6 +244,11 @@ def validate_path_security(user_path: str, operation_type: str = "access") -> st
 
     # Additional validation based on operation type
     if operation_type in ["read", "write", "delete"]:
+        if not normalized_path.startswith(safe_base + os.sep):
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied: Path outside allowed directory",
+            )
         if not os.path.exists(normalized_path):
             raise HTTPException(status_code=404, detail=f"Path not found: {user_path}")
 

--- a/tests/test_security_alert_regressions.py
+++ b/tests/test_security_alert_regressions.py
@@ -1,9 +1,12 @@
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import app.routes.videos as videos
+import app.services.images.category_image_service as category_images
+import app.services.images.image_download_service as image_downloads
 from app.services.images.category_image_service import CategoryImageService
 from app.services.images.image_download_service import ImageDownloadService
 from app.services.processing.recording_task_factory import RecordingTaskFactory
@@ -13,6 +16,8 @@ def _image_download_service(media_dir: Path) -> ImageDownloadService:
     service = ImageDownloadService.__new__(ImageDownloadService)
     service._initialized = True
     service.images_base_dir = media_dir
+    service._failed_downloads = set()
+    service.session = None
     return service
 
 
@@ -21,7 +26,60 @@ def _category_image_service(categories_dir: Path) -> CategoryImageService:
     service = CategoryImageService.__new__(CategoryImageService)
     service.download_service = download_service
     service.categories_dir = categories_dir
+    service._category_cache = {}
+    service._background_tasks = set()
     return service
+
+
+class _ImageContent:
+    async def iter_chunked(self, _size: int):
+        yield b"image"
+
+
+class _ImageResponse:
+    status = 200
+    headers = {"content-type": "image/jpeg"}
+    content = _ImageContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _ImageSession:
+    def get(self, _url: str) -> _ImageResponse:
+        return _ImageResponse()
+
+
+class _CategoryQuery:
+    def __init__(self, category) -> None:
+        self.category = category
+
+    def filter(self, *_args):
+        return self
+
+    def first(self):
+        return self.category
+
+
+class _CategorySession:
+    def __init__(self, category) -> None:
+        self.category = category
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def query(self, *_args) -> _CategoryQuery:
+        return _CategoryQuery(self.category)
+
+
+async def _async_value(value):
+    return value
 
 
 def test_image_destination_accepts_path_inside_media_directory(tmp_path: Path) -> None:
@@ -84,6 +142,38 @@ def test_image_destination_rejects_symlink_escape(tmp_path: Path) -> None:
         service._resolve_destination_path(categories_dir / "escape" / "game.jpg")
 
 
+@pytest.mark.asyncio
+async def test_download_rechecks_destination_before_filesystem_sinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_dir = tmp_path / ".media"
+    media_dir.mkdir()
+    outside_path = tmp_path / "outside" / "game.jpg"
+    service = _image_download_service(media_dir)
+    filesystem_sinks = []
+
+    monkeypatch.setattr(
+        service, "_resolve_destination_path", lambda _path: outside_path
+    )
+    monkeypatch.setattr(service, "get_session", lambda: _async_value(_ImageSession()))
+    monkeypatch.setattr(
+        Path,
+        "mkdir",
+        lambda path, **_kwargs: filesystem_sinks.append(("mkdir", path)),
+    )
+    monkeypatch.setattr(
+        image_downloads.aiofiles,
+        "open",
+        lambda path, _mode: filesystem_sinks.append(("open", path)),
+    )
+
+    assert (
+        await service.download_image("https://example.test/game.jpg", outside_path)
+        is False
+    )
+    assert filesystem_sinks == []
+
+
 def test_category_image_path_preserves_normal_filename(tmp_path: Path) -> None:
     categories_dir = tmp_path / ".media" / "categories"
     categories_dir.mkdir(parents=True)
@@ -133,6 +223,55 @@ def test_category_image_path_rejects_symlink_escape(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="outside the categories directory"):
         service._category_image_path("unsafe")
+
+
+@pytest.mark.asyncio
+async def test_category_download_rechecks_path_before_cached_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    categories_dir = tmp_path / ".media" / "categories"
+    categories_dir.mkdir(parents=True)
+    outside_path = tmp_path / "outside.jpg"
+    service = _category_image_service(categories_dir)
+    filesystem_probes = []
+
+    monkeypatch.setattr(service, "_category_image_path", lambda _name: outside_path)
+    monkeypatch.setattr(
+        Path,
+        "exists",
+        lambda path: filesystem_probes.append(path) or False,
+    )
+
+    result = await service.download_category_image(
+        "Unsafe", "/api/media/categories/unsafe.jpg"
+    )
+
+    assert result is None
+    assert filesystem_probes == []
+
+
+def test_category_cache_lookup_rechecks_path_before_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    categories_dir = tmp_path / ".media" / "categories"
+    categories_dir.mkdir(parents=True)
+    outside_path = tmp_path / "outside.jpg"
+    category = SimpleNamespace(box_art_url="/api/media/categories/unsafe.jpg")
+    service = _category_image_service(categories_dir)
+    filesystem_probes = []
+
+    monkeypatch.setattr(service, "_category_image_path", lambda _name: outside_path)
+    monkeypatch.setattr(
+        category_images, "SessionLocal", lambda: _CategorySession(category)
+    )
+    monkeypatch.setattr(
+        Path,
+        "exists",
+        lambda path: filesystem_probes.append(path) or False,
+    )
+
+    assert service.get_cached_category_image("Unsafe") is None
+    assert filesystem_probes == []
 
 
 def test_recording_path_accepts_file_inside_recording_directory(
@@ -249,6 +388,40 @@ def test_recording_chain_rejects_outside_path_before_filesystem_probe(
             stream_id=1,
             recording_id=1,
             ts_file_path=str(tmp_path / "outside.ts"),
+            output_dir=str(recordings_dir),
+            streamer_name="test",
+            started_at="2026-01-01T00:00:00",
+        )
+
+    assert filesystem_probes == []
+
+
+def test_recording_chain_rechecks_validated_path_before_segments_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recordings_dir = tmp_path / "recordings"
+    recordings_dir.mkdir()
+    outside_path = tmp_path / "outside.ts"
+    filesystem_probes = []
+    monkeypatch.setattr(
+        "app.config.settings.settings.RECORDING_DIRECTORY", str(recordings_dir)
+    )
+    monkeypatch.setattr(
+        RecordingTaskFactory,
+        "_validated_recording_path",
+        staticmethod(lambda _path: outside_path),
+    )
+    monkeypatch.setattr(
+        Path,
+        "is_dir",
+        lambda path: filesystem_probes.append(path) or False,
+    )
+
+    with pytest.raises(ValueError, match="outside the recording directory"):
+        RecordingTaskFactory.create_post_processing_chain(
+            stream_id=1,
+            recording_id=1,
+            ts_file_path=str(outside_path),
             output_dir=str(recordings_dir),
             streamer_name="test",
             started_at="2026-01-01T00:00:00",


### PR DESCRIPTION
## Summary

- add canonical path-prefix validation immediately before category image, image download, and recording filesystem sinks
- harden manual post-processing and shared path validation before filesystem access
- preserve existing helper validation as defense in depth
- add regressions proving compromised helper output cannot trigger filesystem access outside configured roots

## Root cause

CodeQL tracks path normalization state and safe-access checks within the function containing the filesystem sink. The existing helper validation was correct at runtime, but its checked state did not propagate across the helper boundary to later `exists`, `mkdir`, `open`, and `is_dir` calls.

## Functionality

Valid paths keep the same canonical filenames, category URLs, cache keys, recording payloads, MP4 paths, and cleanup entries. Invalid or escaped paths fail before filesystem access.

## Verification

- focused security suite: 70 passed
- full Python 3.14 backend suite: 165 passed
- migration initialization: passed
- Ruff check and format check: passed
- Node 24 frontend lint, token lint, type-check, production build, and npm audit: passed
- pip-audit: no known vulnerabilities
- Bandit Medium/High gate: passed
- Gitleaks: no leaks found
- Hadolint error gate: passed
- Trivy filesystem High/Critical gate: 0 vulnerabilities
- Docker Buildx image build: passed
- runtime smoke: `/api/health/live` returned `status: alive` as `appuser`
- GitHub checks: all 17 checks passed on exact head `53028613cda6eb1b3625daf9e6442365d7f0dc6d`
- exact-head independent review: no blocking findings on the same head and base
- review evidence: https://github.com/Serph91P/StreamVault/pull/746#issuecomment-5152301716

## Security alerts

Targets the five remaining `py/path-injection` findings reported on the current `main` scan in:

- `CategoryImageService.download_category_image`
- `CategoryImageService.get_cached_category_image`
- `ImageDownloadService.download_image`
- `RecordingTaskFactory.create_post_processing_chain`
