### PR TITLE
fix(deps): remediate transitive npm audit advisories

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -4541,9 +4541,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5580,9 +5580,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -7213,9 +7213,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -50,10 +50,11 @@
       "vite": "$vite"
     },
     "@babel/core": "7.29.7",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "immutable": "5.1.9",
     "shell-quote": "1.10.0",
-    "brace-expansion@5": "5.0.8",
+    "brace-expansion@5": "5.0.9",
+    "nanoid": "3.3.18",
     "jake": "12.10.1"
   }
 }


### PR DESCRIPTION
## Summary

- update the existing `fast-uri` override to 3.1.5
- update the existing `brace-expansion` major-5 override to 5.0.9
- add a `nanoid` 3.3.18 override
- update only the matching lockfile records and verified registry integrity values

## Security verification

- RED: `npm audit --package-lock-only --audit-level=high` reported five High findings on the frozen base
- GREEN: the same audit reports zero vulnerabilities
- `npm ci --prefer-offline` resolves the three fixed versions
- `npm ls fast-uri brace-expansion nanoid minimatch ajv --all` confirms the intended override paths

## Local verification

- `npm run lint`
- `npm run lint:tokens`
- `npm run type-check`
- `npm run build`
- `hermes verify --json --skip-start`: bootstrap and test phases passed, 191 tests passed and 2 skipped
- manual `uvicorn app.main:app` boot with isolated writable runtime paths plus `GET /api/health/live`: `200`, status `alive`
- `git diff --check`

## Local environment limitation

The local Docker engine has no working Buildx component. The Dockerfile requires BuildKit for `RUN --mount`, so the no-push image build cannot run on this host. The PR's Buildx workflow remains the required container gate before merge.

Closes #797
