### PR TITLE
fix: enforce Streamlink request budgets

### DIFF
--- a/app/services/proxy/proxy_health_service.py
+++ b/app/services/proxy/proxy_health_service.py
@@ -163,11 +163,14 @@ class ProxyHealthService:
                     return
 
                 logger.info(f"🔍 Checking {len(proxies)} enabled proxies...")
+                access_token = await self._get_app_access_token()
 
                 # Check each proxy
                 for proxy in proxies:
                     try:
-                        health_result = await self._check_proxy_health(proxy.proxy_url)
+                        health_result = await self._check_proxy_health(
+                            proxy.proxy_url, access_token
+                        )
 
                         # Update proxy health in database
                         proxy.last_health_check = datetime.now(timezone.utc)
@@ -234,7 +237,32 @@ class ProxyHealthService:
         # Default: 3 failures
         return 3
 
-    async def _check_proxy_health(self, proxy_url: str) -> Dict[str, Any]:
+    async def _get_app_access_token(self) -> Optional[str]:
+        try:
+            async with aiohttp.ClientSession() as token_session:
+                async with token_session.post(
+                    "https://id.twitch.tv/oauth2/token",
+                    params={
+                        "client_id": settings.TWITCH_APP_ID,
+                        "client_secret": settings.TWITCH_APP_SECRET,
+                        "grant_type": "client_credentials",
+                    },
+                ) as token_response:
+                    if token_response.status != 200:
+                        logger.error(
+                            "Failed to get Twitch access token for proxy health check"
+                        )
+                        return None
+
+                    token_data = await token_response.json()
+                    return token_data.get("access_token")
+        except Exception as e:
+            logger.error(f"Error getting access token for proxy check: {e}")
+            return None
+
+    async def _check_proxy_health(
+        self, proxy_url: str, access_token: Optional[str]
+    ) -> Dict[str, Any]:
         """
         Check health of a single proxy by testing connectivity with Twitch API.
 
@@ -252,41 +280,7 @@ class ProxyHealthService:
                 'error': str or None
             }
         """
-        # Get Twitch access token first
-        try:
-            # Use app credentials to get access token (same as in recordings)
-            async with aiohttp.ClientSession() as token_session:
-                async with token_session.post(
-                    "https://id.twitch.tv/oauth2/token",
-                    params={
-                        "client_id": settings.TWITCH_APP_ID,
-                        "client_secret": settings.TWITCH_APP_SECRET,
-                        "grant_type": "client_credentials",
-                    },
-                ) as token_response:
-                    if token_response.status != 200:
-                        logger.error(
-                            f"Failed to get Twitch access token for proxy health check: {token_response.status}"
-                        )
-                        return {
-                            "status": "failed",
-                            "response_time_ms": None,
-                            "error": "Failed to get Twitch access token",
-                        }
-
-                    token_data = await token_response.json()
-                    access_token = token_data.get("access_token")
-
-                    if not access_token:
-                        return {
-                            "status": "failed",
-                            "response_time_ms": None,
-                            "error": "No access token received",
-                        }
-
-        except Exception as e:
-            # Log full exception details server-side, but return only a generic error message to the client.
-            logger.error(f"Error getting access token for proxy check: {e}")
+        if not access_token:
             return {
                 "status": "failed",
                 "response_time_ms": None,
@@ -421,7 +415,10 @@ class ProxyHealthService:
                 return {"error": "Proxy not found"}
 
             # Run health check
-            health_result = await self._check_proxy_health(proxy.proxy_url)
+            access_token = await self._get_app_access_token()
+            health_result = await self._check_proxy_health(
+                proxy.proxy_url, access_token
+            )
 
             # Update database
             proxy.last_health_check = datetime.now(timezone.utc)

--- a/app/services/system/streamlink_config_service.py
+++ b/app/services/system/streamlink_config_service.py
@@ -100,37 +100,27 @@ class StreamlinkConfigService:
                 logger.warning("⚠️ No OAuth token - H.265/1440p quality unavailable")
                 logger.warning("⚠️ No OAuth token - recordings limited to 1080p60 H.264")
 
-            # Add proxy settings if configured
-            if http_proxy and http_proxy.strip():
+            proxy_url = (http_proxy or https_proxy or "").strip()
+            if proxy_url:
                 config_lines.extend(
                     [
                         "# HTTP Proxy",
-                        f"http-proxy={http_proxy.strip()}",
+                        f"http-proxy={proxy_url}",
                         "",
                     ]
                 )
-                logger.info(f"🔧 HTTP proxy configured: {http_proxy[:30]}...")
-
-            if https_proxy and https_proxy.strip():
-                config_lines.extend(
-                    [
-                        "# HTTPS Proxy",
-                        f"https-proxy={https_proxy.strip()}",
-                        "",
-                    ]
-                )
-                logger.info(f"🔧 HTTPS proxy configured: {https_proxy[:30]}...")
+                logger.info(f"🔧 HTTP proxy configured: {proxy_url[:30]}...")
 
             # Add static Streamlink options (from get_streamlink_command)
             config_lines.extend(
                 [
                     "# Stream stability settings",
-                    "hls-live-edge=99999",
+                    "hls-live-edge=3",
                     "stream-timeout=200",
                     "stream-segment-timeout=200",
                     "stream-segment-threads=5",
                     "retry-streams=10",
-                    "retry-max=5",
+                    "retry-max=2",
                     "",
                     "# FFmpeg output format",
                     "ffmpeg-fout=mpegts",

--- a/app/services/system/streamlink_config_service.py
+++ b/app/services/system/streamlink_config_service.py
@@ -12,6 +12,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from app.utils.security import sanitize_proxy_url_for_logging
+
 logger = logging.getLogger("streamvault")
 
 
@@ -109,7 +111,9 @@ class StreamlinkConfigService:
                         "",
                     ]
                 )
-                logger.info(f"🔧 HTTP proxy configured: {proxy_url[:30]}...")
+                logger.info(
+                    f"🔧 HTTP proxy configured: {sanitize_proxy_url_for_logging(proxy_url)}"
+                )
 
             # Add static Streamlink options (from get_streamlink_command)
             config_lines.extend(

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -621,6 +621,10 @@ def sanitize_proxy_url_for_logging(proxy_url: str) -> str:
 
         parsed = urlparse(proxy_url)
 
+        if "@" in proxy_url and "@" not in parsed.netloc:
+            host_part = proxy_url.rsplit("@", 1)[1]
+            return f"[REDACTED]:[REDACTED]@{host_part}"
+
         # If credentials are present, redact them
         if parsed.username or parsed.password:
             # Replace credentials with [REDACTED]

--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -66,10 +66,11 @@ def check_proxy_connectivity(
     # Test proxy connectivity with a simple Streamlink command
     test_cmd = ["streamlink", "--json", "twitch.tv/test"]
 
-    if "http" in proxy_settings and proxy_settings["http"].strip():
-        test_cmd.append(f"--http-proxy={proxy_settings['http'].strip()}")
-    if "https" in proxy_settings and proxy_settings["https"].strip():
-        test_cmd.append(f"--https-proxy={proxy_settings['https'].strip()}")
+    proxy_url = (
+        proxy_settings.get("http") or proxy_settings.get("https") or ""
+    ).strip()
+    if proxy_url:
+        test_cmd.append(f"--http-proxy={proxy_url}")
 
     try:
         # Use a short timeout to fail fast if proxy is down
@@ -152,10 +153,11 @@ def get_stream_info(
 
     # Add proxy settings if provided
     if proxy_settings:
-        if "http" in proxy_settings and proxy_settings["http"].strip():
-            cmd.append(f"--http-proxy={proxy_settings['http'].strip()}")
-        if "https" in proxy_settings and proxy_settings["https"].strip():
-            cmd.append(f"--https-proxy={proxy_settings['https'].strip()}")
+        proxy_url = (
+            proxy_settings.get("http") or proxy_settings.get("https") or ""
+        ).strip()
+        if proxy_url:
+            cmd.append(f"--http-proxy={proxy_url}")
 
     try:
         # SECURITY: Sanitize command for logging to prevent token exposure (CWE-532)
@@ -323,84 +325,43 @@ def _add_proxy_settings(
     Returns:
         Updated command list with proxy settings
     """
-    # Add HTTP proxy if configured
-    if "http" in proxy_settings and proxy_settings["http"].strip():
-        proxy_url = proxy_settings["http"].strip()
-        # Validate that the proxy URL has the correct protocol prefix
-        if not proxy_url.startswith(("http://", "https://")):
-            error_msg = (
-                f"HTTP proxy URL must start with 'http://' or 'https://'. "
-                f"Current value: {proxy_url}"
-            )
-            logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
-            raise ValueError(error_msg)
+    proxy_url = (
+        proxy_settings.get("http") or proxy_settings.get("https") or ""
+    ).strip()
+    if not proxy_url:
+        return cmd
 
-        cmd.append(f"--http-proxy={proxy_url}")
-        logger.debug(f"Using HTTP proxy: {proxy_url}")
-
-        # Add proxy-specific optimizations for better audio sync
-        seg_timeout = "60" if not force_mode else "90"
-        stream_timeout = "300" if not force_mode else "360"
-        seg_attempts = "15" if not force_mode else "20"
-        cmd.extend(
-            [
-                "--stream-segment-timeout",
-                seg_timeout,
-                "--stream-timeout",
-                stream_timeout,
-                # Multiplication factor for segment queue deadline (default 3.0)
-                # 8x = generous tolerance for proxy latency (replaces deprecated
-                # --hls-segment-queue-threshold since Streamlink 8.1.0)
-                "--stream-segmented-queue-deadline",
-                "8",
-                "--stream-segment-attempts",
-                seg_attempts,
-                "--hls-live-edge",
-                "10",
-                "--ringbuffer-size",
-                "512M",
-                "--hls-segment-stream-data",
-                "--stream-segment-threads",
-                "2",
-                "--hls-playlist-reload-time",
-                "segment",
-            ]
+    if not proxy_url.startswith(("http://", "https://")):
+        error_msg = (
+            "HTTP proxy URL must start with 'http://' or 'https://'. "
+            f"Current value: {proxy_url}"
         )
+        logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
+        raise ValueError(error_msg)
 
-    # Add HTTPS proxy if configured
-    if "https" in proxy_settings and proxy_settings["https"].strip():
-        proxy_url = proxy_settings["https"].strip()
-        # Validate that the proxy URL has the correct protocol prefix
-        if not proxy_url.startswith(("http://", "https://")):
-            error_msg = (
-                f"HTTPS proxy URL must start with 'http://' or 'https://'. "
-                f"Current value: {proxy_url}"
-            )
-            logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
-            raise ValueError(error_msg)
-
-        cmd.append(f"--https-proxy={proxy_url}")
-        logger.debug(f"Using HTTPS proxy: {proxy_url}")
-
-        # Add proxy-specific optimizations for HTTPS connections too
-        cmd.extend(
-            [
-                "--stream-segment-timeout",
-                "60" if not force_mode else "90",
-                "--stream-timeout",
-                "300" if not force_mode else "360",
-                # Multiplication factor for segment queue deadline (default 3.0)
-                # 8x = generous tolerance for proxy latency
-                "--stream-segmented-queue-deadline",
-                "8",
-                "--stream-segment-attempts",
-                "15" if not force_mode else "20",
-                "--hls-live-edge",
-                "10",
-                "--ringbuffer-size",
-                "512M",
-            ]
-        )
+    cmd.extend(
+        [
+            f"--http-proxy={proxy_url}",
+            "--stream-segment-timeout",
+            "60" if not force_mode else "90",
+            "--stream-timeout",
+            "300" if not force_mode else "360",
+            "--stream-segmented-queue-deadline",
+            "8",
+            "--stream-segment-attempts",
+            "5",
+            "--hls-live-edge",
+            "10",
+            "--ringbuffer-size",
+            "512M",
+            "--hls-segment-stream-data",
+            "--stream-segment-threads",
+            "2",
+            "--hls-playlist-reload-time",
+            "segment",
+        ]
+    )
+    logger.debug(f"Using HTTP proxy: {proxy_url}")
 
     return cmd
 

--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from app.models import GlobalSettings
+from app.utils.security import sanitize_proxy_url_for_logging
 
 # Get the logger
 logger = logging.getLogger(__name__)
@@ -332,9 +333,10 @@ def _add_proxy_settings(
         return cmd
 
     if not proxy_url.startswith(("http://", "https://")):
+        sanitized_proxy_url = sanitize_proxy_url_for_logging(proxy_url)
         error_msg = (
             "HTTP proxy URL must start with 'http://' or 'https://'. "
-            f"Current value: {proxy_url}"
+            f"Current value: {sanitized_proxy_url}"
         )
         logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
         raise ValueError(error_msg)
@@ -361,7 +363,7 @@ def _add_proxy_settings(
             "segment",
         ]
     )
-    logger.debug(f"Using HTTP proxy: {proxy_url}")
+    logger.debug(f"Using HTTP proxy: {sanitize_proxy_url_for_logging(proxy_url)}")
 
     return cmd
 

--- a/tests/test_proxy_health_service.py
+++ b/tests/test_proxy_health_service.py
@@ -1,0 +1,193 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.proxy.proxy_health_service import ProxyHealthService
+
+proxy_health_module = importlib.import_module("app.services.proxy.proxy_health_service")
+
+
+class _ProxyQuery:
+    def __init__(self, proxies):
+        self.proxies = proxies
+
+    def filter(self, *_criteria):
+        return self
+
+    def all(self):
+        return self.proxies
+
+
+class _ProxySession:
+    def __init__(self, proxies):
+        self.proxies = proxies
+        self.commit_count = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def query(self, _model):
+        return _ProxyQuery(self.proxies)
+
+    def commit(self):
+        self.commit_count += 1
+
+    def rollback(self):
+        return None
+
+
+def _proxy(proxy_id, proxy_url):
+    return SimpleNamespace(
+        id=proxy_id,
+        proxy_url=proxy_url,
+        masked_url=f"proxy-{proxy_id}",
+        health_status="unknown",
+        average_response_time_ms=None,
+        consecutive_failures=0,
+        enabled=True,
+        last_health_check=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_health_checks_reuses_one_unlogged_app_token_for_each_proxy(
+    monkeypatch, caplog
+):
+    # Given: two enabled proxies and an in-memory app token
+    proxies = [
+        _proxy(1, "http://healthy-proxy.example:8080"),
+        _proxy(2, "http://degraded-proxy.example:8080"),
+        _proxy(3, "http://failed-proxy.example:8080"),
+    ]
+    session = _ProxySession(proxies)
+    service = ProxyHealthService()
+    token_fetches = []
+    reachability_checks = []
+
+    async def get_app_access_token():
+        token_fetches.append(True)
+        return "sensitive-app-token"
+
+    async def check_proxy_health(proxy_url, access_token):
+        reachability_checks.append((proxy_url, access_token))
+        if "degraded" in proxy_url:
+            return {
+                "status": "degraded",
+                "response_time_ms": 2200,
+                "error": "Slow response (2200ms)",
+            }
+        if "failed" in proxy_url:
+            return {
+                "status": "failed",
+                "response_time_ms": None,
+                "error": "Connection error",
+            }
+        return {
+            "status": "healthy",
+            "response_time_ms": 120,
+            "error": None,
+        }
+
+    async def get_max_failures():
+        return 3
+
+    async def broadcast_proxy_status(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(proxy_health_module, "SessionLocal", lambda: session)
+    monkeypatch.setattr(
+        service, "_get_app_access_token", get_app_access_token, raising=False
+    )
+    monkeypatch.setattr(service, "_check_proxy_health", check_proxy_health)
+    monkeypatch.setattr(service, "_get_max_failures", get_max_failures)
+    monkeypatch.setattr(service, "_broadcast_proxy_status", broadcast_proxy_status)
+
+    # When: a complete proxy health cycle runs
+    await service.run_health_checks()
+
+    # Then: one token powers one API reachability request per proxy without log exposure.
+    assert token_fetches == [True]
+    assert reachability_checks == [
+        ("http://healthy-proxy.example:8080", "sensitive-app-token"),
+        ("http://degraded-proxy.example:8080", "sensitive-app-token"),
+        ("http://failed-proxy.example:8080", "sensitive-app-token"),
+    ]
+    assert [proxy.health_status for proxy in proxies] == [
+        "healthy",
+        "degraded",
+        "failed",
+    ]
+    assert [proxy.consecutive_failures for proxy in proxies] == [0, 0, 1]
+    assert session.commit_count == 3
+    assert "sensitive-app-token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_health_checks_marks_each_proxy_failed_when_token_fetch_fails(
+    monkeypatch,
+):
+    # Given: enabled proxies and a failed app-token request
+    proxies = [
+        _proxy(1, "http://first-proxy.example:8080"),
+        _proxy(2, "http://second-proxy.example:8080"),
+    ]
+    session = _ProxySession(proxies)
+    service = ProxyHealthService()
+
+    async def get_app_access_token():
+        return None
+
+    async def get_max_failures():
+        return 3
+
+    async def broadcast_proxy_status(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(proxy_health_module, "SessionLocal", lambda: session)
+    monkeypatch.setattr(service, "_get_app_access_token", get_app_access_token)
+    monkeypatch.setattr(service, "_get_max_failures", get_max_failures)
+    monkeypatch.setattr(service, "_broadcast_proxy_status", broadcast_proxy_status)
+
+    # When: the health-check cycle cannot obtain its app token
+    await service.run_health_checks()
+
+    # Then: no unauthenticated reachability call is made and failures are recorded.
+    assert [proxy.health_status for proxy in proxies] == ["failed", "failed"]
+    assert [proxy.consecutive_failures for proxy in proxies] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_run_health_checks_propagates_cancellation(monkeypatch):
+    # Given: a health check blocked on its one proxy request
+    import asyncio
+
+    proxy = _proxy(1, "http://blocked-proxy.example:8080")
+    session = _ProxySession([proxy])
+    service = ProxyHealthService()
+    request_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def get_app_access_token():
+        return "sensitive-app-token"
+
+    async def check_proxy_health(_proxy_url, _access_token):
+        request_started.set()
+        await never_finishes.wait()
+
+    monkeypatch.setattr(proxy_health_module, "SessionLocal", lambda: session)
+    monkeypatch.setattr(service, "_get_app_access_token", get_app_access_token)
+    monkeypatch.setattr(service, "_check_proxy_health", check_proxy_health)
+
+    # When: the caller cancels the active health-check cycle
+    task = asyncio.create_task(service.run_health_checks())
+    await request_started.wait()
+    task.cancel()
+
+    # Then: cancellation is not converted into a proxy failure.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert proxy.health_status == "unknown"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -483,6 +483,17 @@ class TestProxyURLSanitization:
         assert result == url
         assert "[REDACTED]" not in result
 
+    def test_proxy_credentials_without_scheme_redacted(self):
+        """Test malformed proxy credentials are still redacted"""
+        from app.utils.security import sanitize_proxy_url_for_logging
+
+        url = "user:password@proxy.example.com:8080"
+        result = sanitize_proxy_url_for_logging(url)
+
+        assert "user" not in result
+        assert "password" not in result
+        assert "proxy.example.com:8080" in result
+
     def test_https_proxy_with_credentials_redacted(self):
         """Test HTTPS proxy credentials are redacted"""
         from app.utils.security import sanitize_proxy_url_for_logging

--- a/tests/test_streamlink_command_format.py
+++ b/tests/test_streamlink_command_format.py
@@ -20,7 +20,10 @@ from app.utils.streamlink_utils import get_streamlink_command
 def test_oauth_token_format():
     """Test that OAuth token is passed as single argument with ="""
     cmd = get_streamlink_command(
-        streamer_name="test_streamer", quality="best", output_path="/tmp/test.ts", oauth_token="test_token_123"
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        oauth_token="test_token_123",
     )
 
     # Find the OAuth argument
@@ -43,7 +46,10 @@ def test_oauth_token_format():
 def test_codec_format():
     """Test that codecs are passed as single argument with ="""
     cmd = get_streamlink_command(
-        streamer_name="test_streamer", quality="best", output_path="/tmp/test.ts", supported_codecs="h264,h265,av1"
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        supported_codecs="h264,h265,av1",
     )
 
     # Find the codec argument
@@ -59,7 +65,6 @@ def test_codec_format():
 
 
 def test_proxy_format():
-    """Test that proxy URLs are passed as single argument with ="""
     cmd = get_streamlink_command(
         streamer_name="test_streamer",
         quality="best",
@@ -70,18 +75,27 @@ def test_proxy_format():
         },
     )
 
-    # Find proxy arguments
-    http_proxy_arg = None
-    https_proxy_arg = None
-    for arg in cmd:
-        if arg.startswith("--http-proxy="):
-            http_proxy_arg = arg
-        if arg.startswith("--https-proxy="):
-            https_proxy_arg = arg
+    proxy_args = [arg for arg in cmd if "proxy=" in arg]
+    assert proxy_args == ["--http-proxy=http://user:pass@proxy.example.com:8080"]
 
-    # Verify format
-    assert http_proxy_arg == "--http-proxy=http://user:pass@proxy.example.com:8080"
-    assert https_proxy_arg == "--https-proxy=https://user:pass@proxy.example.com:8443"
+
+def test_https_proxy_falls_back_to_one_http_proxy_with_six_total_segment_attempts():
+    # Given: an HTTPS-only proxy for a force recording command
+    cmd = get_streamlink_command(
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        proxy_settings={"https": "https://proxy.example.com:8443"},
+        force_mode=True,
+    )
+
+    # When: Streamlink 8.4.0 receives the generated command
+    proxy_args = [arg for arg in cmd if "proxy=" in arg]
+
+    # Then: it has one HTTP proxy and five retries after the initial segment request.
+    assert proxy_args == ["--http-proxy=https://proxy.example.com:8443"]
+    attempts_index = cmd.index("--stream-segment-attempts")
+    assert cmd[attempts_index + 1] == "5"
 
 
 def test_no_space_in_critical_arguments():
@@ -96,7 +110,12 @@ def test_no_space_in_critical_arguments():
     )
 
     # Critical arguments that should use = format
-    critical_args = ["--twitch-api-header", "--twitch-supported-codecs", "--http-proxy", "--https-proxy"]
+    critical_args = [
+        "--twitch-api-header",
+        "--twitch-supported-codecs",
+        "--http-proxy",
+        "--https-proxy",
+    ]
 
     # Check each critical argument
     for arg_name in critical_args:
@@ -113,14 +132,19 @@ def test_no_space_in_critical_arguments():
                 next_arg = cmd[idx + 1]
                 # Next argument should be another option or the URL
                 assert (
-                    next_arg.startswith("--") or "twitch.tv" in next_arg or next_arg in ["best", "/tmp/test.ts"]
+                    next_arg.startswith("--")
+                    or "twitch.tv" in next_arg
+                    or next_arg in ["best", "/tmp/test.ts"]
                 ), f"{arg_name} appears to have value as separate argument: {next_arg}"
 
 
 def test_command_structure():
     """Test overall command structure"""
     cmd = get_streamlink_command(
-        streamer_name="test_streamer", quality="best", output_path="/tmp/test.ts", oauth_token="test_token_123"
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        oauth_token="test_token_123",
     )
 
     # Basic structure checks

--- a/tests/test_streamlink_config_service.py
+++ b/tests/test_streamlink_config_service.py
@@ -1,5 +1,13 @@
 import importlib.util
+import socket
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from ipaddress import ip_address
 from pathlib import Path
+from threading import Thread
+from types import SimpleNamespace
+
+import pytest
 
 
 _module_path = (
@@ -13,6 +21,85 @@ assert _spec and _spec.loader
 _module = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_module)
 StreamlinkConfigService = _module.StreamlinkConfigService
+
+
+@pytest.fixture
+def local_hls_server(monkeypatch):
+    requests = Counter()
+    playlist = b"""#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:1
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:1.0,
+segment.ts
+#EXT-X-ENDLIST
+"""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests[self.path] += 1
+            if self.path == "/playlist.m3u8":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/vnd.apple.mpegurl")
+                self.send_header("Content-Length", str(len(playlist)))
+                self.end_headers()
+                self.wfile.write(playlist)
+                return
+
+            self.send_response(503)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, _format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server_thread = Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    original_connect = socket.socket.connect
+
+    def loopback_connect(sock, address):
+        if sock.family in (socket.AF_INET, socket.AF_INET6):
+            host = address[0]
+            if not ip_address(host).is_loopback:
+                raise OSError(f"External network access blocked: {host}")
+        return original_connect(sock, address)
+
+    monkeypatch.setattr(socket.socket, "connect", loopback_connect)
+    host, port = server.server_address
+    try:
+        yield SimpleNamespace(
+            requests=requests,
+            url=lambda path: f"http://{host}:{port}{path}",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+
+def _generated_config_options(service):
+    assert service.generate_twitch_config()
+    return dict(
+        line.split("=", 1)
+        for line in service.twitch_config_path.read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#")
+    )
+
+
+def test_generate_twitch_config_redacts_proxy_credentials_from_log(tmp_path, caplog):
+    service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+    service.config_dir = tmp_path
+    service.twitch_config_path = tmp_path / "config.twitch"
+    proxy_url = "http://user:password@proxy.example.com:8080"
+
+    with caplog.at_level("INFO", logger="streamvault"):
+        assert service.generate_twitch_config(http_proxy=proxy_url)
+
+    assert "user" not in caplog.text
+    assert "password" not in caplog.text
+    assert "proxy.example.com:8080" in caplog.text
 
 
 def test_generate_twitch_config_uses_deterministic_streamlink_8_4_options(tmp_path):
@@ -35,3 +122,76 @@ def test_generate_twitch_config_uses_deterministic_streamlink_8_4_options(tmp_pa
     assert "retry-streams=10" in config_lines
     assert "retry-max=2" in config_lines
     assert "stream-segment-threads=5" in config_lines
+
+
+def test_missing_stream_resolution_stays_within_three_http_attempts(
+    tmp_path, monkeypatch, local_hls_server
+):
+    streamlink = pytest.importorskip("streamlink")
+    streamlink_cli = pytest.importorskip("streamlink_cli.main")
+    assert streamlink.__version__ == "8.4.0"
+
+    service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+    service.config_dir = tmp_path
+    service.twitch_config_path = tmp_path / "config.twitch"
+    options = _generated_config_options(service)
+
+    session = streamlink.Streamlink({"no-plugin-cache": True})
+    session.http.trust_env = False
+    url = local_hls_server.url("/missing.m3u8")
+    _, plugin_class, resolved_url = session.resolve_url(url)
+    plugin = plugin_class(session, resolved_url)
+    monkeypatch.setattr(
+        streamlink_cli,
+        "args",
+        SimpleNamespace(
+            stream_types=["hls", "http", "*"], stream_sorting_excludes=None
+        ),
+    )
+    monkeypatch.setattr(streamlink_cli, "sleep", lambda _interval: None)
+
+    streams = streamlink_cli.fetch_streams_with_retry(
+        plugin,
+        interval=0,
+        count=int(options["retry-max"]),
+    )
+
+    assert not streams
+    assert local_hls_server.requests["/missing.m3u8"] == 3
+
+
+def test_retriable_hls_segment_stays_within_six_http_attempts(
+    monkeypatch, local_hls_server
+):
+    streamlink = pytest.importorskip("streamlink")
+    assert streamlink.__version__ == "8.4.0"
+    from app.utils.streamlink_utils import get_streamlink_command
+    from streamlink.stream.hls import HLSStream
+
+    command = get_streamlink_command(
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        proxy_settings={"http": "http://proxy.example.com:8080"},
+    )
+    attempts_index = command.index("--stream-segment-attempts")
+    retry_attempts = int(command[attempts_index + 1])
+
+    session = streamlink.Streamlink(
+        {
+            "no-plugin-cache": True,
+            "stream-segment-attempts": retry_attempts,
+            "stream-segment-threads": 1,
+        }
+    )
+    session.http.trust_env = False
+    monkeypatch.setattr("streamlink.session.http.time.sleep", lambda _delay: None)
+    stream = HLSStream(session, local_hls_server.url("/playlist.m3u8"))
+
+    reader = stream.open()
+    try:
+        assert reader.read(8192) == b""
+    finally:
+        reader.close()
+
+    assert local_hls_server.requests["/segment.ts"] == 6

--- a/tests/test_streamlink_config_service.py
+++ b/tests/test_streamlink_config_service.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+
+
+_module_path = (
+    Path(__file__).resolve().parents[1]
+    / "app/services/system/streamlink_config_service.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "streamlink_config_service_under_test", _module_path
+)
+assert _spec and _spec.loader
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+StreamlinkConfigService = _module.StreamlinkConfigService
+
+
+def test_generate_twitch_config_uses_deterministic_streamlink_8_4_options(tmp_path):
+    # Given: differing HTTP and HTTPS proxies and a writable config path
+    service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+    service.config_dir = tmp_path
+    service.twitch_config_path = tmp_path / "config.twitch"
+
+    # When: the Twitch plugin config is generated
+    assert service.generate_twitch_config(
+        http_proxy="http://http-proxy.example:8080",
+        https_proxy="http://https-proxy.example:8443",
+    )
+
+    # Then: Streamlink 8.4.0 receives one deterministic proxy and stability budget
+    config_lines = service.twitch_config_path.read_text(encoding="utf-8").splitlines()
+    assert config_lines.count("http-proxy=http://http-proxy.example:8080") == 1
+    assert not any(line.startswith("https-proxy=") for line in config_lines)
+    assert "hls-live-edge=3" in config_lines
+    assert "retry-streams=10" in config_lines
+    assert "retry-max=2" in config_lines
+    assert "stream-segment-threads=5" in config_lines

--- a/tests/utils/test_streamlink_utils.py
+++ b/tests/utils/test_streamlink_utils.py
@@ -7,11 +7,36 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from app.utils.streamlink_utils import (
+    _add_proxy_settings,
     get_streamlink_command,
     get_streamlink_vod_command,
     get_streamlink_clip_command,
     get_proxy_settings_from_db,
 )
+
+
+def test_add_proxy_settings_redacts_credentials_from_log(caplog):
+    proxy_url = "http://user:password@proxy.example.com:8080"
+
+    with caplog.at_level("DEBUG", logger="app.utils.streamlink_utils"):
+        _add_proxy_settings([], {"http": proxy_url}, force_mode=False)
+
+    assert "user" not in caplog.text
+    assert "password" not in caplog.text
+    assert "proxy.example.com:8080" in caplog.text
+
+
+def test_add_proxy_settings_redacts_credentials_from_invalid_proxy(caplog):
+    proxy_url = "user:password@proxy.example.com:8080"
+
+    with caplog.at_level("ERROR", logger="app.utils.streamlink_utils"):
+        with pytest.raises(ValueError) as exc_info:
+            _add_proxy_settings([], {"http": proxy_url}, force_mode=False)
+
+    diagnostic = f"{exc_info.value} {caplog.text}"
+    assert "user" not in diagnostic
+    assert "password" not in diagnostic
+    assert "proxy.example.com:8080" in diagnostic
 
 
 class TestStreamlinkUtils:


### PR DESCRIPTION
## Summary
- Configure deterministic Streamlink retry and live-edge options.
- Use one HTTP proxy option with bounded segment attempts.
- Reuse one in-memory Twitch app token per proxy health-check cycle.

## Validation
- pytest focused and full suites
- ruff check and format checks
- migrations initialization

Closes #782