### PR TITLE
fix(ci): harden release governance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,8 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment:
+      name: ${{ (github.ref == 'refs/heads/main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev'))) && 'stable-release' || 'development-release' }}
     permissions:
       contents: read
       packages: write
@@ -222,6 +224,52 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: ${{ needs.prepare.outputs.docker_tags }}
+          labels: ${{ needs.prepare.outputs.docker_labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            COMMIT_SHA=${{ github.sha }}
+            BRANCH=${{ github.ref_name }}
+
+      - name: Select local image for security scan
+        id: image_name
+        env:
+          IMAGE_TAGS: ${{ needs.prepare.outputs.docker_tags }}
+        run: |
+          SCAN_IMAGE=$(printf '%s\n' "$IMAGE_TAGS" | sed -n '/./{p;q;}')
+          test -n "$SCAN_IMAGE"
+          docker image inspect "$SCAN_IMAGE" >/dev/null
+          echo "full_ref=$SCAN_IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db:2'
+          TRIVY_JAVA_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-java-db:1'
+        with:
+          image-ref: ${{ steps.image_name.outputs.full_ref }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v4.37.7
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-container'
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -235,56 +283,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ needs.prepare.outputs.docker_tags }}
-          labels: ${{ needs.prepare.outputs.docker_labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            COMMIT_SHA=${{ github.sha }}
-            BRANCH=${{ github.ref_name }}
-
-      # Security scanning
-      - name: Set lowercase image name
-        id: image_name
+      - name: Push verified Docker images
+        env:
+          IMAGE_TAGS: ${{ needs.prepare.outputs.docker_tags }}
         run: |
-          IMAGE_TAG="${{ github.ref == 'refs/heads/main' && 'latest' || 'dev' }}"
-          echo "tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "full_ref=${{ env.REGISTRY }}/${IMAGE_NAME,,}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-        env:
-          IMAGE_NAME: ${{ github.repository_owner }}/streamvault
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-db:2'
-          TRIVY_JAVA_DB_REPOSITORY: 'ghcr.io/aquasecurity/trivy-java-db:1'
-        with:
-          image-ref: ${{ steps.image_name.outputs.full_ref }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
-        continue-on-error: true
-
-      - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4.37.7
-        if: always() && hashFiles('trivy-results.sarif') != ''
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: 'trivy-container'
+          while IFS= read -r image; do
+            if [ -n "$image" ]; then
+              docker push "$image"
+            fi
+          done <<< "$IMAGE_TAGS"
 
   create-release:
     needs: [prepare, build-and-push]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment:
+      name: ${{ (github.ref == 'refs/heads/main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev'))) && 'stable-release' || 'development-release' }}
     permissions:
       contents: write
     # Create releases for tags, develop and main branch pushes
@@ -378,7 +392,7 @@ jobs:
           
           ## 🐳 Docker Images
           
-          This release is available as multi-architecture Docker images (amd64, arm64):
+          This release is available as a linux/amd64 Docker image:
           
           ### Pull the image:
           \`\`\`bash
@@ -411,7 +425,7 @@ jobs:
           | GitHub Registry | \`ghcr.io/${REPO_OWNER}/streamvault\` |
           | DockerHub | \`frequency2098/streamvault\` |
           | Version | \`${VERSION}\` |
-          | Architectures | linux/amd64, linux/arm64 |
+          | Architectures | linux/amd64 |
           
           ## Documentation
           

--- a/tests/test_release_governance_contract.py
+++ b/tests/test_release_governance_contract.py
@@ -1,0 +1,117 @@
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+SELECTOR_PATTERN = re.compile(
+    r"^\$\{\{ \(github\.ref == '([^']+)' \|\| "
+    r"\(startsWith\(github\.ref, '([^']+)'\) && "
+    r"!contains\(github\.ref, '([^']+)'\)\)\) && "
+    r"'([^']+)' \|\| '([^']+)' \}\}$"
+)
+
+
+def _load_workflow() -> tuple[str, dict]:
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    document = yaml.safe_load(text)
+    return text, document["jobs"]
+
+
+def _step(job: dict, name: str) -> dict:
+    matches = [step for step in job["steps"] if step.get("name") == name]
+    assert len(matches) == 1, f"expected exactly one step named {name!r}"
+    return matches[0]
+
+
+def _selected_environment(selector: str, ref: str) -> str:
+    match = SELECTOR_PATTERN.fullmatch(selector)
+    assert match, "release environment selector changed unexpectedly"
+    main_ref, tag_prefix, development_marker, stable_name, development_name = (
+        match.groups()
+    )
+    is_stable = ref == main_ref or (
+        ref.startswith(tag_prefix) and development_marker not in ref
+    )
+    return stable_name if is_stable else development_name
+
+
+@pytest.mark.parametrize("job_id", ["build-and-push", "create-release"])
+@pytest.mark.parametrize(
+    ("ref", "expected"),
+    [
+        ("refs/heads/main", "stable-release"),
+        ("refs/heads/develop", "development-release"),
+        ("refs/tags/v2.13.40", "stable-release"),
+        ("refs/tags/v2.13.40-dev", "development-release"),
+    ],
+)
+def test_release_environment_routing(job_id: str, ref: str, expected: str):
+    _, jobs = _load_workflow()
+    selector = jobs[job_id]["environment"]["name"]
+    assert _selected_environment(selector, ref) == expected
+
+
+def test_image_is_scanned_before_credentials_and_publication():
+    _, jobs = _load_workflow()
+    build_job = jobs["build-and-push"]
+    step_names = [step.get("name") for step in build_job["steps"]]
+
+    required_order = [
+        "Build Docker image",
+        "Select local image for security scan",
+        "Run Trivy vulnerability scanner",
+        "Upload Trivy scan results",
+        "Log in to GitHub Container Registry",
+        "Log in to DockerHub",
+        "Push verified Docker images",
+    ]
+    assert [step_names.index(name) for name in required_order] == sorted(
+        step_names.index(name) for name in required_order
+    )
+
+    assert "continue-on-error" not in build_job
+    for step in build_job["steps"]:
+        assert "continue-on-error" not in step
+
+    image_build = _step(build_job, "Build Docker image")
+    assert image_build["with"]["platforms"] == "linux/amd64"
+    assert image_build["with"]["load"] is True
+    assert image_build["with"]["push"] is False
+    assert image_build["with"]["tags"] == "${{ needs.prepare.outputs.docker_tags }}"
+
+    selector = _step(build_job, "Select local image for security scan")
+    assert selector["env"]["IMAGE_TAGS"] == "${{ needs.prepare.outputs.docker_tags }}"
+    assert 'docker image inspect "$SCAN_IMAGE"' in selector["run"]
+    assert 'echo "full_ref=$SCAN_IMAGE" >> "$GITHUB_OUTPUT"' in selector["run"]
+
+    trivy = _step(build_job, "Run Trivy vulnerability scanner")
+    assert re.fullmatch(r"aquasecurity/trivy-action@[0-9a-f]{40}", trivy["uses"])
+    assert trivy["with"]["image-ref"] == "${{ steps.image_name.outputs.full_ref }}"
+    assert trivy["with"]["format"] == "sarif"
+    assert trivy["with"]["output"] == "trivy-results.sarif"
+    assert trivy["with"]["severity"] == "CRITICAL,HIGH"
+    assert trivy["with"]["exit-code"] == "1"
+
+    upload = _step(build_job, "Upload Trivy scan results")
+    assert upload["if"] == "always() && hashFiles('trivy-results.sarif') != ''"
+    assert upload["with"]["sarif_file"] == "trivy-results.sarif"
+
+    push = _step(build_job, "Push verified Docker images")
+    assert push["env"]["IMAGE_TAGS"] == "${{ needs.prepare.outputs.docker_tags }}"
+    assert 'docker push "$image"' in push["run"]
+    assert jobs["create-release"]["needs"] == ["prepare", "build-and-push"]
+
+
+def test_release_notes_match_the_published_platform():
+    workflow, jobs = _load_workflow()
+    release_job = jobs["create-release"]
+    release_job_text = yaml.safe_dump(release_job)
+
+    assert "multi-architecture" not in workflow
+    assert "linux/amd64, linux/arm64" not in workflow
+    assert "linux/amd64 Docker image" in release_job_text
+    assert "| Architectures | linux/amd64 |" in release_job_text


### PR DESCRIPTION
## Summary

- bind Docker publication and GitHub release jobs to stable or development environments based on the ref
- build and load the exact image locally, scan it before registry credentials and public push, then publish the same metadata tag set
- pin Trivy to the verified v0.36.0 commit and make HIGH and CRITICAL findings fail the release job while still uploading SARIF
- correct release notes to the actually published `linux/amd64` architecture
- add a mutation-resistant executable release-governance contract test

## Immutable candidate

- head: `a00681005f5d7a8641fa5f0aefb59d9e6fd62c92`
- base `develop`: `c21af7664d5bb3c5c25dc84b7cca0e294f9459a5`
- direct parent: `c21af7664d5bb3c5c25dc84b7cca0e294f9459a5`
- `release.yml` SHA-256: `73880328031b85dd80d708ea49b304da3acfd11ba1845f3495ee720cf4182547`
- governance test SHA-256: `0647333dc6ac31993a2247a4480f2c4b900dbc9a8fb0f6ac31d64324b21b6063`

## Exact PR CI

All 17 check contexts are terminal and successful on the immutable head:

- Tests: run `32348778621`
- Security Scanning: run `32348778756`
- Docker Build Test: run `32348778709`

## Live governance

- `stable-release` environment requires a separate deployment reviewer, prevents self-review, disables admin bypass, and permits only `main` plus stable tags
- `development-release` permits `develop` plus development tags without blocking normal development publication
- active `main` ruleset has no bypass actor, requires merge PRs, thread resolution, strict native CI contexts, `Hermes Independent Release Review`, and `Hermes Release Security Preflight`

## Verification

- focused RED confirmed against the prior workflow
- focused GREEN: 10 governance-contract tests passed
- seven targeted fail-open, routing, mutable-action and stale-target mutations were rejected
- full backend: 201 passed, 2 skipped
- full frontend install, audit, lint, token lint, type-check and production build passed
- migrations, Ruff, format, YAML parse, `git diff --check` and actionlint 1.7.12 passed
- Hermes Verify passed bootstrap, full test, real application boot, HTTP readiness and clean teardown
- independent technical and security remediation reviews approved the immutable file snapshot with no findings

Closes #802
