### PR TITLE
fix(container): harden runtime image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -175,6 +175,12 @@ RUN apk add --no-cache \
 COPY --from=python-deps /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=python-deps /usr/local/bin /usr/local/bin
 
+# pip is only needed while building dependencies. Removing it from the runtime
+# also removes pip's embedded vendor SBOM, which lists build-time packages that
+# are not installed in the final image and must not drive release scan results.
+RUN python -m pip uninstall --yes pip && \
+    chmod -R a+rX /bin /lib /usr/bin /usr/lib /usr/sbin /usr/share /usr/local/bin /usr/local/lib/python3.14/site-packages
+
 # Copy application from final stage
 COPY --from=final --chown=appuser:appuser /app /app
 

--- a/tests/test_container_runtime_security_contract.py
+++ b/tests/test_container_runtime_security_contract.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = ROOT / "docker" / "Dockerfile"
+
+
+def _instructions(dockerfile: str) -> list[tuple[str, str]]:
+    instructions: list[tuple[str, str]] = []
+    pending = ""
+
+    for raw_line in dockerfile.splitlines():
+        line = raw_line.strip()
+        if not pending and (not line or line.startswith("#")):
+            continue
+
+        pending = f"{pending} {line}".strip()
+        if pending.endswith("\\"):
+            pending = pending[:-1].rstrip()
+            continue
+
+        keyword, separator, value = pending.partition(" ")
+        assert separator, f"Invalid Dockerfile instruction: {pending}"
+        instructions.append((keyword.upper(), " ".join(value.split())))
+        pending = ""
+
+    assert not pending, "Unterminated Dockerfile continuation"
+    return instructions
+
+
+def _runtime_instructions(dockerfile: str) -> list[tuple[str, str]]:
+    runtime: list[tuple[str, str]] = []
+    in_runtime = False
+
+    for keyword, value in _instructions(dockerfile):
+        if keyword == "FROM":
+            if in_runtime:
+                break
+            in_runtime = value.lower().endswith(" as runtime")
+            continue
+        if in_runtime:
+            runtime.append((keyword, value))
+
+    assert in_runtime, "Runtime stage not found"
+    return runtime
+
+
+def _validate_runtime_contract(dockerfile: str) -> None:
+    runtime = _runtime_instructions(dockerfile)
+
+    copy_packages = (
+        "--from=python-deps /usr/local/lib/python3.14/site-packages "
+        "/usr/local/lib/python3.14/site-packages"
+    )
+    remove_pip = "python -m pip uninstall --yes pip"
+    normalize_permissions = (
+        "chmod -R a+rX /bin /lib /usr/bin /usr/lib /usr/sbin /usr/share "
+        "/usr/local/bin /usr/local/lib/python3.14/site-packages"
+    )
+
+    copy_index = runtime.index(("COPY", copy_packages))
+    cleanup_indices = [
+        index
+        for index, (keyword, value) in enumerate(runtime)
+        if keyword == "RUN" and remove_pip in value and normalize_permissions in value
+    ]
+    assert len(cleanup_indices) == 1
+    cleanup_index = cleanup_indices[0]
+
+    user_instructions = [
+        (index, value)
+        for index, (keyword, value) in enumerate(runtime)
+        if keyword == "USER"
+    ]
+    assert user_instructions
+    final_user_index, final_user = user_instructions[-1]
+    assert final_user == "appuser"
+
+    assert copy_index < cleanup_index < final_user_index
+    assert all("setuptools==" not in value for _, value in runtime)
+    assert all("msgpack==" not in value for _, value in runtime)
+
+
+def test_runtime_image_removes_pip_and_normalizes_public_runtime_paths():
+    _validate_runtime_contract(DOCKERFILE.read_text(encoding="utf-8"))
+
+
+def test_contract_rejects_commented_out_runtime_cleanup():
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    active = (
+        "RUN python -m pip uninstall --yes pip && \\\n"
+        "    chmod -R a+rX /bin /lib /usr/bin /usr/lib /usr/sbin /usr/share "
+        "/usr/local/bin /usr/local/lib/python3.14/site-packages"
+    )
+    commented = "\n".join(f"# {line}" for line in active.splitlines())
+    assert active in dockerfile
+
+    with pytest.raises(AssertionError):
+        _validate_runtime_contract(dockerfile.replace(active, commented, 1))
+
+
+def test_contract_rejects_later_root_user_override():
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    marker = "USER appuser\nWORKDIR /app"
+    assert marker in dockerfile
+
+    with pytest.raises(AssertionError):
+        _validate_runtime_contract(
+            dockerfile.replace(marker, "USER appuser\nUSER root\nWORKDIR /app", 1)
+        )

--- a/tests/test_container_runtime_security_contract.py
+++ b/tests/test_container_runtime_security_contract.py
@@ -31,20 +31,24 @@ def _instructions(dockerfile: str) -> list[tuple[str, str]]:
 
 
 def _runtime_instructions(dockerfile: str) -> list[tuple[str, str]]:
-    runtime: list[tuple[str, str]] = []
-    in_runtime = False
+    stages: list[tuple[str, list[tuple[str, str]]]] = []
 
     for keyword, value in _instructions(dockerfile):
         if keyword == "FROM":
-            if in_runtime:
-                break
-            in_runtime = value.lower().endswith(" as runtime")
+            stages.append((value, []))
             continue
-        if in_runtime:
-            runtime.append((keyword, value))
+        assert stages, "Instruction before first FROM"
+        stages[-1][1].append((keyword, value))
 
-    assert in_runtime, "Runtime stage not found"
-    return runtime
+    runtime_indices = [
+        index
+        for index, (from_value, _) in enumerate(stages)
+        if from_value.lower().endswith(" as runtime")
+    ]
+    assert len(runtime_indices) == 1, "Expected exactly one runtime stage"
+    runtime_index = runtime_indices[0]
+    assert runtime_index == len(stages) - 1, "Runtime must be the final stage"
+    return stages[runtime_index][1]
 
 
 def _validate_runtime_contract(dockerfile: str) -> None:
@@ -110,3 +114,11 @@ def test_contract_rejects_later_root_user_override():
         _validate_runtime_contract(
             dockerfile.replace(marker, "USER appuser\nUSER root\nWORKDIR /app", 1)
         )
+
+
+def test_contract_rejects_replacement_stage_after_runtime():
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    replacement_stage = "\nFROM python-deps AS runtime-reintroduced-pip\nUSER root\n"
+
+    with pytest.raises(AssertionError):
+        _validate_runtime_contract(dockerfile + replacement_stage)


### PR DESCRIPTION
## Summary

- remove pip and its embedded vendor SBOM from the final runtime image while retaining pip in build stages
- normalize read/execute permissions only on public runtime binary and library paths before switching to `appuser`
- add an executable Dockerfile contract that rejects disabled cleanup and later root-user overrides

## Immutable candidate

- head: `4080c7be093b92c5e14b5b10deb2e1d36c9a1d73`
- base `develop` / merge-base: `1f03aae376eb2f7753042549fbbddb2ccc3ed547`
- direct parent: `e4ef3c11b1ab6f3021acd8bededb4a6946ef096b`
- `docker/Dockerfile` SHA-256: `418397d03e37ae029993012b19598fd56acce0fb8b934ab9ee6ad97a88d86f98`
- `tests/test_container_runtime_security_contract.py` SHA-256: `0a19f69f17dda9e3d9dd5b79ad09b91884f8ef5fdaa8545f869da767f2d9ea5a`

## Exact PR CI runs

- Tests: `32353545737`
- Security Scanning: `32353545748`
- Docker Build Test: `32353545829`

## Root cause

The fail-closed release scan reported stale `setuptools 70.3.0` and `msgpack 1.1.2` entries from pip's embedded `pip/_vendor/bom.cdx.json`; neither distribution was installed in the final runtime image. Reproduction matched upstream Trivy discussion #11031. The same image inspection found existing restrictive file modes that blocked non-root Uvicorn imports and the curl-based Docker healthcheck.

No Trivy ignore, suppression, severity downgrade, package pin, application behavior, API, or schema change is included.

## Verification

- full backend: 204 passed, 2 skipped
- Ruff check and format check
- frontend npm audit, ESLint, design-token lint, type-check and production build
- exact local linux/amd64 Buildx image build
- final image has no pip, setuptools, msgpack or pip vendor SBOM
- Trivy 0.70 HIGH/CRITICAL scan: 0 findings
- default entrypoint runs as `appuser`; `/api/health/live` returns alive; Docker health is healthy
- Hermes Verify: bootstrap, 204 tests, HTTP 200 readiness and clean shutdown
- independent technical review: APPROVED
- independent security review after bounded test remediation: APPROVED

Closes #804
