### PR TITLE
chore(deps): group routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Node.js dependencies (npm)
   - package-ecosystem: "npm"
@@ -28,6 +35,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Docker dependencies
   - package-ecosystem: "docker"
@@ -42,6 +56,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 5
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -56,3 +77,10 @@ updates:
     commit-message:
       prefix: "ci(deps)"
     open-pull-requests-limit: 5
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- group routine Python minor and patch updates in one pip-specific pull request
- group routine frontend minor and patch updates in one npm-specific pull request
- group routine Docker minor and patch updates in one Docker-specific pull request
- group routine GitHub Actions minor and patch updates in one Actions-specific pull request
- leave major updates outside the groups so they remain individually reviewable

## Validation

- parsed `.github/dependabot.yml` with Ruby Psych
- verified exactly four updater entries and one ecosystem-local group per updater
- verified every group uses `patterns: ["*"]` and only `minor` plus `patch` update types
- verified all existing updater properties match `develop` exactly after removing the new group blocks
- verified matching pip, npm, Docker, and GitHub Actions sources exist
- `git diff --check`
- exact changed and staged path: `.github/dependabot.yml`
- U+2013 and U+2014 scan passed

Closes #779
