### PR TITLE
fix: bound Streamlink request budgets

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -792,20 +792,13 @@ class ProxySettings(Base):
     @property
     def masked_url(self) -> str:
         """
-        Return proxy URL with password masked for security.
-        Example: http://username:***@proxy-host:9999
+        Return validated proxy host and port for diagnostics.
 
         SECURITY: Safe to display in UI and logs.
         """
-        decrypted_url = self.proxy_url
+        from app.utils.security import sanitize_proxy_url_for_logging
 
-        if "@" in decrypted_url:
-            parts = decrypted_url.split("@")
-            if ":" in parts[0]:
-                # Split protocol://username:password
-                user_part = parts[0].rsplit(":", 1)[0]
-                return f"{user_part}:***@{parts[1]}"
-        return decrypted_url
+        return sanitize_proxy_url_for_logging(self.proxy_url)
 
     def calculate_success_rate(self) -> Optional[float]:
         """Calculate success rate as percentage"""
@@ -824,12 +817,13 @@ class ProxySettings(Base):
         Serialize proxy settings to dictionary.
 
         Args:
-            mask_password: If True, replace password with *** in URL
+            mask_password: If True, expose only validated host and port
         """
+        masked_url = self.masked_url
         return {
             "id": self.id,
-            "proxy_url": self.masked_url if mask_password else self.proxy_url,
-            "masked_url": self.masked_url,  # Always include masked URL for display
+            "proxy_url": masked_url if mask_password else self.proxy_url,
+            "masked_url": masked_url,
             "priority": self.priority,
             "enabled": self.enabled,
             "last_check": self.last_health_check.isoformat()

--- a/app/routes/proxy.py
+++ b/app/routes/proxy.py
@@ -142,10 +142,6 @@ async def add_proxy(request: ProxyAddRequest, user=Depends(get_current_user)):
         # URL-encode credentials in proxy URL (fixes passwords with special chars like _)
         encoded_proxy_url = encode_proxy_url(request.proxy_url)
 
-        logger.debug(
-            f"Encoding proxy URL: {request.proxy_url[:30]}... → {encoded_proxy_url[:30]}..."
-        )
-
         # Check for duplicate proxy URL (check both raw and encoded)
         existing = (
             db.query(ProxySettings)

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -32,6 +32,7 @@ from typing import Dict, Optional, Set
 from app.database import SessionLocal
 from app.services.proxy.proxy_health_service import proxy_health_service
 from app.services.system.twitch_token_service import TwitchTokenService
+from app.utils.security import sanitize_proxy_url_for_logging
 from app.utils.streamlink_utils import _add_proxy_settings
 
 logger = logging.getLogger("streamvault")
@@ -471,9 +472,12 @@ class LiveStreamingService:
                 if proxy_url:
                     proxy_settings = {"http": proxy_url, "https": proxy_url}
                     cmd = _add_proxy_settings(cmd, proxy_settings, force_mode=False)
-                    logger.debug(f"[LIVE] Using proxy: {proxy_url}")
-            except Exception as e:
-                logger.warning(f"[LIVE] Could not get proxy: {e}")
+                    logger.debug(
+                        "[LIVE] Using proxy: %s",
+                        sanitize_proxy_url_for_logging(proxy_url),
+                    )
+            except Exception:
+                logger.warning("[LIVE] Could not get proxy")
 
         return cmd
 

--- a/app/services/proxy/proxy_health_service.py
+++ b/app/services/proxy/proxy_health_service.py
@@ -31,6 +31,7 @@ from app.config.constants import ASYNC_DELAYS
 from app.config.settings import settings
 from app.database import SessionLocal
 from app.models import ProxySettings, RecordingSettings
+from app.utils.security import sanitize_proxy_url_for_logging
 
 logger = logging.getLogger("streamvault")
 
@@ -107,8 +108,8 @@ class ProxyHealthService:
             except asyncio.CancelledError:
                 logger.info("🛑 Health check loop cancelled")
                 break
-            except Exception as e:
-                logger.error(f"🚨 Error in health check loop: {e}", exc_info=True)
+            except Exception:
+                logger.error("🚨 Error in health check loop")
                 # Wait before retrying to avoid tight error loop
                 await asyncio.sleep(ASYNC_DELAYS.PROXY_HEALTH_CHECK_ERROR_WAIT)
 
@@ -121,8 +122,8 @@ class ProxyHealthService:
                     settings, "proxy_health_check_interval_seconds"
                 ):
                     return settings.proxy_health_check_interval_seconds
-        except Exception as e:
-            logger.error(f"Error getting check interval: {e}")
+        except Exception:
+            logger.error("Error getting check interval")
 
         # Default: 5 minutes
         return 300
@@ -134,8 +135,8 @@ class ProxyHealthService:
                 settings = db.query(RecordingSettings).first()
                 if settings and hasattr(settings, "proxy_health_check_enabled"):
                     return settings.proxy_health_check_enabled
-        except Exception as e:
-            logger.error(f"Error checking if health checks enabled: {e}")
+        except Exception:
+            logger.error("Error checking if health checks enabled")
 
         # Default: enabled
         return True
@@ -164,10 +165,21 @@ class ProxyHealthService:
 
                 logger.info(f"🔍 Checking {len(proxies)} enabled proxies...")
 
+                access_token = await self._get_twitch_access_token()
+                if not access_token:
+                    logger.error(
+                        "Proxy health checks skipped: Twitch token unavailable"
+                    )
+                    return
+
                 # Check each proxy
                 for proxy in proxies:
                     try:
-                        health_result = await self._check_proxy_health(proxy.proxy_url)
+                        proxy_url = proxy.proxy_url
+                        safe_proxy_url = sanitize_proxy_url_for_logging(proxy_url)
+                        health_result = await self._check_proxy_health(
+                            proxy_url, access_token
+                        )
 
                         # Update proxy health in database
                         proxy.last_health_check = datetime.now(timezone.utc)
@@ -180,7 +192,7 @@ class ProxyHealthService:
                         if health_result["status"] == "failed":
                             proxy.consecutive_failures += 1
                             logger.warning(
-                                f"⚠️ Proxy health check failed: {proxy.masked_url} - "
+                                f"⚠️ Proxy health check failed: {safe_proxy_url} - "
                                 f"Failures: {proxy.consecutive_failures}/{await self._get_max_failures()} - "
                                 f"Error: {health_result.get('error', 'Unknown')}"
                             )
@@ -188,7 +200,7 @@ class ProxyHealthService:
                             # Reset counter on success
                             proxy.consecutive_failures = 0
                             logger.info(
-                                f"✅ Proxy health check passed: {proxy.masked_url} - "
+                                f"✅ Proxy health check passed: {safe_proxy_url} - "
                                 f"{health_result['status']} ({health_result.get('response_time_ms')}ms)"
                             )
 
@@ -198,7 +210,7 @@ class ProxyHealthService:
                             proxy.enabled = False
                             logger.error(
                                 f"🚨 Proxy auto-disabled after {proxy.consecutive_failures} failures: "
-                                f"{proxy.masked_url}"
+                                f"{safe_proxy_url}"
                             )
 
                             # Broadcast notification
@@ -213,10 +225,8 @@ class ProxyHealthService:
 
                         db.commit()
 
-                    except Exception as e:
-                        logger.error(
-                            f"Error checking proxy {proxy.id}: {e}", exc_info=True
-                        )
+                    except Exception:
+                        logger.error(f"Error checking proxy {proxy.id}")
                         db.rollback()
 
                 logger.info("✅ Proxy health checks completed")
@@ -228,13 +238,49 @@ class ProxyHealthService:
                 settings = db.query(RecordingSettings).first()
                 if settings and hasattr(settings, "proxy_max_consecutive_failures"):
                     return settings.proxy_max_consecutive_failures
-        except Exception as e:
-            logger.error(f"Error getting max failures: {e}")
+        except Exception:
+            logger.error("Error getting max failures")
 
         # Default: 3 failures
         return 3
 
-    async def _check_proxy_health(self, proxy_url: str) -> Dict[str, Any]:
+    async def _get_twitch_access_token(self) -> Optional[str]:
+        """Fetch one ephemeral Twitch app token for a health-check operation."""
+        try:
+            async with aiohttp.ClientSession() as token_session:
+                async with token_session.post(
+                    "https://id.twitch.tv/oauth2/token",
+                    params={
+                        "client_id": settings.TWITCH_APP_ID,
+                        "client_secret": settings.TWITCH_APP_SECRET,
+                        "grant_type": "client_credentials",
+                    },
+                ) as token_response:
+                    if token_response.status != 200:
+                        logger.error(
+                            "Failed to get Twitch access token for proxy health check "
+                            f"(HTTP {token_response.status})"
+                        )
+                        return None
+
+                    token_data = await token_response.json()
+                    access_token = token_data.get("access_token")
+                    if not access_token:
+                        logger.error(
+                            "Twitch token response for proxy health check was invalid"
+                        )
+                        return None
+                    return access_token
+        except asyncio.CancelledError:
+            logger.error("Twitch token request for proxy health check was cancelled")
+            raise
+        except Exception:
+            logger.error("Error getting access token for proxy health check")
+            return None
+
+    async def _check_proxy_health(
+        self, proxy_url: str, access_token: str
+    ) -> Dict[str, Any]:
         """
         Check health of a single proxy by testing connectivity with Twitch API.
 
@@ -252,48 +298,6 @@ class ProxyHealthService:
                 'error': str or None
             }
         """
-        # Get Twitch access token first
-        try:
-            # Use app credentials to get access token (same as in recordings)
-            async with aiohttp.ClientSession() as token_session:
-                async with token_session.post(
-                    "https://id.twitch.tv/oauth2/token",
-                    params={
-                        "client_id": settings.TWITCH_APP_ID,
-                        "client_secret": settings.TWITCH_APP_SECRET,
-                        "grant_type": "client_credentials",
-                    },
-                ) as token_response:
-                    if token_response.status != 200:
-                        logger.error(
-                            f"Failed to get Twitch access token for proxy health check: {token_response.status}"
-                        )
-                        return {
-                            "status": "failed",
-                            "response_time_ms": None,
-                            "error": "Failed to get Twitch access token",
-                        }
-
-                    token_data = await token_response.json()
-                    access_token = token_data.get("access_token")
-
-                    if not access_token:
-                        return {
-                            "status": "failed",
-                            "response_time_ms": None,
-                            "error": "No access token received",
-                        }
-
-        except Exception as e:
-            # Log full exception details server-side, but return only a generic error message to the client.
-            logger.error(f"Error getting access token for proxy check: {e}")
-            return {
-                "status": "failed",
-                "response_time_ms": None,
-                "error": "Token error",
-            }
-
-        # Now test the proxy with authenticated Twitch API request
         timeout = aiohttp.ClientTimeout(total=10.0, connect=5.0)
 
         try:
@@ -313,7 +317,7 @@ class ProxyHealthService:
                         "Authorization": f"Bearer {access_token}",
                     },
                     proxy=proxy_url,  # Use proxy for this request
-                    allow_redirects=True,
+                    allow_redirects=False,
                 ) as response:
                     end_time = asyncio.get_event_loop().time()
                     response_time_ms = int((end_time - start_time) * 1000)
@@ -345,9 +349,8 @@ class ProxyHealthService:
                         # 4xx = proxy works but might have auth issues
                         # Check if it's specifically auth (401/403) which might be token issue
                         if response.status in (401, 403):
-                            error_text = await response.text()
                             logger.warning(
-                                f"Proxy health check got {response.status}: {error_text[:100]}"
+                                f"Proxy health check got HTTP {response.status}"
                             )
                             return {
                                 "status": "degraded",
@@ -375,27 +378,28 @@ class ProxyHealthService:
                 "error": "Timeout after 10 seconds",
             }
 
-            # Log detailed connection error, but expose only a generic message to the client.
-        except aiohttp.ClientProxyConnectionError as e:
-            logger.error(f"Proxy connection error during health check: {e}")
+        except asyncio.CancelledError:
+            logger.warning("Proxy health request was cancelled")
+            raise
+
+        except aiohttp.ClientProxyConnectionError:
+            logger.error("Proxy connection error during health check")
             return {
                 "status": "failed",
                 "response_time_ms": None,
                 "error": "Proxy connection failed",
             }
 
-            # Log detailed client error, but expose only a generic message to the client.
-        except aiohttp.ClientError as e:
-            logger.error(f"Client error during proxy health check: {e}")
+        except aiohttp.ClientError:
+            logger.error("Client error during proxy health check")
             return {
                 "status": "failed",
                 "response_time_ms": None,
                 "error": "Connection error",
             }
 
-            # Log unexpected exceptions with stack trace, but do not leak details to the client.
-        except Exception as e:
-            logger.error(f"Unexpected error checking proxy health: {e}", exc_info=True)
+        except Exception:
+            logger.error("Unexpected error checking proxy health")
             return {
                 "status": "failed",
                 "response_time_ms": None,
@@ -420,8 +424,17 @@ class ProxyHealthService:
             if not proxy:
                 return {"error": "Proxy not found"}
 
-            # Run health check
-            health_result = await self._check_proxy_health(proxy.proxy_url)
+            access_token = await self._get_twitch_access_token()
+            if access_token:
+                health_result = await self._check_proxy_health(
+                    proxy.proxy_url, access_token
+                )
+            else:
+                health_result = {
+                    "status": "failed",
+                    "response_time_ms": None,
+                    "error": "Health check unavailable",
+                }
 
             # Update database
             proxy.last_health_check = datetime.now(timezone.utc)
@@ -440,7 +453,9 @@ class ProxyHealthService:
             await self._broadcast_proxy_status(proxy, auto_disabled=False)
 
             logger.info(
-                f"🔧 Manual health check: {proxy.masked_url} - {health_result['status']}"
+                "🔧 Manual health check: "
+                f"{sanitize_proxy_url_for_logging(proxy.proxy_url)} - "
+                f"{health_result['status']}"
                 + (
                     f" - Error: {health_result.get('error')}"
                     if health_result.get("error")
@@ -500,7 +515,8 @@ class ProxyHealthService:
             best_proxy = sorted_proxies[0]
 
             logger.info(
-                f"✅ Selected best proxy: {best_proxy.masked_url} - "
+                "✅ Selected best proxy: "
+                f"{sanitize_proxy_url_for_logging(best_proxy.proxy_url)} - "
                 f"Status: {best_proxy.health_status}, Priority: {best_proxy.priority}, "
                 f"Response: {best_proxy.average_response_time_ms}ms"
             )
@@ -520,17 +536,21 @@ class ProxyHealthService:
         try:
             from app.services.communication.websocket_manager import websocket_manager
 
+            proxy_data = proxy.to_dict(mask_password=True)
+            safe_proxy_url = sanitize_proxy_url_for_logging(proxy.proxy_url)
+            proxy_data["proxy_url"] = safe_proxy_url
+            proxy_data["masked_url"] = safe_proxy_url
             message = {
                 "type": "proxy_health_update",
-                "proxy": proxy.to_dict(mask_password=True),
+                "proxy": proxy_data,
                 "auto_disabled": auto_disabled,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 
             await websocket_manager.send_notification(message)
 
-        except Exception as e:
-            logger.error(f"Error broadcasting proxy status: {e}", exc_info=True)
+        except Exception:
+            logger.error("Error broadcasting proxy status")
 
     async def increment_recording_stats(self, proxy_url: str, success: bool):
         """
@@ -556,7 +576,8 @@ class ProxyHealthService:
                 db.commit()
 
                 logger.debug(
-                    f"📊 Proxy stats updated: {proxy.masked_url} - "
+                    "📊 Proxy stats updated: "
+                    f"{sanitize_proxy_url_for_logging(proxy.proxy_url)} - "
                     f"Total: {proxy.total_recordings}, Failed: {proxy.failed_recordings}, "
                     f"Success rate: {proxy.success_rate:.1f}%"
                 )

--- a/app/services/proxy/proxy_health_service.py
+++ b/app/services/proxy/proxy_health_service.py
@@ -284,7 +284,8 @@ class ProxyHealthService:
         """
         Check health of a single proxy by testing connectivity with Twitch API.
 
-        Uses authenticated Twitch API request to test the actual endpoint used for recordings.
+        Uses authenticated Twitch API request to test the actual endpoint used for
+        recordings.
         This ensures the proxy works for Streamlink, not just general web traffic.
 
         Args:

--- a/app/services/system/streamlink_config_service.py
+++ b/app/services/system/streamlink_config_service.py
@@ -12,6 +12,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from app.utils.security import sanitize_proxy_url_for_logging
+
 logger = logging.getLogger("streamvault")
 
 
@@ -109,7 +111,10 @@ class StreamlinkConfigService:
                         "",
                     ]
                 )
-                logger.info(f"🔧 HTTP proxy configured: {proxy_url[:30]}...")
+                logger.info(
+                    "🔧 HTTP proxy configured: %s",
+                    sanitize_proxy_url_for_logging(proxy_url),
+                )
 
             # Add static Streamlink options (from get_streamlink_command)
             config_lines.extend(

--- a/app/services/system/streamlink_config_service.py
+++ b/app/services/system/streamlink_config_service.py
@@ -100,37 +100,27 @@ class StreamlinkConfigService:
                 logger.warning("⚠️ No OAuth token - H.265/1440p quality unavailable")
                 logger.warning("⚠️ No OAuth token - recordings limited to 1080p60 H.264")
 
-            # Add proxy settings if configured
-            if http_proxy and http_proxy.strip():
+            proxy_url = (http_proxy or "").strip() or (https_proxy or "").strip()
+            if proxy_url:
                 config_lines.extend(
                     [
                         "# HTTP Proxy",
-                        f"http-proxy={http_proxy.strip()}",
+                        f"http-proxy={proxy_url}",
                         "",
                     ]
                 )
-                logger.info(f"🔧 HTTP proxy configured: {http_proxy[:30]}...")
-
-            if https_proxy and https_proxy.strip():
-                config_lines.extend(
-                    [
-                        "# HTTPS Proxy",
-                        f"https-proxy={https_proxy.strip()}",
-                        "",
-                    ]
-                )
-                logger.info(f"🔧 HTTPS proxy configured: {https_proxy[:30]}...")
+                logger.info(f"🔧 HTTP proxy configured: {proxy_url[:30]}...")
 
             # Add static Streamlink options (from get_streamlink_command)
             config_lines.extend(
                 [
                     "# Stream stability settings",
-                    "hls-live-edge=99999",
+                    "hls-live-edge=3",
                     "stream-timeout=200",
                     "stream-segment-timeout=200",
                     "stream-segment-threads=5",
                     "retry-streams=10",
-                    "retry-max=5",
+                    "retry-max=2",
                     "",
                     "# FFmpeg output format",
                     "ffmpeg-fout=mpegts",

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -597,8 +597,8 @@ def sanitize_proxy_url_for_logging(proxy_url: str) -> str:
     """
     Sanitize proxy URL for logging to prevent credential exposure
 
-    This function prevents logging of proxy credentials (CWE-532) by redacting
-    username and password from proxy URLs while preserving host information.
+    This function prevents logging of proxy credentials and signed URL data
+    (CWE-532) by retaining only validated host and port information.
 
     Args:
         proxy_url: Proxy URL that may contain credentials
@@ -608,39 +608,37 @@ def sanitize_proxy_url_for_logging(proxy_url: str) -> str:
 
     Example:
         >>> sanitize_proxy_url_for_logging("http://user:pass@proxy.com:8080")
-        "http://[REDACTED]:[REDACTED]@proxy.com:8080"
+        "proxy.com:8080"
 
-        >>> sanitize_proxy_url_for_logging("http://proxy.com:8080")
-        "http://proxy.com:8080"
+        >>> sanitize_proxy_url_for_logging("http://proxy.com:8080/private?token=secret")
+        "proxy.com:8080"
     """
     if not proxy_url or not isinstance(proxy_url, str):
         return "[INVALID_URL]"
 
     try:
-        from urllib.parse import urlparse, urlunparse
+        from urllib.parse import urlsplit
 
-        parsed = urlparse(proxy_url)
+        parsed = urlsplit(proxy_url)
+        if not parsed.scheme or not parsed.netloc:
+            return "[REDACTED_PROXY_URL]"
 
-        # If credentials are present, redact them
-        if parsed.username or parsed.password:
-            # Replace credentials with [REDACTED]
-            netloc = parsed.netloc
-            if "@" in netloc:
-                # Extract host part after @
-                host_part = netloc.split("@", 1)[1]
-                # Reconstruct with redacted credentials
-                netloc = f"[REDACTED]:[REDACTED]@{host_part}"
+        host = parsed.hostname
+        port = parsed.port
+        if not host:
+            return "[REDACTED_PROXY_URL]"
 
-            # Rebuild URL with redacted credentials
-            sanitized_parsed = parsed._replace(netloc=netloc)
-            return urlunparse(sanitized_parsed)
-        else:
-            # No credentials, safe to log as-is
-            return proxy_url
+        if ":" in host:
+            import ipaddress
 
-    except Exception as e:
-        # If parsing fails, redact the entire URL to be safe
-        logger.warning(f"Failed to parse proxy URL for sanitization: {e}")
+            ipaddress.IPv6Address(host)
+            host = f"[{host}]"
+        elif not re.fullmatch(r"[A-Za-z0-9.-]+", host):
+            return "[REDACTED_PROXY_URL]"
+
+        return f"{host}:{port}" if port is not None else host
+
+    except (TypeError, ValueError):
         return "[REDACTED_PROXY_URL]"
 
 

--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -323,84 +323,43 @@ def _add_proxy_settings(
     Returns:
         Updated command list with proxy settings
     """
-    # Add HTTP proxy if configured
-    if "http" in proxy_settings and proxy_settings["http"].strip():
-        proxy_url = proxy_settings["http"].strip()
-        # Validate that the proxy URL has the correct protocol prefix
-        if not proxy_url.startswith(("http://", "https://")):
-            error_msg = (
-                f"HTTP proxy URL must start with 'http://' or 'https://'. "
-                f"Current value: {proxy_url}"
-            )
-            logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
-            raise ValueError(error_msg)
+    http_proxy = proxy_settings.get("http", "").strip()
+    https_proxy = proxy_settings.get("https", "").strip()
+    proxy_url = http_proxy or https_proxy
+    if not proxy_url:
+        return cmd
 
-        cmd.append(f"--http-proxy={proxy_url}")
-        logger.debug(f"Using HTTP proxy: {proxy_url}")
-
-        # Add proxy-specific optimizations for better audio sync
-        seg_timeout = "60" if not force_mode else "90"
-        stream_timeout = "300" if not force_mode else "360"
-        seg_attempts = "15" if not force_mode else "20"
-        cmd.extend(
-            [
-                "--stream-segment-timeout",
-                seg_timeout,
-                "--stream-timeout",
-                stream_timeout,
-                # Multiplication factor for segment queue deadline (default 3.0)
-                # 8x = generous tolerance for proxy latency (replaces deprecated
-                # --hls-segment-queue-threshold since Streamlink 8.1.0)
-                "--stream-segmented-queue-deadline",
-                "8",
-                "--stream-segment-attempts",
-                seg_attempts,
-                "--hls-live-edge",
-                "10",
-                "--ringbuffer-size",
-                "512M",
-                "--hls-segment-stream-data",
-                "--stream-segment-threads",
-                "2",
-                "--hls-playlist-reload-time",
-                "segment",
-            ]
+    proxy_label = "HTTP" if http_proxy else "HTTPS"
+    if not proxy_url.startswith(("http://", "https://")):
+        error_msg = (
+            f"{proxy_label} proxy URL must start with 'http://' or 'https://'. "
+            f"Current value: {proxy_url}"
         )
+        logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
+        raise ValueError(error_msg)
 
-    # Add HTTPS proxy if configured
-    if "https" in proxy_settings and proxy_settings["https"].strip():
-        proxy_url = proxy_settings["https"].strip()
-        # Validate that the proxy URL has the correct protocol prefix
-        if not proxy_url.startswith(("http://", "https://")):
-            error_msg = (
-                f"HTTPS proxy URL must start with 'http://' or 'https://'. "
-                f"Current value: {proxy_url}"
-            )
-            logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
-            raise ValueError(error_msg)
+    cmd.append(f"--http-proxy={proxy_url}")
+    logger.debug(f"Using {proxy_label} proxy via --http-proxy: {proxy_url}")
 
-        cmd.append(f"--https-proxy={proxy_url}")
-        logger.debug(f"Using HTTPS proxy: {proxy_url}")
-
-        # Add proxy-specific optimizations for HTTPS connections too
-        cmd.extend(
-            [
-                "--stream-segment-timeout",
-                "60" if not force_mode else "90",
-                "--stream-timeout",
-                "300" if not force_mode else "360",
-                # Multiplication factor for segment queue deadline (default 3.0)
-                # 8x = generous tolerance for proxy latency
-                "--stream-segmented-queue-deadline",
-                "8",
-                "--stream-segment-attempts",
-                "15" if not force_mode else "20",
-                "--hls-live-edge",
-                "10",
-                "--ringbuffer-size",
-                "512M",
-            ]
-        )
+    seg_timeout = "60" if not force_mode else "90"
+    stream_timeout = "300" if not force_mode else "360"
+    cmd.extend(
+        [
+            "--stream-segment-timeout",
+            seg_timeout,
+            "--stream-timeout",
+            stream_timeout,
+            "--stream-segmented-queue-deadline",
+            "8",
+            "--stream-segment-attempts",
+            "5",
+            "--ringbuffer-size",
+            "512M",
+            "--hls-segment-stream-data",
+            "--hls-playlist-reload-time",
+            "segment",
+        ]
+    )
 
     return cmd
 

--- a/app/utils/streamlink_utils.py
+++ b/app/utils/streamlink_utils.py
@@ -15,9 +15,20 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from app.models import GlobalSettings
+from app.utils.security import (
+    sanitize_command_for_logging,
+    sanitize_proxy_url_for_logging,
+)
 
 # Get the logger
 logger = logging.getLogger(__name__)
+
+
+def _select_proxy_url(proxy_settings: Dict[str, str]) -> str:
+    return (
+        proxy_settings.get("http", "").strip()
+        or proxy_settings.get("https", "").strip()
+    )
 
 
 def get_streamlink_version() -> str:
@@ -66,10 +77,9 @@ def check_proxy_connectivity(
     # Test proxy connectivity with a simple Streamlink command
     test_cmd = ["streamlink", "--json", "twitch.tv/test"]
 
-    if "http" in proxy_settings and proxy_settings["http"].strip():
-        test_cmd.append(f"--http-proxy={proxy_settings['http'].strip()}")
-    if "https" in proxy_settings and proxy_settings["https"].strip():
-        test_cmd.append(f"--https-proxy={proxy_settings['https'].strip()}")
+    proxy_url = _select_proxy_url(proxy_settings)
+    if proxy_url:
+        test_cmd.append(f"--http-proxy={proxy_url}")
 
     try:
         # Use a short timeout to fail fast if proxy is down
@@ -100,7 +110,6 @@ def check_proxy_connectivity(
             if pattern in stderr_lower:
                 error_msg = f"Proxy connectivity check failed: {pattern}"
                 logger.error(f"🔴 {error_msg}")
-                logger.debug(f"Proxy test stderr: {result.stderr}")
                 return False, error_msg
 
         # If we got here without errors, proxy is reachable
@@ -111,8 +120,8 @@ def check_proxy_connectivity(
         error_msg = "Proxy connectivity check timed out after 10 seconds"
         logger.error(f"🔴 {error_msg}")
         return False, error_msg
-    except Exception as e:
-        error_msg = f"Proxy connectivity check failed with exception: {e}"
+    except Exception:
+        error_msg = "Proxy connectivity check failed with an unexpected error"
         logger.error(f"🔴 {error_msg}")
         return False, error_msg
 
@@ -142,7 +151,7 @@ def get_stream_info(
                 "error": "Proxy connection failed",
                 "details": proxy_error,
                 "proxy_settings": {
-                    k: v[:50] + "..." if len(v) > 50 else v
+                    k: sanitize_proxy_url_for_logging(v)
                     for k, v in proxy_settings.items()
                     if v
                 },
@@ -152,15 +161,11 @@ def get_stream_info(
 
     # Add proxy settings if provided
     if proxy_settings:
-        if "http" in proxy_settings and proxy_settings["http"].strip():
-            cmd.append(f"--http-proxy={proxy_settings['http'].strip()}")
-        if "https" in proxy_settings and proxy_settings["https"].strip():
-            cmd.append(f"--https-proxy={proxy_settings['https'].strip()}")
+        proxy_url = _select_proxy_url(proxy_settings)
+        if proxy_url:
+            cmd.append(f"--http-proxy={proxy_url}")
 
     try:
-        # SECURITY: Sanitize command for logging to prevent token exposure (CWE-532)
-        from app.utils.security import sanitize_command_for_logging
-
         logger.debug(
             f"Running stream info command: {sanitize_command_for_logging(cmd)}"
         )
@@ -176,9 +181,7 @@ def get_stream_info(
         logger.error(f"🔴 {error_msg} for {streamer_name}")
         return False, {"error": error_msg}
     except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to get stream info for {streamer_name}: {e}")
-        logger.debug(f"Command output: {e.stdout}")
-        logger.debug(f"Command error: {e.stderr}")
+        logger.error(f"Failed to get stream info for {streamer_name}")
 
         # Check if this is a proxy-related error
         stderr_lower = (e.stderr or "").lower()
@@ -188,23 +191,20 @@ def get_stream_info(
         ):
             return False, {
                 "error": "Proxy or network connection failed",
-                "stderr": e.stderr,
                 "details": "Check proxy settings or network connectivity",
             }
 
         return False, {
-            "error": str(e),
-            "stderr": e.stderr if hasattr(e, "stderr") else "No error output",
+            "error": "Streamlink command failed",
         }
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse JSON output from Streamlink: {e}")
         return False, {
             "error": f"JSON parse error: {e}",
-            "raw_output": result.stdout if "result" in locals() else "No output",
         }
-    except Exception as e:
-        logger.error(f"Unexpected error getting stream info: {e}")
-        return False, {"error": str(e)}
+    except Exception:
+        logger.error("Unexpected error getting stream info")
+        return False, {"error": "Unexpected error getting stream info"}
 
 
 def get_streamlink_command(
@@ -324,8 +324,7 @@ def _add_proxy_settings(
         Updated command list with proxy settings
     """
     http_proxy = proxy_settings.get("http", "").strip()
-    https_proxy = proxy_settings.get("https", "").strip()
-    proxy_url = http_proxy or https_proxy
+    proxy_url = _select_proxy_url(proxy_settings)
     if not proxy_url:
         return cmd
 
@@ -333,13 +332,17 @@ def _add_proxy_settings(
     if not proxy_url.startswith(("http://", "https://")):
         error_msg = (
             f"{proxy_label} proxy URL must start with 'http://' or 'https://'. "
-            f"Current value: {proxy_url}"
+            f"Current value: {sanitize_proxy_url_for_logging(proxy_url)}"
         )
         logger.error(f"PROXY_VALIDATION_FAILED: {error_msg}")
         raise ValueError(error_msg)
 
     cmd.append(f"--http-proxy={proxy_url}")
-    logger.debug(f"Using {proxy_label} proxy via --http-proxy: {proxy_url}")
+    logger.debug(
+        "Using %s proxy via --http-proxy: %s",
+        proxy_label,
+        sanitize_proxy_url_for_logging(proxy_url),
+    )
 
     seg_timeout = "60" if not force_mode else "90"
     stream_timeout = "300" if not force_mode else "360"

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -5,8 +5,10 @@ Pure unit tests — no database imports, no pytest-asyncio.
 Tests only logic that doesn't require external services.
 """
 
-from unittest.mock import MagicMock
+import asyncio
+import logging
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
 
 def test_live_stream_session_properties():
@@ -191,3 +193,80 @@ def test_stop_existing_user_streams_replaces_same_streamer():
     assert "old" not in svc.user_sessions["user-1"]
     assert "other-streamer" in svc.sessions
     assert "other-user" in svc.sessions
+
+
+def test_live_proxy_command_preserves_url_and_redacts_diagnostics(monkeypatch, caplog):
+    from app.services import live_streaming_service
+
+    proxy_url = (
+        "https://live-user:live-password@proxy.example:8443/"
+        "signed/path?token=live-secret#live-fragment"
+    )
+
+    class TokenService:
+        def __init__(self, db):
+            pass
+
+        async def get_valid_access_token(self):
+            return None
+
+    async def get_best_proxy():
+        return proxy_url
+
+    monkeypatch.setattr(live_streaming_service, "TwitchTokenService", TokenService)
+    monkeypatch.setattr(
+        live_streaming_service.proxy_health_service,
+        "get_best_proxy",
+        get_best_proxy,
+    )
+
+    service = live_streaming_service.LiveStreamingService()
+    with caplog.at_level(logging.DEBUG, logger="streamvault"):
+        command = asyncio.run(service._build_streamlink_command("streamer", "best"))
+
+    assert f"--http-proxy={proxy_url}" in command
+    assert "proxy.example:8443" in caplog.text
+    for secret in (
+        "live-user",
+        "live-password",
+        "signed",
+        "path",
+        "token",
+        "live-secret",
+        "live-fragment",
+    ):
+        assert secret not in caplog.text
+
+
+def test_live_proxy_lookup_exception_does_not_reach_diagnostics(monkeypatch, caplog):
+    from app.services import live_streaming_service
+
+    proxy_url = (
+        "https://live-user:live-password@proxy.example:8443/"
+        "signed/path?token=live-secret#live-fragment"
+    )
+
+    class TokenService:
+        def __init__(self, db):
+            pass
+
+        async def get_valid_access_token(self):
+            return None
+
+    async def get_best_proxy():
+        raise RuntimeError(proxy_url)
+
+    monkeypatch.setattr(live_streaming_service, "TwitchTokenService", TokenService)
+    monkeypatch.setattr(
+        live_streaming_service.proxy_health_service,
+        "get_best_proxy",
+        get_best_proxy,
+    )
+
+    service = live_streaming_service.LiveStreamingService()
+    with caplog.at_level(logging.WARNING, logger="streamvault"):
+        command = asyncio.run(service._build_streamlink_command("streamer", "best"))
+
+    assert not any(arg.startswith("--http-proxy=") for arg in command)
+    assert "Could not get proxy" in caplog.text
+    assert proxy_url not in caplog.text

--- a/tests/test_proxy_diagnostic_redaction.py
+++ b/tests/test_proxy_diagnostic_redaction.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models import ProxySettings
+from app.routes import proxy as proxy_routes
+from app.utils import proxy_encryption
+
+
+PROXY_URL = (
+    "https://route-user:route-password@proxy.example:8443/"
+    "signed/path?token=route-secret#route-fragment"
+)
+SAFE_PROXY_URL = "proxy.example:8443"
+
+
+class DeterministicEncryption:
+    prefix = "encrypted::"
+
+    def encrypt(self, plaintext):
+        return f"{self.prefix}{plaintext}"
+
+    def decrypt(self, encrypted):
+        if not encrypted:
+            return encrypted
+        assert encrypted.startswith(self.prefix)
+        return encrypted.removeprefix(self.prefix)
+
+
+class FakeQuery:
+    def __init__(self, model, proxy):
+        self.model = model
+        self.proxy = proxy
+
+    def order_by(self, *args):
+        return self
+
+    def filter(self, *args):
+        return self
+
+    def all(self):
+        return [self.proxy] if self.model is ProxySettings else []
+
+    def first(self):
+        return self.proxy if self.model is ProxySettings else None
+
+
+class FakeDatabase:
+    def __init__(self, proxy):
+        self.proxy = proxy
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def query(self, model):
+        return FakeQuery(model, self.proxy)
+
+
+@pytest.fixture
+def proxy_factory(monkeypatch):
+    encryption = DeterministicEncryption()
+    monkeypatch.setattr(proxy_encryption, "get_proxy_encryption", lambda: encryption)
+
+    def make_proxy(url=PROXY_URL):
+        proxy = ProxySettings()
+        proxy.id = 1
+        proxy.proxy_url = url
+        proxy.priority = 0
+        proxy.enabled = True
+        proxy.health_status = "healthy"
+        proxy.last_health_check = None
+        proxy.average_response_time_ms = 25
+        proxy.consecutive_failures = 0
+        proxy.total_recordings = 4
+        proxy.failed_recordings = 1
+        proxy.created_at = None
+        return proxy
+
+    return make_proxy
+
+
+def assert_safe_diagnostic_fields(payload, expected=SAFE_PROXY_URL):
+    assert payload["proxy_url"] == expected
+    assert payload["masked_url"] == expected
+
+
+def test_default_serialization_redacts_every_non_host_component(proxy_factory):
+    proxy = proxy_factory()
+
+    assert proxy._proxy_url_encrypted != PROXY_URL
+    assert proxy.proxy_url == PROXY_URL
+    assert proxy.masked_url == SAFE_PROXY_URL
+    assert_safe_diagnostic_fields(proxy.to_dict())
+    assert proxy.to_dict(mask_password=False)["proxy_url"] == PROXY_URL
+    assert proxy.to_dict(mask_password=False)["masked_url"] == SAFE_PROXY_URL
+
+
+@pytest.mark.parametrize(
+    ("proxy_url", "expected"),
+    [
+        ("", "[INVALID_URL]"),
+        ("not-a-proxy-url/signed?token=secret", "[REDACTED_PROXY_URL]"),
+    ],
+)
+def test_default_serialization_fails_closed(proxy_factory, proxy_url, expected):
+    proxy = proxy_factory(proxy_url)
+
+    assert proxy.masked_url == expected
+    assert_safe_diagnostic_fields(proxy.to_dict(), expected)
+
+
+def test_authenticated_list_and_best_routes_return_safe_diagnostics(
+    monkeypatch, proxy_factory
+):
+    proxy = proxy_factory()
+    monkeypatch.setattr(proxy_routes, "SessionLocal", lambda: FakeDatabase(proxy))
+
+    async def get_best_proxy():
+        return PROXY_URL
+
+    monkeypatch.setattr(
+        proxy_routes.proxy_health_service,
+        "get_best_proxy",
+        get_best_proxy,
+    )
+
+    app = FastAPI()
+    app.include_router(proxy_routes.router)
+    app.dependency_overrides[proxy_routes.get_current_user] = lambda: SimpleNamespace(
+        id=1, is_admin=True
+    )
+
+    with TestClient(app) as client:
+        list_response = client.get("/api/proxy/list")
+        best_response = client.get("/api/proxy/best")
+
+    assert list_response.status_code == 200
+    assert best_response.status_code == 200
+    assert_safe_diagnostic_fields(list_response.json()["proxies"][0])
+    assert_safe_diagnostic_fields(best_response.json()["proxy"])

--- a/tests/test_proxy_health_request_budget.py
+++ b/tests/test_proxy_health_request_budget.py
@@ -1,0 +1,400 @@
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+from types import SimpleNamespace
+
+import pytest
+
+
+class FakeResponse:
+    def __init__(self, status, payload=None, body=""):
+        self.status = status
+        self.payload = payload or {}
+        self.body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self):
+        return self.payload
+
+    async def text(self):
+        return self.body
+
+
+class RaisingRequest:
+    def __init__(self, error):
+        self.error = error
+
+    async def __aenter__(self):
+        raise self.error
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class RecordingSession:
+    def __init__(self, recorder, responses, **kwargs):
+        self.recorder = recorder
+        self.responses = responses
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def post(self, url, **kwargs):
+        self.recorder["token_requests"] += 1
+        return self.responses["token"]
+
+    def get(self, url, **kwargs):
+        self.recorder["reachability_requests"] += 1
+        self.recorder["authorization_values"].append(kwargs["headers"]["Authorization"])
+        self.recorder["redirect_values"].append(kwargs["allow_redirects"])
+        return self.responses["proxies"].pop(0)
+
+
+class FakeQuery:
+    def __init__(self, proxies):
+        self.proxies = proxies
+
+    def filter(self, *args):
+        return self
+
+    def all(self):
+        return self.proxies
+
+
+class FakeDatabase:
+    def __init__(self, proxies):
+        self.proxies = proxies
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def query(self, model):
+        return FakeQuery(self.proxies)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def make_proxy(proxy_id, url):
+    return SimpleNamespace(
+        id=proxy_id,
+        proxy_url=url,
+        masked_url=url,
+        enabled=True,
+        consecutive_failures=0,
+        health_status="unknown",
+        average_response_time_ms=None,
+    )
+
+
+@pytest.fixture
+def proxy_health_module(monkeypatch):
+    constants_module = ModuleType("app.config.constants")
+    constants_module.ASYNC_DELAYS = SimpleNamespace(PROXY_HEALTH_CHECK_ERROR_WAIT=1)
+    settings_module = ModuleType("app.config.settings")
+    settings_module.settings = SimpleNamespace(
+        TWITCH_APP_ID="test-app-id",
+        TWITCH_APP_SECRET="test-app-secret",
+    )
+    database_module = ModuleType("app.database")
+    database_module.SessionLocal = lambda: None
+    models_module = ModuleType("app.models")
+
+    class EnabledField:
+        def is_(self, value):
+            return value
+
+    models_module.ProxySettings = type("ProxySettings", (), {"enabled": EnabledField()})
+    models_module.RecordingSettings = type("RecordingSettings", (), {})
+
+    monkeypatch.setitem(sys.modules, "app.config.constants", constants_module)
+    monkeypatch.setitem(sys.modules, "app.config.settings", settings_module)
+    monkeypatch.setitem(sys.modules, "app.database", database_module)
+    monkeypatch.setitem(sys.modules, "app.models", models_module)
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "app"
+        / "services"
+        / "proxy"
+        / "proxy_health_service.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "proxy_health_service_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_fakes(monkeypatch, proxy_health_module, proxies, responses):
+    recorder = {
+        "token_requests": 0,
+        "reachability_requests": 0,
+        "authorization_values": [],
+        "redirect_values": [],
+    }
+    monkeypatch.setattr(
+        proxy_health_module,
+        "SessionLocal",
+        lambda: FakeDatabase(proxies),
+    )
+    monkeypatch.setattr(
+        proxy_health_module.aiohttp,
+        "ClientSession",
+        lambda **kwargs: RecordingSession(recorder, responses, **kwargs),
+    )
+    monkeypatch.setattr(proxy_health_module.aiohttp, "TCPConnector", lambda: object())
+    return recorder
+
+
+async def prepare_service(monkeypatch, proxy_health_module):
+    service = proxy_health_module.ProxyHealthService()
+
+    async def max_failures():
+        return 3
+
+    async def broadcast(proxy, auto_disabled=False):
+        pass
+
+    monkeypatch.setattr(service, "_get_max_failures", max_failures)
+    monkeypatch.setattr(service, "_broadcast_proxy_status", broadcast)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_cycle_uses_one_token_and_one_request_per_proxy(
+    monkeypatch, proxy_health_module
+):
+    token = "cycle-token-secret"
+    proxies = [
+        make_proxy(1, "http://first.example:8080"),
+        make_proxy(2, "https://second.example:8443"),
+    ]
+    responses = {
+        "token": FakeResponse(200, {"access_token": token}),
+        "proxies": [FakeResponse(200), FakeResponse(302)],
+    }
+    recorder = install_fakes(monkeypatch, proxy_health_module, proxies, responses)
+    service = await prepare_service(monkeypatch, proxy_health_module)
+
+    await service.run_health_checks()
+
+    assert recorder["token_requests"] == 1
+    assert recorder["reachability_requests"] == len(proxies)
+    assert len(recorder["authorization_values"]) == len(proxies)
+    assert all(value == f"Bearer {token}" for value in recorder["authorization_values"])
+    assert recorder["redirect_values"] == [False, False]
+    assert [proxy.health_status for proxy in proxies] == ["healthy", "healthy"]
+
+
+@pytest.mark.asyncio
+async def test_token_failure_stops_before_reachability_request(
+    monkeypatch, caplog, proxy_health_module
+):
+    response_secret = "token-response-body-secret"
+    proxies = [make_proxy(1, "http://proxy.example:8080")]
+    responses = {
+        "token": FakeResponse(503, body=response_secret),
+        "proxies": [FakeResponse(200)],
+    }
+    recorder = install_fakes(monkeypatch, proxy_health_module, proxies, responses)
+    service = await prepare_service(monkeypatch, proxy_health_module)
+
+    with caplog.at_level(logging.ERROR, logger="streamvault"):
+        await service.run_health_checks()
+
+    assert recorder["token_requests"] == 1
+    assert recorder["reachability_requests"] == 0
+    assert response_secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_proxy_failure_is_isolated_without_secret_leaks(
+    monkeypatch, caplog, proxy_health_module
+):
+    token = "isolated-token-secret"
+    exception_secret = "signed.example/path?signature=exception-secret#fragment-secret"
+    proxy_secret = "proxy-user-secret"
+    proxies = [
+        make_proxy(
+            1,
+            f"http://{proxy_secret}:password-secret@first.example:8080/path?key=query-secret#fragment-secret",
+        ),
+        make_proxy(2, "http://second.example:8080"),
+    ]
+    responses = {
+        "token": FakeResponse(200, {"access_token": token}),
+        "proxies": [
+            RaisingRequest(RuntimeError(exception_secret)),
+            FakeResponse(401, body="response-body-secret"),
+        ],
+    }
+    recorder = install_fakes(monkeypatch, proxy_health_module, proxies, responses)
+    service = await prepare_service(monkeypatch, proxy_health_module)
+
+    with caplog.at_level(logging.INFO, logger="streamvault"):
+        await service.run_health_checks()
+
+    assert recorder["token_requests"] == 1
+    assert recorder["reachability_requests"] == len(proxies)
+    assert [proxy.health_status for proxy in proxies] == [
+        "failed",
+        "degraded",
+    ]
+    for secret in (
+        token,
+        exception_secret,
+        proxy_secret,
+        "password-secret",
+        "query-secret",
+        "fragment-secret",
+        "response-body-secret",
+    ):
+        assert secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_proxy_request_cancellation_propagates_and_stops_cycle(
+    monkeypatch, caplog, proxy_health_module
+):
+    cancellation_secret = "proxy-cancel-secret"
+    token = "cancellation-token-secret"
+    proxies = [
+        make_proxy(1, "http://first.example:8080"),
+        make_proxy(2, "http://second.example:8080"),
+        make_proxy(3, "http://third.example:8080"),
+    ]
+    responses = {
+        "token": FakeResponse(200, {"access_token": token}),
+        "proxies": [
+            FakeResponse(200),
+            RaisingRequest(asyncio.CancelledError(cancellation_secret)),
+            FakeResponse(200),
+        ],
+    }
+    recorder = install_fakes(monkeypatch, proxy_health_module, proxies, responses)
+    service = await prepare_service(monkeypatch, proxy_health_module)
+
+    with caplog.at_level(logging.INFO, logger="streamvault"):
+        with pytest.raises(asyncio.CancelledError):
+            await service.run_health_checks()
+
+    assert recorder["token_requests"] == 1
+    assert recorder["reachability_requests"] == 2
+    assert [proxy.health_status for proxy in proxies] == [
+        "healthy",
+        "unknown",
+        "unknown",
+    ]
+    assert cancellation_secret not in caplog.text
+    assert token not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_token_request_cancellation_propagates_without_reachability(
+    monkeypatch, caplog, proxy_health_module
+):
+    cancellation_secret = "token-cancel-secret"
+    proxies = [make_proxy(1, "http://proxy.example:8080")]
+    responses = {
+        "token": RaisingRequest(asyncio.CancelledError(cancellation_secret)),
+        "proxies": [FakeResponse(200)],
+    }
+    recorder = install_fakes(monkeypatch, proxy_health_module, proxies, responses)
+    service = await prepare_service(monkeypatch, proxy_health_module)
+
+    with caplog.at_level(logging.ERROR, logger="streamvault"):
+        with pytest.raises(asyncio.CancelledError):
+            await service.run_health_checks()
+
+    assert recorder["token_requests"] == 1
+    assert recorder["reachability_requests"] == 0
+    assert cancellation_secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_token_exception_returns_generic_diagnostic(
+    monkeypatch, caplog, proxy_health_module
+):
+    exception_secret = "oauth-exception-secret"
+    responses = {
+        "token": RaisingRequest(RuntimeError(exception_secret)),
+        "proxies": [],
+    }
+    recorder = install_fakes(monkeypatch, proxy_health_module, [], responses)
+    service = await prepare_service(monkeypatch, proxy_health_module)
+
+    with caplog.at_level(logging.ERROR, logger="streamvault"):
+        result = await service._get_twitch_access_token()
+
+    assert result is None
+    assert recorder["token_requests"] == 1
+    assert exception_secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_broadcast_diagnostic_and_repr_retain_only_proxy_host_port(
+    monkeypatch, proxy_health_module
+):
+    messages = []
+
+    class WebsocketManager:
+        async def send_notification(self, message):
+            messages.append(message)
+
+    websocket_module = ModuleType("app.services.communication.websocket_manager")
+    websocket_module.websocket_manager = WebsocketManager()
+    monkeypatch.setitem(sys.modules, "app.services", ModuleType("app.services"))
+    monkeypatch.setitem(
+        sys.modules,
+        "app.services.communication",
+        ModuleType("app.services.communication"),
+    )
+    monkeypatch.setitem(
+        sys.modules, "app.services.communication.websocket_manager", websocket_module
+    )
+
+    proxy_url = (
+        "http://broadcast-user:broadcast-password@proxy.example:8080/"
+        "signed/path?token=broadcast-query#broadcast-fragment"
+    )
+    proxy = SimpleNamespace(
+        proxy_url=proxy_url,
+        to_dict=lambda mask_password=True: {
+            "proxy_url": proxy_url,
+            "masked_url": proxy_url,
+        },
+    )
+    service = proxy_health_module.ProxyHealthService()
+
+    await service._broadcast_proxy_status(proxy)
+
+    assert messages[0]["proxy"]["proxy_url"] == "proxy.example:8080"
+    assert messages[0]["proxy"]["masked_url"] == "proxy.example:8080"
+    diagnostic_repr = repr(messages)
+    for secret in (
+        "broadcast-user",
+        "broadcast-password",
+        "signed",
+        "broadcast-query",
+        "broadcast-fragment",
+    ):
+        assert secret not in diagnostic_repr

--- a/tests/test_proxy_health_request_budget.py
+++ b/tests/test_proxy_health_request_budget.py
@@ -236,7 +236,8 @@ async def test_proxy_failure_is_isolated_without_secret_leaks(
     proxies = [
         make_proxy(
             1,
-            f"http://{proxy_secret}:password-secret@first.example:8080/path?key=query-secret#fragment-secret",
+            f"http://{proxy_secret}:password-secret@first.example:8080/"
+            "path?key=query-secret#fragment-secret",
         ),
         make_proxy(2, "http://second.example:8080"),
     ]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -470,17 +470,16 @@ class TestProxyURLSanitization:
 
         assert "user" not in result
         assert "password" not in result
-        assert "[REDACTED]" in result
-        assert "proxy.com:8080" in result
+        assert result == "proxy.com:8080"
 
     def test_proxy_without_credentials_unchanged(self):
-        """Test that proxy URLs without credentials are unchanged"""
+        """Test that proxy URLs without credentials retain only host and port"""
         from app.utils.security import sanitize_proxy_url_for_logging
 
         url = "http://proxy.com:8080"
         result = sanitize_proxy_url_for_logging(url)
 
-        assert result == url
+        assert result == "proxy.com:8080"
         assert "[REDACTED]" not in result
 
     def test_https_proxy_with_credentials_redacted(self):
@@ -492,8 +491,7 @@ class TestProxyURLSanitization:
 
         assert "admin" not in result
         assert "secret123" not in result
-        assert "[REDACTED]" in result
-        assert "secure-proxy.example.com:443" in result
+        assert result == "secure-proxy.example.com:443"
 
     def test_socks_proxy_with_credentials_redacted(self):
         """Test SOCKS proxy credentials are redacted"""
@@ -504,8 +502,7 @@ class TestProxyURLSanitization:
 
         assert "user" not in result
         assert "pass" not in result
-        assert "[REDACTED]" in result
-        assert "socks-proxy.com:1080" in result
+        assert result == "socks-proxy.com:1080"
 
     def test_empty_or_invalid_proxy_url(self):
         """Test that empty or invalid URLs are handled gracefully"""
@@ -522,8 +519,42 @@ class TestProxyURLSanitization:
         url = "not-a-valid-url-format"
         result = sanitize_proxy_url_for_logging(url)
 
-        # Should be safe - either return as-is (no credentials) or redact
-        assert "not-a-valid-url-format" in result or "[REDACTED" in result
+        assert result == "[REDACTED_PROXY_URL]"
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            (
+                "http://user-secret:password-secret@proxy.example:8080/signed/path?token=query-secret#fragment-secret",
+                "proxy.example:8080",
+            ),
+            ("https://proxy.example/private/path?signature=secret", "proxy.example"),
+            (
+                "http://user:password@[broken-host:8080/path?secret=value",
+                "[REDACTED_PROXY_URL]",
+            ),
+            (
+                "user:password@proxy.example:8080/signed?secret=value",
+                "[REDACTED_PROXY_URL]",
+            ),
+        ],
+    )
+    def test_proxy_diagnostics_are_host_port_only_or_redacted(self, url, expected):
+        from app.utils.security import sanitize_proxy_url_for_logging
+
+        result = sanitize_proxy_url_for_logging(url)
+
+        assert result == expected
+        for secret in (
+            "user-secret",
+            "password-secret",
+            "signed",
+            "private",
+            "query-secret",
+            "fragment-secret",
+            "value",
+        ):
+            assert secret not in result
 
 
 class TestCommandSanitization:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -525,7 +525,8 @@ class TestProxyURLSanitization:
         ("url", "expected"),
         [
             (
-                "http://user-secret:password-secret@proxy.example:8080/signed/path?token=query-secret#fragment-secret",
+                "http://user-secret:password-secret@proxy.example:8080/"
+                "signed/path?token=query-secret#fragment-secret",
                 "proxy.example:8080",
             ),
             ("https://proxy.example/private/path?signature=secret", "proxy.example"),

--- a/tests/test_streamlink_command_format.py
+++ b/tests/test_streamlink_command_format.py
@@ -14,12 +14,16 @@ FIX: Now sends:
 """
 
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import logging
 from pathlib import Path
+import subprocess
 from threading import Thread
+from types import SimpleNamespace
 from unittest.mock import patch
 from urllib.parse import urlsplit
 
 import pytest
+from app.utils import streamlink_utils
 from app.utils.streamlink_utils import get_streamlink_command
 
 
@@ -87,6 +91,111 @@ def test_proxy_format():
     # Verify format
     assert http_proxy_arg == "--http-proxy=https://user:pass@proxy.example.com:8443"
     assert not any(arg.startswith("--https-proxy=") for arg in cmd)
+
+
+@pytest.mark.parametrize(
+    ("proxy_settings", "expected_proxy"),
+    [
+        (
+            {
+                "http": "http://preferred.example:8080",
+                "https": "https://fallback.example:8443",
+            },
+            "http://preferred.example:8080",
+        ),
+        (
+            {"https": "https://fallback.example:8443"},
+            "https://fallback.example:8443",
+        ),
+    ],
+)
+def test_proxy_probe_and_stream_info_use_one_http_proxy_argument(
+    monkeypatch, proxy_settings, expected_proxy
+):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(streamlink_utils.subprocess, "run", fake_run)
+
+    assert streamlink_utils.check_proxy_connectivity(proxy_settings) == (True, "")
+    assert streamlink_utils.get_stream_info("test_streamer", proxy_settings) == (
+        True,
+        {},
+    )
+
+    for command in commands:
+        assert [arg for arg in command if arg.startswith("--http-proxy=")] == [
+            f"--http-proxy={expected_proxy}"
+        ]
+        assert not any(arg.startswith("--https-proxy=") for arg in command)
+
+
+def test_proxy_diagnostics_retain_only_host_port(monkeypatch, caplog, tmp_path: Path):
+    proxy_url = (
+        "https://user:password@proxy.example:8443/signed/path?token=secret#fragment"
+    )
+    with caplog.at_level(logging.DEBUG):
+        get_streamlink_command(
+            streamer_name="test_streamer",
+            quality="best",
+            output_path="/tmp/test.ts",
+            proxy_settings={"https": proxy_url},
+            log_path="/tmp/streamlink.log",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            streamlink_utils._add_proxy_settings(
+                [], {"http": proxy_url.replace("https://", "socks5://")}, False
+            )
+
+        with patch("pathlib.Path.exists", return_value=True):
+            from app.services.system.streamlink_config_service import (
+                StreamlinkConfigService,
+            )
+
+        service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+        service.config_dir = tmp_path
+        service.twitch_config_path = tmp_path / "config.twitch"
+        assert service.generate_twitch_config(https_proxy=proxy_url)
+
+    diagnostics = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if "proxy" in record.getMessage().lower()
+    )
+    diagnostics = f"{diagnostics}\n{exc_info.value}"
+    assert "proxy.example:8443" in diagnostics
+    for secret in (
+        "user",
+        "password",
+        "signed",
+        "path",
+        "token",
+        "secret",
+        "fragment",
+    ):
+        assert secret not in diagnostics
+
+
+def test_proxy_failure_details_retain_only_host_port(monkeypatch):
+    proxy_url = (
+        "https://user:password@proxy.example:8443/signed/path?token=secret#fragment"
+    )
+    monkeypatch.setattr(
+        streamlink_utils,
+        "check_proxy_connectivity",
+        lambda settings: (False, "Proxy connectivity check failed"),
+    )
+
+    success, details = streamlink_utils.get_stream_info(
+        "test_streamer", {"https": proxy_url}
+    )
+
+    assert not success
+    assert details["proxy_settings"] == {"https": "proxy.example:8443"}
 
 
 @pytest.mark.parametrize("force_mode", [False, True])
@@ -191,6 +300,89 @@ def test_streamlink_840_segment_attempts_cap_http_requests(monkeypatch):
 
         assert set(requested_hosts) == {"127.0.0.1"}
         assert segment_requests <= 6
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+
+
+def test_streamlink_840_retry_max_caps_missing_stream_resolution_attempts(
+    monkeypatch, tmp_path: Path
+):
+    streamlink = pytest.importorskip("streamlink")
+    streamlink_cli = pytest.importorskip("streamlink_cli.main")
+    plugin_module = pytest.importorskip("streamlink.plugin")
+    assert streamlink.__version__ == "8.4.0"
+
+    with patch("pathlib.Path.exists", return_value=True):
+        from app.services.system.streamlink_config_service import (
+            StreamlinkConfigService,
+        )
+
+    service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+    service.config_dir = tmp_path
+    service.twitch_config_path = tmp_path / "config.twitch"
+
+    assert service.generate_twitch_config()
+
+    config = dict(
+        line.split("=", 1)
+        for line in service.twitch_config_path.read_text().splitlines()
+        if "=" in line
+    )
+    assert config["retry-streams"] == "10"
+    assert config["retry-max"] == "2"
+    resolution_attempts = 0
+
+    class MissingStreamHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            nonlocal resolution_attempts
+            resolution_attempts += 1
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    class MissingStreamPlugin(plugin_module.Plugin):
+        def _get_streams(self):
+            response = self.session.http.get(self.url, timeout=1)
+            response.raise_for_status()
+            return {}
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), MissingStreamHandler)
+    server_thread = Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        session = streamlink.Streamlink()
+        request = session.http.request
+
+        def local_only_request(method, url, *args, **kwargs):
+            if urlsplit(url).hostname != "127.0.0.1":
+                raise RuntimeError(f"Blocked non-loopback request to {url}")
+            return request(method, url, *args, **kwargs)
+
+        monkeypatch.setattr(session.http, "request", local_only_request)
+        monkeypatch.setattr(streamlink_cli, "sleep", lambda _delay: None)
+        monkeypatch.setattr(
+            streamlink_cli,
+            "args",
+            SimpleNamespace(stream_types=None, stream_sorting_excludes=None),
+        )
+        plugin = MissingStreamPlugin(
+            session,
+            f"http://127.0.0.1:{server.server_port}/missing-stream",
+        )
+
+        assert (
+            streamlink_cli.fetch_streams_with_retry(
+                plugin,
+                int(config["retry-streams"]),
+                int(config["retry-max"]),
+            )
+            is None
+        )
+        assert resolution_attempts == 3
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_streamlink_command_format.py
+++ b/tests/test_streamlink_command_format.py
@@ -13,6 +13,12 @@ FIX: Now sends:
   (1 single argument, properly parsed)
 """
 
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from unittest.mock import patch
+from urllib.parse import urlsplit
+
 import pytest
 from app.utils.streamlink_utils import get_streamlink_command
 
@@ -20,7 +26,10 @@ from app.utils.streamlink_utils import get_streamlink_command
 def test_oauth_token_format():
     """Test that OAuth token is passed as single argument with ="""
     cmd = get_streamlink_command(
-        streamer_name="test_streamer", quality="best", output_path="/tmp/test.ts", oauth_token="test_token_123"
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        oauth_token="test_token_123",
     )
 
     # Find the OAuth argument
@@ -43,7 +52,10 @@ def test_oauth_token_format():
 def test_codec_format():
     """Test that codecs are passed as single argument with ="""
     cmd = get_streamlink_command(
-        streamer_name="test_streamer", quality="best", output_path="/tmp/test.ts", supported_codecs="h264,h265,av1"
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        supported_codecs="h264,h265,av1",
     )
 
     # Find the codec argument
@@ -64,24 +76,189 @@ def test_proxy_format():
         streamer_name="test_streamer",
         quality="best",
         output_path="/tmp/test.ts",
-        proxy_settings={
-            "http": "http://user:pass@proxy.example.com:8080",
-            "https": "https://user:pass@proxy.example.com:8443",
-        },
+        proxy_settings={"https": "https://user:pass@proxy.example.com:8443"},
     )
 
-    # Find proxy arguments
     http_proxy_arg = None
-    https_proxy_arg = None
     for arg in cmd:
         if arg.startswith("--http-proxy="):
             http_proxy_arg = arg
-        if arg.startswith("--https-proxy="):
-            https_proxy_arg = arg
 
     # Verify format
-    assert http_proxy_arg == "--http-proxy=http://user:pass@proxy.example.com:8080"
-    assert https_proxy_arg == "--https-proxy=https://user:pass@proxy.example.com:8443"
+    assert http_proxy_arg == "--http-proxy=https://user:pass@proxy.example.com:8443"
+    assert not any(arg.startswith("--https-proxy=") for arg in cmd)
+
+
+@pytest.mark.parametrize("force_mode", [False, True])
+def test_proxy_request_profile_uses_one_bounded_block(force_mode: bool):
+    cmd = get_streamlink_command(
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        proxy_settings={
+            "http": "http://proxy.example.com:8080",
+            "https": "https://proxy.example.com:8443",
+        },
+        force_mode=force_mode,
+        log_path="/tmp/streamlink.log",
+    )
+
+    assert [arg for arg in cmd if arg.startswith("--http-proxy=")] == [
+        "--http-proxy=http://proxy.example.com:8080"
+    ]
+    assert not any(arg.startswith("--https-proxy=") for arg in cmd)
+    assert cmd.count("--stream-segment-attempts") == 1
+    attempts_index = cmd.index("--stream-segment-attempts")
+    assert cmd[attempts_index + 1] == "5"
+    assert "--hls-live-edge" not in cmd
+    assert "--stream-segment-threads" not in cmd
+
+
+def test_streamlink_840_segment_attempts_cap_http_requests(monkeypatch):
+    streamlink = pytest.importorskip("streamlink")
+    hls = pytest.importorskip("streamlink.stream.hls")
+    streamlink_http = pytest.importorskip("streamlink.session.http")
+    assert streamlink.__version__ == "8.4.0"
+
+    cmd = get_streamlink_command(
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        proxy_settings={"http": "http://proxy.example.com:8080"},
+        log_path="/tmp/streamlink.log",
+    )
+    attempts_index = cmd.index("--stream-segment-attempts")
+    segment_attempts = int(cmd[attempts_index + 1])
+    segment_requests = 0
+
+    class HLSHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            nonlocal segment_requests
+            if self.path == "/playlist.m3u8":
+                body = (
+                    b"#EXTM3U\n"
+                    b"#EXT-X-TARGETDURATION:1\n"
+                    b"#EXT-X-MEDIA-SEQUENCE:0\n"
+                    b"#EXTINF:1,\n"
+                    b"segment.ts\n"
+                    b"#EXT-X-ENDLIST\n"
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/vnd.apple.mpegurl")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
+            if self.path == "/segment.ts":
+                segment_requests += 1
+                self.send_response(503)
+                self.end_headers()
+                return
+
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), HLSHandler)
+    server_thread = Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        session = streamlink.Streamlink()
+        session.set_option("stream-segment-attempts", segment_attempts)
+        session.set_option("stream-segment-threads", 1)
+        requested_hosts = []
+        request = session.http.request
+
+        def local_only_request(method, url, *args, **kwargs):
+            host = urlsplit(url).hostname
+            requested_hosts.append(host)
+            if host != "127.0.0.1":
+                raise RuntimeError(f"Blocked non-loopback request to {host}")
+            return request(method, url, *args, **kwargs)
+
+        monkeypatch.setattr(session.http, "request", local_only_request)
+        monkeypatch.setattr(streamlink_http.time, "sleep", lambda _delay: None)
+
+        playlist_url = f"http://127.0.0.1:{server.server_port}/playlist.m3u8"
+        reader = hls.HLSStream(session, playlist_url).open()
+        try:
+            assert reader.read(8192) == b""
+        finally:
+            reader.close()
+
+        assert set(requested_hosts) == {"127.0.0.1"}
+        assert segment_requests <= 6
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join()
+
+
+def test_generated_config_uses_bounded_central_request_profile(tmp_path: Path):
+    with patch("pathlib.Path.exists", return_value=True):
+        from app.services.system.streamlink_config_service import (
+            StreamlinkConfigService,
+        )
+
+    service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+    service.config_dir = tmp_path
+    service.twitch_config_path = tmp_path / "config.twitch"
+
+    assert service.generate_twitch_config()
+
+    config_lines = set(service.twitch_config_path.read_text().splitlines())
+    assert {
+        "hls-live-edge=3",
+        "stream-segment-threads=5",
+        "retry-streams=10",
+        "retry-max=2",
+    } <= config_lines
+
+
+@pytest.mark.parametrize(
+    ("http_proxy", "https_proxy", "expected_proxy"),
+    [
+        (
+            "http://preferred.example.com:8080",
+            "https://fallback.example.com:8443",
+            "http-proxy=http://preferred.example.com:8080",
+        ),
+        (
+            None,
+            "https://fallback.example.com:8443",
+            "http-proxy=https://fallback.example.com:8443",
+        ),
+    ],
+)
+def test_generated_config_selects_one_http_proxy(
+    tmp_path: Path,
+    http_proxy: str | None,
+    https_proxy: str,
+    expected_proxy: str,
+):
+    with patch("pathlib.Path.exists", return_value=True):
+        from app.services.system.streamlink_config_service import (
+            StreamlinkConfigService,
+        )
+
+    service = StreamlinkConfigService.__new__(StreamlinkConfigService)
+    service.config_dir = tmp_path
+    service.twitch_config_path = tmp_path / "config.twitch"
+
+    assert service.generate_twitch_config(
+        http_proxy=http_proxy,
+        https_proxy=https_proxy,
+    )
+
+    proxy_lines = [
+        line
+        for line in service.twitch_config_path.read_text().splitlines()
+        if line.startswith(("http-proxy=", "https-proxy="))
+    ]
+    assert proxy_lines == [expected_proxy]
 
 
 def test_no_space_in_critical_arguments():
@@ -96,7 +273,12 @@ def test_no_space_in_critical_arguments():
     )
 
     # Critical arguments that should use = format
-    critical_args = ["--twitch-api-header", "--twitch-supported-codecs", "--http-proxy", "--https-proxy"]
+    critical_args = [
+        "--twitch-api-header",
+        "--twitch-supported-codecs",
+        "--http-proxy",
+        "--https-proxy",
+    ]
 
     # Check each critical argument
     for arg_name in critical_args:
@@ -113,14 +295,19 @@ def test_no_space_in_critical_arguments():
                 next_arg = cmd[idx + 1]
                 # Next argument should be another option or the URL
                 assert (
-                    next_arg.startswith("--") or "twitch.tv" in next_arg or next_arg in ["best", "/tmp/test.ts"]
+                    next_arg.startswith("--")
+                    or "twitch.tv" in next_arg
+                    or next_arg in ["best", "/tmp/test.ts"]
                 ), f"{arg_name} appears to have value as separate argument: {next_arg}"
 
 
 def test_command_structure():
     """Test overall command structure"""
     cmd = get_streamlink_command(
-        streamer_name="test_streamer", quality="best", output_path="/tmp/test.ts", oauth_token="test_token_123"
+        streamer_name="test_streamer",
+        quality="best",
+        output_path="/tmp/test.ts",
+        oauth_token="test_token_123",
     )
 
     # Basic structure checks


### PR DESCRIPTION
## Summary
- Binds Streamlink retry, segment and live-edge settings to the Issue #782 request budgets.
- Reuses one in-memory Twitch app token per proxy health-check cycle and limits each proxy to one reachability request.
- Preserves cancellation propagation, blocks redirects, and redacts proxy and token diagnostics to host and port only.

## Local verification
- Isolated uv environment with requirements.txt, Streamlink 8.4.0, pytest, pytest-asyncio, pytest-cov, httpx and Ruff.
- `pytest tests/test_streamlink_command_format.py -q`: 11 passed.
- `pytest tests/test_proxy_health_request_budget.py tests/test_security.py -q`: 57 passed.
- `pytest tests/ -q`: 182 passed, 38 warnings.
- Ruff check, required format checks, migrations initialization, frontend lint, token lint, type check and production build passed.
- `tests/test_security.py` retains six pre-existing Ruff-format hunks, with six hunks also present at the frozen base.
- `git diff --check` and Unicode dash scan passed.
- Docker integration validation was not run because the local daemon is unreachable at `unix:///var/run/docker.sock`.

Closes #782

@Serph91P Please review the immutable candidate at `e12223eea835649a8f33755ab4573a1e9250c811`.