### PR TITLE
fix(recording): prevent orphaned rotation processes

### DIFF
--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -620,7 +620,8 @@ class ProcessManager:
                     rotated = await self._rotate_segment(stream, segment_info, quality)
                     if not rotated:
                         logger.error(
-                            f"Segment rotation failed for stream {stream.id}; current process ownership retained"
+                            f"Segment rotation failed for stream {stream.id}; "
+                            "current process ownership retained"
                         )
 
         except asyncio.CancelledError:
@@ -704,7 +705,8 @@ class ProcessManager:
 
             if captured_process.returncode is None:
                 logger.error(
-                    f"Segment rotation could not confirm exit for stream {stream.id}; retaining current ownership"
+                    f"Segment rotation could not confirm exit for stream {stream.id}; "
+                    "retaining current ownership"
                 )
                 return False
 
@@ -738,7 +740,8 @@ class ProcessManager:
                 return False
 
             logger.info(
-                f"Successfully rotated to segment {segment_info['segment_count']} for stream {stream.id}"
+                f"Successfully rotated to segment {segment_info['segment_count']} "
+                f"for stream {stream.id}"
             )
             return True
 

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -93,6 +93,8 @@ class ProcessManager:
         self.active_processes = {}
         self.long_stream_processes = {}  # Track processes that need segmentation
         self.lock = asyncio.Lock()
+        self.rotation_locks = {}
+        self.ASYNC_DELAYS = ASYNC_DELAYS
         self.config_manager = config_manager
         self.post_processing_callback = post_processing_callback  # Injected dependency
 
@@ -610,7 +612,11 @@ class ProcessManager:
 
                 if should_rotate:
                     logger.info(f"Rotating segment for stream {stream.id}")
-                    await self._rotate_segment(stream, segment_info, quality)
+                    rotated = await self._rotate_segment(stream, segment_info, quality)
+                    if not rotated:
+                        logger.error(
+                            f"Segment rotation failed for stream {stream.id}; current process ownership retained"
+                        )
 
         except asyncio.CancelledError:
             logger.info(f"Long stream monitoring cancelled for stream {stream.id}")
@@ -645,94 +651,91 @@ class ProcessManager:
             logger.error(f"Error checking segment rotation: {e}", exc_info=True)
             return False
 
-    async def _rotate_segment(self, stream: Stream, segment_info: Dict, quality: str):
+    async def _rotate_segment(
+        self, stream: Stream, segment_info: Dict, quality: str
+    ) -> bool:
         """Rotate to a new segment file"""
-        try:
-            process_id = f"stream_{stream.id}"
+        process_id = f"stream_{stream.id}"
+        rotation_locks = getattr(self, "rotation_locks", None)
+        if rotation_locks is None:
+            rotation_locks = self.rotation_locks = {}
+        rotation_lock = rotation_locks.setdefault(process_id, asyncio.Lock())
+        captured_process = self.active_processes.get(process_id)
 
-            # Stop current process gracefully
-            # CRITICAL: Entire process cleanup must be wrapped in try-catch
-            # because uvloop can throw ProcessLookupError at ANY point when checking dead processes
-            if process_id in self.active_processes:
-                current_process = self.active_processes[process_id]
+        if captured_process is None:
+            return False
 
-                try:
-                    # Try to poll the process to update returncode
-                    # uvloop may throw ProcessLookupError here if process is a zombie
-                    current_process.poll()
+        async with rotation_lock:
+            if self.active_processes.get(process_id) is not captured_process:
+                return False
 
-                    # Check if process is still alive before trying to terminate
-                    if current_process.returncode is None:
-                        # Process appears to be running, try graceful termination
-                        current_process.terminate()
-                        logger.debug(f"Sent SIGTERM to stream {stream.id} process")
-
-                        # Wait a bit for graceful termination
-                        await asyncio.sleep(ASYNC_DELAYS.RECORDING_ERROR_RECOVERY)
-
-                        # Poll again to check termination status
-                        current_process.poll()
-
-                        # Check again and force kill if still running
-                        if current_process.returncode is None:
-                            current_process.kill()
-                            logger.debug(f"Sent SIGKILL to stream {stream.id} process")
-                    else:
-                        logger.info(
-                            f"Process for stream {stream.id} already terminated (returncode: {current_process.returncode})"
-                        )
-
-                except ProcessLookupError:
-                    # Process is a zombie or was cleaned up externally
-                    # This is EXPECTED for long-running streams where streamlink crashes/OOM
-                    logger.info(
-                        f"🔄 ROTATION: Process for stream {stream.id} already terminated externally, continuing with rotation"
-                    )
-
-                except Exception as proc_error:
-                    # Log but continue - we still want to start the new segment
-                    logger.warning(
-                        f"🔄 ROTATION: Error stopping old process for stream {stream.id}: {proc_error}, continuing anyway"
-                    )
-
-                finally:
-                    # ALWAYS remove the old process from tracking, even if cleanup failed
-                    # This prevents stuck process references
+            wait_timeout = ASYNC_DELAYS.RECORDING_ERROR_RECOVERY
+            try:
+                if captured_process.returncode is None:
+                    captured_process.terminate()
+                    logger.debug(f"Sent SIGTERM to stream {stream.id} process")
                     try:
-                        self.active_processes.pop(process_id, None)
-                        logger.debug(
-                            f"Removed process {process_id} from active_processes tracking"
+                        await asyncio.wait_for(
+                            captured_process.wait(), timeout=wait_timeout
                         )
-                    except Exception as e:
-                        logger.warning(
-                            f"Error removing process {process_id} from tracking: {e}"
+                    except TimeoutError:
+                        captured_process.kill()
+                        logger.debug(f"Sent SIGKILL to stream {stream.id} process")
+                        await asyncio.wait_for(
+                            captured_process.wait(), timeout=wait_timeout
                         )
+                else:
+                    await asyncio.wait_for(
+                        captured_process.wait(), timeout=wait_timeout
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as process_error:
+                logger.error(
+                    f"Segment rotation could not stop stream {stream.id} process "
+                    f"({type(process_error).__name__}); retaining current ownership"
+                )
+                return False
 
-            # Prepare next segment
+            if captured_process.returncode is None:
+                logger.error(
+                    f"Segment rotation could not confirm exit for stream {stream.id}; retaining current ownership"
+                )
+                return False
+
+            async with self.lock:
+                if self.active_processes.get(process_id) is not captured_process:
+                    return False
+                del self.active_processes[process_id]
+
             segment_info["segment_count"] += 1
             base_path = Path(segment_info["base_output_path"])
             segment_filename = f"{base_path.stem}{self.SEGMENT_PART_IDENTIFIER}{segment_info['segment_count']:03d}.ts"
             next_segment_path = Path(segment_info["segment_dir"]) / segment_filename
-
             segment_info["current_segment_path"] = str(next_segment_path)
             segment_info["segment_start_time"] = datetime.now()
 
-            # Start new segment
-            new_process = await self._start_segment(
-                stream, str(next_segment_path), quality, segment_info
-            )
-
-            if new_process:
-                logger.info(
-                    f"Successfully rotated to segment {segment_info['segment_count']} for stream {stream.id}"
+            try:
+                new_process = await self._start_segment(
+                    stream, str(next_segment_path), quality, segment_info
                 )
-            else:
-                logger.error(f"Failed to start new segment for stream {stream.id}")
+            except asyncio.CancelledError:
+                raise
+            except Exception as start_error:
+                logger.error(
+                    f"Failed to start rotated segment for stream {stream.id} "
+                    f"({type(start_error).__name__})"
+                )
+                return False
 
-        except Exception as e:
-            logger.error(
-                f"Error rotating segment for stream {stream.id}: {e}", exc_info=True
+            if not new_process:
+                logger.error(f"Failed to start new segment for stream {stream.id}")
+                return False
+
+            logger.info(
+                f"Successfully rotated to segment {segment_info['segment_count']} for stream {stream.id}"
             )
+            return True
 
     async def monitor_process(self, process: asyncio.subprocess.Process) -> int:
         """Monitor a recording process until completion with failure detection
@@ -762,6 +765,10 @@ class ProcessManager:
 
             # Handle segmented vs normal recording completion
             if segment_info:
+                async with self.lock:
+                    if self.active_processes.get(process_id) is not process:
+                        return process.returncode or 0
+
                 # For segmented recordings, the process ending means the stream is over
                 # We need to concatenate all segments
                 logger.info(

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -499,6 +499,11 @@ class ProcessManager:
             if process.returncode is not None:
                 # Process already ended, capture output
                 stdout, stderr = await process.communicate()
+                async with self.lock:
+                    if self.active_processes.get(process_id) is process:
+                        del self.active_processes[process_id]
+                    if self.long_stream_processes.get(process_id) is segment_info:
+                        del self.long_stream_processes[process_id]
                 logger.error(
                     f"🎬 PROCESS_FAILED_IMMEDIATELY: PID would be {process.pid}, exit code {process.returncode}"
                 )
@@ -777,9 +782,11 @@ class ProcessManager:
                         del self.active_processes[process_id]
 
                     try:
-                        # Claim the exact owner before finalization so rotation cannot replace it.
+                        # Claim the exact owner before finalization so rotation
+                        # cannot replace it.
                         logger.info(
-                            f"Segmented recording completed for stream {segment_info['stream_id']}"
+                            "Segmented recording completed for stream "
+                            f"{segment_info['stream_id']}"
                         )
                         await self._finalize_segmented_recording(segment_info)
                         return 0  # Success for segmented recording

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -490,6 +490,10 @@ class ProcessManager:
                 *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
 
+            # Publish ownership before any cancellable post-creation work.
+            process_id = f"stream_{stream.id}"
+            self.active_processes[process_id] = process
+
             # Add immediate check to see if process started successfully
             await asyncio.sleep(ASYNC_DELAYS.PROCESS_START_GRACE)
             if process.returncode is not None:
@@ -527,10 +531,6 @@ class ProcessManager:
                 raise ProcessError(
                     f"Streamlink process failed immediately: {stderr.decode()}"
                 )
-
-            process_id = f"stream_{stream.id}"
-            async with self.lock:
-                self.active_processes[process_id] = process
 
             # Add segment to the list
             segment_info["total_segments"].append(
@@ -765,17 +765,31 @@ class ProcessManager:
 
             # Handle segmented vs normal recording completion
             if segment_info:
-                async with self.lock:
-                    if self.active_processes.get(process_id) is not process:
-                        return process.returncode or 0
+                rotation_locks = getattr(self, "rotation_locks", None)
+                if rotation_locks is None:
+                    rotation_locks = self.rotation_locks = {}
+                rotation_lock = rotation_locks.setdefault(process_id, asyncio.Lock())
 
-                # For segmented recordings, the process ending means the stream is over
-                # We need to concatenate all segments
-                logger.info(
-                    f"Segmented recording completed for stream {segment_info['stream_id']}"
-                )
-                await self._finalize_segmented_recording(segment_info)
-                return 0  # Success for segmented recording
+                async with rotation_lock:
+                    async with self.lock:
+                        if self.active_processes.get(process_id) is not process:
+                            return process.returncode or 0
+                        del self.active_processes[process_id]
+
+                    try:
+                        # Claim the exact owner before finalization so rotation cannot replace it.
+                        logger.info(
+                            f"Segmented recording completed for stream {segment_info['stream_id']}"
+                        )
+                        await self._finalize_segmented_recording(segment_info)
+                        return 0  # Success for segmented recording
+                    finally:
+                        async with self.lock:
+                            if (
+                                self.long_stream_processes.get(process_id)
+                                is segment_info
+                            ):
+                                del self.long_stream_processes[process_id]
             else:
                 # Normal single-file recording
                 stdout, stderr = await process.communicate()

--- a/tests/test_recording_rotation_safety.py
+++ b/tests/test_recording_rotation_safety.py
@@ -1,0 +1,254 @@
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.recording.process_manager import ProcessManager
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        *,
+        returncode: int | None = None,
+        terminate_error: BaseException | None = None,
+        release_on_terminate: bool = True,
+        release_on_kill: bool = True,
+    ) -> None:
+        self.returncode = returncode
+        self.terminate_error = terminate_error
+        self.release_on_terminate = release_on_terminate
+        self.release_on_kill = release_on_kill
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_calls = 0
+        self.wait_started = asyncio.Event()
+        self.release = asyncio.Event()
+        if returncode is not None:
+            self.release.set()
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self.terminate_error is not None:
+            raise self.terminate_error
+        if self.release_on_terminate:
+            self.returncode = -15
+            self.release.set()
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        if self.release_on_kill:
+            self.returncode = -9
+            self.release.set()
+
+    async def wait(self) -> int:
+        self.wait_calls += 1
+        self.wait_started.set()
+        await self.release.wait()
+        assert self.returncode is not None
+        return self.returncode
+
+
+def make_manager(process: FakeProcess, stream_id: int = 7) -> ProcessManager:
+    manager = object.__new__(ProcessManager)
+    manager.active_processes = {f"stream_{stream_id}": process}
+    manager.lock = asyncio.Lock()
+    manager.rotation_locks = {}
+    return manager
+
+
+def make_segment_info() -> dict:
+    return {
+        "base_output_path": "/tmp/recording.ts",
+        "segment_dir": "/tmp/recording_segments",
+        "current_segment_path": "/tmp/recording_segments/recording_part001.ts",
+        "segment_count": 1,
+        "segment_start_time": datetime(2026, 1, 1),
+        "total_segments": [],
+    }
+
+
+def install_segment_starter(
+    manager: ProcessManager,
+    started: list[FakeProcess],
+) -> None:
+    async def start_segment(stream, segment_path, quality, segment_info):
+        replacement = FakeProcess()
+        manager.active_processes[f"stream_{stream.id}"] = replacement
+        started.append(replacement)
+        return replacement
+
+    manager._start_segment = start_segment
+
+
+@pytest.mark.asyncio
+async def test_rotation_reaps_exited_process_before_starting_replacement() -> None:
+    old_process = FakeProcess(returncode=0)
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+
+    rotated = await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+
+    assert rotated is True
+    assert old_process.wait_calls == 1
+    assert old_process.terminate_calls == 0
+    assert old_process.kill_calls == 0
+    assert manager.active_processes["stream_7"] is started[0]
+
+
+@pytest.mark.asyncio
+async def test_rotation_terminates_and_waits_before_starting_replacement() -> None:
+    old_process = FakeProcess()
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+
+    rotated = await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+
+    assert rotated is True
+    assert old_process.terminate_calls == 1
+    assert old_process.wait_calls == 1
+    assert old_process.kill_calls == 0
+    assert len(started) == 1
+
+
+@pytest.mark.asyncio
+async def test_rotation_kills_and_waits_after_graceful_timeout(monkeypatch) -> None:
+    old_process = FakeProcess(release_on_terminate=False)
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+    monkeypatch.setattr(
+        "app.services.recording.process_manager.ASYNC_DELAYS",
+        SimpleNamespace(RECORDING_ERROR_RECOVERY=0.01),
+    )
+
+    rotated = await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+
+    assert rotated is True
+    assert old_process.terminate_calls == 1
+    assert old_process.kill_calls == 1
+    assert old_process.wait_calls == 2
+    assert len(started) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "termination_error",
+    [ProcessLookupError(), PermissionError()],
+)
+async def test_rotation_retains_tracking_when_terminate_raises(
+    termination_error: BaseException,
+) -> None:
+    old_process = FakeProcess(terminate_error=termination_error)
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    original_path = segment_info["current_segment_path"]
+    started = []
+    install_segment_starter(manager, started)
+
+    rotated = await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+
+    assert rotated is False
+    assert manager.active_processes["stream_7"] is old_process
+    assert segment_info["current_segment_path"] == original_path
+    assert started == []
+
+
+@pytest.mark.asyncio
+async def test_rotation_retains_tracking_when_forced_wait_times_out(
+    monkeypatch,
+) -> None:
+    old_process = FakeProcess(
+        release_on_terminate=False,
+        release_on_kill=False,
+    )
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+    monkeypatch.setattr(
+        "app.services.recording.process_manager.ASYNC_DELAYS",
+        SimpleNamespace(RECORDING_ERROR_RECOVERY=0.01),
+    )
+
+    rotated = await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+
+    assert rotated is False
+    assert manager.active_processes["stream_7"] is old_process
+    assert old_process.kill_calls == 1
+    assert started == []
+
+
+@pytest.mark.asyncio
+async def test_rotation_cancellation_retains_tracking() -> None:
+    old_process = FakeProcess(release_on_terminate=False)
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+
+    rotation = asyncio.create_task(
+        manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+    )
+    await old_process.wait_started.wait()
+    rotation.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await rotation
+    assert manager.active_processes["stream_7"] is old_process
+    assert started == []
+
+
+@pytest.mark.asyncio
+async def test_rotation_does_not_replace_newer_tracked_process() -> None:
+    old_process = FakeProcess(release_on_terminate=False)
+    newer_process = FakeProcess()
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+
+    rotation = asyncio.create_task(
+        manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+    )
+    await old_process.wait_started.wait()
+    manager.active_processes["stream_7"] = newer_process
+    old_process.returncode = -15
+    old_process.release.set()
+
+    assert await rotation is False
+    assert manager.active_processes["stream_7"] is newer_process
+    assert started == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_rotation_requests_start_one_replacement() -> None:
+    old_process = FakeProcess(release_on_terminate=False)
+    manager = make_manager(old_process)
+    first_segment_info = make_segment_info()
+    second_segment_info = make_segment_info()
+    started = []
+    install_segment_starter(manager, started)
+
+    first_rotation = asyncio.create_task(
+        manager._rotate_segment(SimpleNamespace(id=7), first_segment_info, "best")
+    )
+    await old_process.wait_started.wait()
+    second_rotation = asyncio.create_task(
+        manager._rotate_segment(SimpleNamespace(id=7), second_segment_info, "best")
+    )
+    await asyncio.sleep(0)
+    old_process.returncode = -15
+    old_process.release.set()
+
+    results = await asyncio.gather(first_rotation, second_rotation)
+    assert results == [True, False]
+    assert old_process.terminate_calls == 1
+    assert len(started) == 1
+    assert manager.active_processes["stream_7"] is started[0]

--- a/tests/test_recording_rotation_safety.py
+++ b/tests/test_recording_rotation_safety.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 from datetime import datetime
 from types import SimpleNamespace
 
@@ -53,6 +54,7 @@ class FakeProcess:
 def make_manager(process: FakeProcess, stream_id: int = 7) -> ProcessManager:
     manager = object.__new__(ProcessManager)
     manager.active_processes = {f"stream_{stream_id}": process}
+    manager.long_stream_processes = {}
     manager.lock = asyncio.Lock()
     manager.rotation_locks = {}
     return manager
@@ -60,12 +62,14 @@ def make_manager(process: FakeProcess, stream_id: int = 7) -> ProcessManager:
 
 def make_segment_info() -> dict:
     return {
+        "stream_id": 7,
         "base_output_path": "/tmp/recording.ts",
         "segment_dir": "/tmp/recording_segments",
         "current_segment_path": "/tmp/recording_segments/recording_part001.ts",
         "segment_count": 1,
         "segment_start_time": datetime(2026, 1, 1),
         "total_segments": [],
+        "monitor_task": None,
     }
 
 
@@ -252,3 +256,132 @@ async def test_concurrent_rotation_requests_start_one_replacement() -> None:
     assert old_process.terminate_calls == 1
     assert len(started) == 1
     assert manager.active_processes["stream_7"] is started[0]
+
+
+@pytest.mark.asyncio
+async def test_monitor_finalization_and_rotation_cannot_both_win() -> None:
+    old_process = FakeProcess(returncode=0)
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    manager.long_stream_processes["stream_7"] = segment_info
+    started = []
+    install_segment_starter(manager, started)
+    finalization_started = asyncio.Event()
+    release_finalization = asyncio.Event()
+
+    async def finalize_segmented_recording(info):
+        assert info is segment_info
+        finalization_started.set()
+        await release_finalization.wait()
+
+    manager._finalize_segmented_recording = finalize_segmented_recording
+    monitor = asyncio.create_task(manager.monitor_process(old_process))
+    await finalization_started.wait()
+    rotation = asyncio.create_task(
+        manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+    )
+
+    try:
+        rotated_while_finalizing = await asyncio.wait_for(
+            asyncio.shield(rotation), timeout=0.05
+        )
+    except TimeoutError:
+        rotated_while_finalizing = None
+    owner_while_finalizing = manager.active_processes.get("stream_7")
+    release_finalization.set()
+    monitor_result, rotation_result = await asyncio.gather(monitor, rotation)
+
+    assert (
+        rotated_while_finalizing is not True and owner_while_finalizing not in started
+    ), (
+        "rotation and finalization both won: "
+        f"rotation={rotated_while_finalizing!r}, "
+        f"replacement_owned={owner_while_finalizing in started}"
+    )
+    assert monitor_result == 0
+    assert rotation_result is False
+    assert started == []
+
+
+@pytest.mark.asyncio
+async def test_rotation_cancellation_tracks_or_reaps_created_replacement(
+    monkeypatch,
+) -> None:
+    process_manager_module = importlib.import_module(
+        "app.services.recording.process_manager"
+    )
+    old_process = FakeProcess(returncode=0)
+    manager = make_manager(old_process)
+    manager.logging_service = None
+    segment_info = make_segment_info()
+    replacement = FakeProcess()
+    replacement.pid = 1234
+    child_created = asyncio.Event()
+
+    class FakeQuery:
+        def first(self):
+            return None
+
+        def filter(self, *args):
+            return self
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def query(self, *args):
+            return FakeQuery()
+
+    class FakeTokenService:
+        def __init__(self, db):
+            pass
+
+        async def get_valid_access_token(self):
+            return None
+
+    async def create_subprocess(*args, **kwargs):
+        child_created.set()
+        return replacement
+
+    monkeypatch.setattr("app.database.SessionLocal", FakeSession)
+    monkeypatch.setattr(
+        "app.services.system.twitch_token_service.TwitchTokenService",
+        FakeTokenService,
+    )
+    monkeypatch.setattr(
+        process_manager_module,
+        "get_streamlink_command",
+        lambda **kwargs: ["harmless-local-command"],
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+    monkeypatch.setattr(
+        process_manager_module,
+        "ASYNC_DELAYS",
+        SimpleNamespace(PROCESS_START_GRACE=3600, RECORDING_ERROR_RECOVERY=1),
+    )
+    stream = SimpleNamespace(
+        id=7,
+        streamer_id=3,
+        streamer=SimpleNamespace(username="local-test"),
+        title="",
+        category_name="",
+    )
+
+    rotation = asyncio.create_task(
+        manager._rotate_segment(stream, segment_info, "best")
+    )
+    await child_created.wait()
+    rotation.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await rotation
+
+    tracked = manager.active_processes.get("stream_7") is replacement
+    reaped = replacement.returncode is not None and replacement.wait_calls > 0
+    assert manager.active_processes.get("stream_7") is not old_process
+    assert tracked or reaped, (
+        f"created replacement was orphaned: tracked={tracked}, reaped={reaped}"
+    )

--- a/tests/test_recording_rotation_safety.py
+++ b/tests/test_recording_rotation_safety.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.services.recording.process_manager import ProcessManager
+from app.services.recording.exceptions import ProcessError
 
 
 class FakeProcess:
@@ -24,6 +25,7 @@ class FakeProcess:
         self.terminate_calls = 0
         self.kill_calls = 0
         self.wait_calls = 0
+        self.communicate_calls = 0
         self.wait_started = asyncio.Event()
         self.release = asyncio.Event()
         if returncode is not None:
@@ -49,6 +51,10 @@ class FakeProcess:
         await self.release.wait()
         assert self.returncode is not None
         return self.returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        self.communicate_calls += 1
+        return b"", b"harmless local failure"
 
 
 def make_manager(process: FakeProcess, stream_id: int = 7) -> ProcessManager:
@@ -84,6 +90,80 @@ def install_segment_starter(
         return replacement
 
     manager._start_segment = start_segment
+
+
+def install_immediate_exit_start(
+    monkeypatch,
+    failed_process: FakeProcess,
+) -> tuple[ProcessManager, SimpleNamespace, list]:
+    process_manager_module = importlib.import_module(
+        "app.services.recording.process_manager"
+    )
+    manager = object.__new__(ProcessManager)
+    manager.active_processes = {}
+    manager.long_stream_processes = {}
+    manager.lock = asyncio.Lock()
+    manager.rotation_locks = {}
+    manager.logging_service = None
+    monitor_coroutines = []
+
+    class FakeQuery:
+        def first(self):
+            return None
+
+        def filter(self, *args):
+            return self
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def query(self, *args):
+            return FakeQuery()
+
+    class FakeTokenService:
+        def __init__(self, db):
+            pass
+
+        async def get_valid_access_token(self):
+            return None
+
+    async def create_subprocess(*args, **kwargs):
+        return failed_process
+
+    def create_task(coroutine):
+        monitor_coroutines.append(coroutine)
+        coroutine.close()
+        return SimpleNamespace()
+
+    monkeypatch.setattr("app.database.SessionLocal", FakeSession)
+    monkeypatch.setattr(
+        "app.services.system.twitch_token_service.TwitchTokenService",
+        FakeTokenService,
+    )
+    monkeypatch.setattr(
+        process_manager_module,
+        "get_streamlink_command",
+        lambda **kwargs: ["harmless-local-command"],
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+    monkeypatch.setattr(asyncio, "create_task", create_task)
+    monkeypatch.setattr(
+        process_manager_module,
+        "ASYNC_DELAYS",
+        SimpleNamespace(PROCESS_START_GRACE=0),
+    )
+    stream = SimpleNamespace(
+        id=7,
+        streamer_id=3,
+        streamer=SimpleNamespace(username="local-test"),
+        title="",
+        category_name="",
+    )
+    return manager, stream, monitor_coroutines
 
 
 @pytest.mark.asyncio
@@ -385,3 +465,69 @@ async def test_rotation_cancellation_tracks_or_reaps_created_replacement(
     assert tracked or reaped, (
         f"created replacement was orphaned: tracked={tracked}, reaped={reaped}"
     )
+
+
+@pytest.mark.asyncio
+async def test_start_recording_cleans_up_immediately_exited_child(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    failed_process = FakeProcess(returncode=1)
+    failed_process.pid = 1234
+    manager, stream, monitor_coroutines = install_immediate_exit_start(
+        monkeypatch,
+        failed_process,
+    )
+
+    with pytest.raises(ProcessError):
+        await manager.start_recording_process(
+            stream,
+            str(tmp_path / "recording.ts"),
+            "best",
+        )
+
+    assert failed_process.communicate_calls == 1
+    assert (manager.active_processes, manager.long_stream_processes) == ({}, {})
+    assert monitor_coroutines == []
+
+
+@pytest.mark.asyncio
+async def test_immediate_exit_cleanup_preserves_newer_owners(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    failed_process = FakeProcess(returncode=1)
+    failed_process.pid = 1234
+    manager, stream, monitor_coroutines = install_immediate_exit_start(
+        monkeypatch,
+        failed_process,
+    )
+    newer_process = FakeProcess()
+    newer_segment_info = {"attempt": "newer"}
+
+    class ReplacingLock:
+        def __init__(self):
+            self.enter_calls = 0
+
+        async def __aenter__(self):
+            self.enter_calls += 1
+            if self.enter_calls == 2:
+                manager.active_processes["stream_7"] = newer_process
+                manager.long_stream_processes["stream_7"] = newer_segment_info
+
+        async def __aexit__(self, *args):
+            return None
+
+    manager.lock = ReplacingLock()
+
+    with pytest.raises(ProcessError):
+        await manager.start_recording_process(
+            stream,
+            str(tmp_path / "recording.ts"),
+            "best",
+        )
+
+    assert manager.active_processes["stream_7"] is newer_process
+    assert manager.long_stream_processes["stream_7"] is newer_segment_info
+    assert failed_process.communicate_calls == 1
+    assert monitor_coroutines == []


### PR DESCRIPTION
## Summary

- Serializes recording rotation per stream and preserves process ownership until the previous subprocess has exited.
- Uses bounded terminate and wait, followed by kill and wait only after a timeout.
- Prevents a stale segmented-process monitor from finalizing a recording after rotation replaced its owner.
- Adds deterministic local fake-process coverage for rotation lifecycle, failure, cancellation, stale ownership, concurrent rotation behavior, and immediate-exit ownership cleanup.
- Wraps the three rotation log messages to comply with the 88-character Python line limit without changing their meaning.

## Verification

- Exact immutable head: `25bdfd5aeab3d37eac48da15717176d476a1c3fd` on `fix/781-rotation-orphans`, based on `develop` at `326c77b8cad3fc35881ff2d3d21b8f31656c2e07`.
- Focused rotation and recovery suite passed: 16 passed.
- Full backend suite passed: 218 passed, 2 skipped.
- Ruff check and format check passed for the touched recording source and regression tests.
- Migration initialization smoke check passed.
- `git diff --check` and the forbidden Unicode dash scan passed.
- All 17 current-head GitHub checks passed, including Docker Build Test.
- Local Docker Buildx is unavailable, so the linux/amd64 image build was verified by the exact-head CI gate.

Closes #781
