### PR TITLE
feat(twitch): coordinate persistent upstream leases

### DIFF
--- a/app/frontend/src/services/api-real.ts
+++ b/app/frontend/src/services/api-real.ts
@@ -64,7 +64,19 @@ class ApiClient {
           // Throw to abort the caller so it doesn't continue processing
           throw new Error('Session expired - redirecting to login')
         }
-        throw new Error(`HTTP error! status: ${response.status}`)
+        const contentType = response.headers.get('content-type')
+        const errorBody = contentType?.includes('application/json')
+          ? await response.json()
+          : null
+        const detail = errorBody?.detail
+        const error = new Error(
+          typeof detail?.reason === 'string'
+            ? detail.reason
+            : `HTTP error! status: ${response.status}`
+        ) as Error & { status?: number; detail?: unknown }
+        error.status = response.status
+        error.detail = detail
+        throw error
       }
 
       const contentType = response.headers.get('content-type')
@@ -512,10 +524,12 @@ export const liveApi = {
   startLiveStream: (
     streamerName: string,
     quality: string = 'best',
-    supportedCodecs: string = 'h264'
+    supportedCodecs: string = 'h264',
+    enhancedQuality: boolean = false
   ) => apiClient.post(`/api/live/start/${streamerName}`, {
     quality,
-    supported_codecs: supportedCodecs
+    supported_codecs: supportedCodecs,
+    enhanced_quality: enhancedQuality
   }),
 
   // Stop a live stream session
@@ -605,5 +619,4 @@ export const videoApi = {
 
 // Export the main API client as default
 export default apiClient
-
 

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -228,13 +228,15 @@ const mockLiveApi = {
   startLiveStream: (
     streamerName: string,
     quality: string = 'best',
-    supportedCodecs: string = 'h264'
+    supportedCodecs: string = 'h264',
+    _enhancedQuality: boolean = false
   ) => mockResponse({
     success: true,
     session_id: `mock-live-${Date.now()}`,
     streamer_name: streamerName,
     quality,
     supported_codecs: supportedCodecs,
+    idempotent: false,
     playlist_url: '/api/live/stream/mock/playlist.m3u8',
     message: 'Stream started (mock)'
   }),

--- a/app/main.py
+++ b/app/main.py
@@ -170,6 +170,13 @@ async def lifespan(app: FastAPI):
                 "⚠️ Application will continue but may have limited functionality"
             )
 
+        from app.services.twitch_upstream_coordinator import (
+            twitch_upstream_coordinator,
+        )
+
+        reconciled_leases = await twitch_upstream_coordinator.reconcile()
+        logger.info("Reconciled %s stale Twitch upstream leases", reconciled_leases)
+
         # Initialize EventSub
         event_registry = await get_event_registry()
         await event_registry.initialize_eventsub()

--- a/app/models.py
+++ b/app/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Text,
     Index,
     Float,
+    CheckConstraint,
 )
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
@@ -266,6 +267,66 @@ class SystemState(Base):
     )
 
 
+class TwitchUpstreamCoordinationState(Base):
+    __tablename__ = "twitch_upstream_coordination_state"
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_twitch_upstream_coordination_singleton"),
+        {"extend_existing": True},
+    )
+
+    id = Column(Integer, primary_key=True, default=1)
+    lock_version = Column(Integer, nullable=False, default=0, server_default="0")
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class TwitchUpstreamLease(Base):
+    __tablename__ = "twitch_upstream_leases"
+    __table_args__ = (
+        Index("ix_twitch_upstream_leases_state_expiry", "state", "expires_at"),
+        Index("ix_twitch_upstream_leases_auth_state", "auth_key", "state"),
+        Index("ix_twitch_upstream_leases_owner_state", "owner_user_id", "state"),
+        Index("ix_twitch_upstream_leases_recording_id", "recording_id"),
+        Index("uq_twitch_upstream_leases_channel_key", "channel_key", unique=True),
+        CheckConstraint(
+            "purpose IN ('RECORDING', 'LIVE', 'ROTATION', 'RECOVERY')",
+            name="ck_twitch_upstream_leases_purpose",
+        ),
+        CheckConstraint(
+            "state IN ('STARTING', 'ACTIVE', 'ROTATING', 'RECOVERING', 'RELEASED')",
+            name="ck_twitch_upstream_leases_state",
+        ),
+        {"extend_existing": True},
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    channel_key = Column(String(255), nullable=False)
+    auth_key = Column(String(128), nullable=True)
+    owner_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    recording_id = Column(
+        Integer, ForeignKey("recordings.id", ondelete="SET NULL"), nullable=True
+    )
+    live_session_id = Column(String(64), nullable=True)
+    purpose = Column(String(16), nullable=False)
+    state = Column(String(16), nullable=False)
+    generation = Column(Integer, nullable=False)
+    process_pid = Column(Integer, nullable=True)
+    process_group_id = Column(Integer, nullable=True)
+    process_started_at = Column(DateTime(timezone=True), nullable=True)
+    process_start_fingerprint = Column(String(128), nullable=True)
+    reserved_at = Column(DateTime(timezone=True), nullable=False)
+    activated_at = Column(DateTime(timezone=True), nullable=True)
+    heartbeat_at = Column(DateTime(timezone=True), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    released_at = Column(DateTime(timezone=True), nullable=True)
+    release_reason = Column(String(64), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False)
+    updated_at = Column(DateTime(timezone=True), nullable=False)
+
+
 class ApiKey(Base):
     """Long-lived API key for programmatic access without an interactive session.
 
@@ -401,6 +462,9 @@ class GlobalSettings(Base):
     prefer_higher_quality: bool = Column(
         Boolean, default=True
     )  # Auto-select highest available quality with h265/av1
+    twitch_max_concurrent_upstreams: int = Column(
+        Integer, nullable=False, default=5, server_default="5"
+    )
 
     # Proxy encryption key (Migration 032) - Persists Fernet key for proxy credential encryption
     # Auto-generated on first use, persists across restarts

--- a/app/routes/live.py
+++ b/app/routes/live.py
@@ -29,6 +29,8 @@ from app.database import get_db
 from app.dependencies import get_current_user
 from app.models import Streamer, User
 from app.services.live_streaming_service import live_streaming_service
+from app.services.live_streaming_service import TwitchUpstreamStopForbidden
+from app.services.twitch_upstream_coordinator import TwitchUpstreamConflict
 
 logger = logging.getLogger("streamvault")
 
@@ -56,6 +58,7 @@ def _append_playback_token_to_playlist(playlist: str, token: str) -> str:
 class LiveStartRequest(BaseModel):
     quality: Optional[str] = None
     supported_codecs: Optional[str] = None
+    enhanced_quality: bool = False
 
 
 @router.post("/start/{streamer_name}")
@@ -89,8 +92,15 @@ async def start_live_stream(
         requested_quality = body.quality or quality
         supported_codecs = body.supported_codecs or "h264"
 
-        # Verify streamer exists
-        streamer = db.query(Streamer).filter(Streamer.username == streamer_name).first()
+        normalized_name = streamer_name.strip().casefold()
+        streamer = next(
+            (
+                candidate
+                for candidate in db.query(Streamer).all()
+                if candidate.username.strip().casefold() == normalized_name
+            ),
+            None,
+        )
         if not streamer:
             raise HTTPException(
                 status_code=404, detail=f"Streamer '{streamer_name}' not found"
@@ -101,12 +111,15 @@ async def start_live_stream(
 
         # Start stream
         user_id = str(current_user.id) if current_user else None
-        session_id = await live_streaming_service.start_stream(
-            streamer_name=streamer_name,
+        start_result = await live_streaming_service.start_stream(
+            streamer_name=streamer.username,
+            channel_key=streamer.twitch_id,
             quality=requested_quality,
             supported_codecs=supported_codecs,
             user_id=user_id,
+            enhanced_quality=body.enhanced_quality,
         )
+        session_id = start_result.session_id
 
         session = live_streaming_service.get_session(session_id)
         if not session:
@@ -120,21 +133,25 @@ async def start_live_stream(
         )
 
         logger.info(
-            f"[LIVE] Stream started by user {user_id}: {session_id} ({streamer_name})"
+            f"[LIVE] Stream started by user {user_id}: {session_id} ({streamer.username})"
         )
 
         return {
             "success": True,
             "session_id": session_id,
-            "streamer_name": streamer_name,
+            "streamer_name": streamer.username,
             "quality": requested_quality,
             "supported_codecs": live_streaming_service._normalize_supported_codecs(
                 supported_codecs
             ),
             "playlist_url": playlist_url,
-            "message": "Stream started successfully",
+            "idempotent": start_result.idempotent,
         }
 
+    except TwitchUpstreamConflict as conflict:
+        raise HTTPException(status_code=409, detail=conflict.as_detail())
+    except HTTPException:
+        raise
     except RuntimeError as e:
         logger.warning(f"[LIVE] Failed to start stream for {streamer_name}: {e}")
         raise HTTPException(status_code=429, detail=str(e))
@@ -165,7 +182,10 @@ async def stop_live_stream(
                 status_code=404, detail="Session not found or already stopped"
             )
 
-        success = await live_streaming_service.stop_stream(session_id)
+        user_id = str(current_user.id) if current_user else None
+        success = await live_streaming_service.stop_stream(
+            session_id, requesting_user_id=user_id
+        )
 
         if success:
             return {
@@ -175,6 +195,14 @@ async def stop_live_stream(
         else:
             raise HTTPException(status_code=404, detail="Session not found")
 
+    except TwitchUpstreamStopForbidden:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "twitch_upstream_stop_forbidden",
+                "reason": "not_lease_owner",
+            },
+        )
     except HTTPException:
         raise
     except Exception as e:

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -82,6 +82,11 @@ async def get_settings():
                 if hasattr(settings, "prefer_higher_quality")
                 else True
             ),
+            twitch_max_concurrent_upstreams=(
+                settings.twitch_max_concurrent_upstreams
+                if hasattr(settings, "twitch_max_concurrent_upstreams")
+                else 5
+            ),
             http_proxy=settings.http_proxy,
             https_proxy=settings.https_proxy,
             apprise_docs_url="https://github.com/caronc/apprise/wiki",
@@ -353,6 +358,9 @@ async def update_settings(settings_data: GlobalSettingsSchema):
                 )
             if hasattr(settings_data, "prefer_higher_quality"):
                 settings.prefer_higher_quality = settings_data.prefer_higher_quality
+            settings.twitch_max_concurrent_upstreams = (
+                settings_data.twitch_max_concurrent_upstreams
+            )
             settings.http_proxy = settings_data.http_proxy or ""
             settings.https_proxy = settings_data.https_proxy or ""
 

--- a/app/schemas/settings.py
+++ b/app/schemas/settings.py
@@ -27,6 +27,7 @@ class GlobalSettingsSchema(BaseModel):
     # Codec preferences (Migration 024) - H.265/AV1 Support (Streamlink 8.0.0+)
     supported_codecs: str = "h264,h265"  # Default: H.264 with H.265 fallback
     prefer_higher_quality: bool = True  # Auto-select highest available quality
+    twitch_max_concurrent_upstreams: int = Field(default=5, ge=1, le=100)
     http_proxy: Optional[str] = Field(
         default="",
         description="HTTP proxy URL for Streamlink (e.g., http://proxy.example.com:8080)",

--- a/app/services/init/startup_init.py
+++ b/app/services/init/startup_init.py
@@ -525,7 +525,7 @@ async def cleanup_zombie_recordings():
         )
 
         from app.database import SessionLocal
-        from app.models import Recording, Stream
+        from app.models import Recording, Stream, TwitchUpstreamLease
         from app.services.streamer_service import StreamerService
         from app.services.recording.recording_service import RecordingService
         from app.services.communication.websocket_manager import websocket_manager
@@ -660,12 +660,30 @@ async def cleanup_zombie_recordings():
                         try:
                             # Resume recording through RecordingService
                             # Pass resume_segments_dir to continue in the same segments folder
-                            await recording_service.start_recording(
-                                stream_id=stream.id,
-                                streamer_id=streamer.id,
-                                force_mode=True,  # Force resume even if recording "exists"
-                                resume_segments_dir=resume_segments_dir,  # Continue in same segments folder!
+                            upstream_lease = (
+                                db.query(TwitchUpstreamLease)
+                                .filter(
+                                    TwitchUpstreamLease.channel_key
+                                    == streamer.twitch_id,
+                                    TwitchUpstreamLease.state == "RELEASED",
+                                )
+                                .first()
                             )
+                            if upstream_lease:
+                                await recording_service.start_recording(
+                                    stream_id=stream.id,
+                                    streamer_id=streamer.id,
+                                    force_mode=True,
+                                    resume_segments_dir=resume_segments_dir,
+                                    recovery_generation=upstream_lease.generation,
+                                )
+                            else:
+                                await recording_service.start_recording(
+                                    stream_id=stream.id,
+                                    streamer_id=streamer.id,
+                                    force_mode=True,
+                                    resume_segments_dir=resume_segments_dir,
+                                )
                             resumed_count += 1
                             if resume_segments_dir:
                                 logger.info(

--- a/app/services/live_streaming_service.py
+++ b/app/services/live_streaming_service.py
@@ -23,8 +23,10 @@ import asyncio
 import logging
 import os
 import secrets
+import signal
 import shutil
 import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Set
@@ -32,10 +34,25 @@ from typing import Dict, Optional, Set
 from app.database import SessionLocal
 from app.services.proxy.proxy_health_service import proxy_health_service
 from app.services.system.twitch_token_service import TwitchTokenService
+from app.services.twitch_upstream_coordinator import (
+    AUTHENTICATED_TWITCH_ACCOUNT,
+    TwitchUpstreamConflict,
+    twitch_upstream_coordinator,
+)
 from app.utils.security import sanitize_proxy_url_for_logging
 from app.utils.streamlink_utils import _add_proxy_settings
 
 logger = logging.getLogger("streamvault")
+
+
+@dataclass(frozen=True)
+class LiveStreamStartResult:
+    session_id: str
+    idempotent: bool
+
+
+class TwitchUpstreamStopForbidden(PermissionError):
+    pass
 
 
 class LiveStreamSession:
@@ -50,6 +67,12 @@ class LiveStreamSession:
         ffmpeg_process: asyncio.subprocess.Process,
         output_dir: Path,
         user_id: Optional[str] = None,
+        channel_key: Optional[str] = None,
+        enhanced_quality: bool = False,
+        lease_generation: Optional[int] = None,
+        process_group_id: Optional[int] = None,
+        process_started_at: Optional[datetime] = None,
+        process_start_fingerprint: Optional[str] = None,
     ):
         self.session_id = session_id
         self.streamer_name = streamer_name
@@ -58,6 +81,12 @@ class LiveStreamSession:
         self.ffmpeg_process = ffmpeg_process
         self.output_dir = output_dir
         self.user_id = user_id
+        self.channel_key = channel_key
+        self.enhanced_quality = enhanced_quality
+        self.lease_generation = lease_generation
+        self.process_group_id = process_group_id
+        self.process_started_at = process_started_at
+        self.process_start_fingerprint = process_start_fingerprint
         self.playback_token = secrets.token_urlsafe(32)
         self.created_at = datetime.utcnow()
         self.last_accessed = datetime.utcnow()
@@ -97,11 +126,13 @@ class LiveStreamingService:
     # Playlist window size (number of segments)
     HLS_LIST_SIZE = 10
 
-    def __init__(self):
+    def __init__(self, coordinator=None, output_root=None):
         self.sessions: Dict[str, LiveStreamSession] = {}
         self.user_sessions: Dict[str, Set[str]] = {}  # user_id -> set of session_ids
         self._cleanup_task: Optional[asyncio.Task] = None
         self._lock = asyncio.Lock()
+        self._coordinator = coordinator or twitch_upstream_coordinator
+        self._output_root = Path(output_root or "/tmp/streamvault-live")
 
     async def start(self):
         """Start the background cleanup task"""
@@ -123,18 +154,25 @@ class LiveStreamingService:
             session_ids = list(self.sessions.keys())
 
         for session_id in session_ids:
-            await self.stop_stream(session_id)
+            try:
+                await self.stop_stream(session_id)
+            except PermissionError:
+                logger.warning(
+                    "[LIVE] Session %s was fenced during shutdown", session_id
+                )
 
         logger.info("Live streaming service stopped")
 
     async def start_stream(
         self,
         streamer_name: str,
+        channel_key: Optional[str] = None,
         quality: str = "best",
         supported_codecs: str = "h264",
         user_id: Optional[str] = None,
-        replace_existing: bool = True,
-    ) -> str:
+        enhanced_quality: bool = False,
+        replace_existing: bool = False,
+    ) -> LiveStreamStartResult:
         """
         Start a new live streaming session.
 
@@ -151,28 +189,6 @@ class LiveStreamingService:
         Raises:
             RuntimeError: If max concurrent streams reached or stream start fails
         """
-        if replace_existing and user_id:
-            await self._stop_existing_user_streams(user_id, streamer_name)
-
-        async with self._lock:
-            # Check global concurrent limit
-            active_count = sum(1 for s in self.sessions.values() if s.is_active)
-            if active_count >= self.MAX_CONCURRENT_STREAMS:
-                raise RuntimeError(
-                    f"Maximum concurrent streams reached"
-                    f" ({self.MAX_CONCURRENT_STREAMS})."
-                    " Please stop another stream first."
-                )
-
-            # Limit per-user concurrent streams
-            if user_id:
-                user_stream_count = len(self.user_sessions.get(user_id, set()))
-                if user_stream_count >= 2:
-                    raise RuntimeError(
-                        "Maximum 2 concurrent streams per user."
-                        " Please stop another stream first."
-                    )
-
         # Verify FFmpeg is available before starting anything
         ffmpeg_bin = os.environ.get("FFMPEG_PATH") or "ffmpeg"
         if shutil.which(ffmpeg_bin) is None:
@@ -182,17 +198,39 @@ class LiveStreamingService:
 
         # Generate unique session ID
         session_id = str(uuid.uuid4())[:8]
+        channel_key = channel_key or streamer_name.strip().casefold()
+        auth_key = AUTHENTICATED_TWITCH_ACCOUNT if enhanced_quality else None
+        reservation = await self._coordinator.reserve(
+            channel_key=channel_key,
+            auth_key=auth_key,
+            purpose="LIVE",
+            owner_user_id=int(user_id) if user_id is not None else None,
+            live_session_id=session_id,
+        )
+        if reservation.live_session_id != session_id:
+            existing = self.sessions.get(reservation.live_session_id)
+            if existing and existing.is_active:
+                return LiveStreamStartResult(existing.session_id, True)
+            raise TwitchUpstreamConflict(
+                "twitch_upstream_channel_conflict",
+                "active_live_session_not_local",
+                channel_key,
+            )
 
         # Create output directory for HLS segments
-        output_dir = Path(f"/tmp/streamvault-live/{session_id}")
-        output_dir.mkdir(parents=True, exist_ok=True)
+        output_dir = self._output_root / session_id
 
         streamlink_process = None
         ffmpeg_process = None
+        active_lease = None
         try:
+            output_dir.mkdir(parents=True, exist_ok=True)
             # Get fresh OAuth token and proxy settings
             streamlink_cmd = await self._build_streamlink_command(
-                streamer_name, quality, supported_codecs=supported_codecs
+                streamer_name,
+                quality,
+                supported_codecs=supported_codecs,
+                enhanced_quality=enhanced_quality,
             )
 
             # Build FFmpeg HLS command
@@ -210,6 +248,7 @@ class LiveStreamingService:
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
             )
 
             # Start Streamlink with stdout captured
@@ -217,7 +256,22 @@ class LiveStreamingService:
                 *streamlink_cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
             )
+            process_group_id = os.getpgid(streamlink_process.pid)
+            activation = asyncio.create_task(
+                self._coordinator.activate(
+                    channel_key=channel_key,
+                    generation=reservation.generation,
+                    process_pid=streamlink_process.pid,
+                    process_group_id=process_group_id,
+                )
+            )
+            try:
+                active_lease = await asyncio.shield(activation)
+            except asyncio.CancelledError:
+                active_lease = await activation
+                raise
 
             # Start background stderr loggers so we can diagnose failures
             asyncio.create_task(
@@ -259,6 +313,16 @@ class LiveStreamingService:
                 ffmpeg_process=ffmpeg_process,
                 output_dir=output_dir,
                 user_id=user_id,
+                channel_key=channel_key,
+                enhanced_quality=enhanced_quality,
+                lease_generation=reservation.generation,
+                process_group_id=getattr(
+                    active_lease, "process_group_id", process_group_id
+                ),
+                process_started_at=getattr(active_lease, "process_started_at", None),
+                process_start_fingerprint=getattr(
+                    active_lease, "process_start_fingerprint", ""
+                ),
             )
 
             async with self._lock:
@@ -272,14 +336,38 @@ class LiveStreamingService:
             asyncio.create_task(self._monitor_session(session_id))
 
             logger.info(f"[LIVE] Session {session_id} started successfully")
-            return session_id
+            return LiveStreamStartResult(session_id, False)
 
-        except Exception:
-            # Cleanup on any failure
-            if streamlink_process and streamlink_process.returncode is None:
-                streamlink_process.kill()
-            if ffmpeg_process and ffmpeg_process.returncode is None:
-                ffmpeg_process.kill()
+        except BaseException:
+            authorized = active_lease is None
+            if active_lease is not None:
+                try:
+                    await self._coordinator.assert_stop_authorized(
+                        channel_key=channel_key,
+                        generation=reservation.generation,
+                        process_pid=streamlink_process.pid,
+                        process_group_id=getattr(
+                            active_lease, "process_group_id", process_group_id
+                        ),
+                        process_start_fingerprint=getattr(
+                            active_lease, "process_start_fingerprint", ""
+                        ),
+                        expected_purpose="LIVE",
+                        requesting_owner_user_id=(
+                            int(user_id) if user_id is not None else None
+                        ),
+                    )
+                    authorized = True
+                except PermissionError:
+                    authorized = False
+            if authorized:
+                await self._reap_process(streamlink_process)
+                await self._reap_process(ffmpeg_process)
+            await self._coordinator.release(
+                channel_key=channel_key,
+                generation=reservation.generation,
+                reason="live_start_failed",
+            )
             shutil.rmtree(output_dir, ignore_errors=True)
             raise
 
@@ -333,13 +421,16 @@ class LiveStreamingService:
                 line = await process.stderr.readline()
                 if not line:
                     break
-                text = line.decode("utf-8", errors="replace").rstrip()
-                if text:
-                    logger.debug(f"[LIVE][{name}] {text}")
-        except Exception as e:
-            logger.debug(f"[LIVE][{name}] stderr logger ended: {e}")
+                # Drain stderr without copying upstream URLs, headers, or credentials
+                # into application diagnostics.
+        except Exception as error:
+            logger.debug(
+                "[LIVE][%s] stderr logger ended (%s)", name, type(error).__name__
+            )
 
-    async def stop_stream(self, session_id: str) -> bool:
+    async def stop_stream(
+        self, session_id: str, requesting_user_id: Optional[str] = None
+    ) -> bool:
         """
         Stop a live streaming session and cleanup resources.
 
@@ -349,36 +440,90 @@ class LiveStreamingService:
         Returns:
             True if session was stopped, False if not found
         """
+        return await self._stop_session(
+            session_id, requesting_user_id=requesting_user_id
+        )
+
+    async def _stop_monitored_session(
+        self,
+        session_id: str,
+        monitored_session: LiveStreamSession,
+        *,
+        leader_exited: bool,
+    ) -> bool:
+        return await self._stop_session(
+            session_id,
+            monitored_session=monitored_session,
+            leader_exited=leader_exited,
+        )
+
+    async def _stop_session(
+        self,
+        session_id: str,
+        requesting_user_id: Optional[str] = None,
+        monitored_session: Optional[LiveStreamSession] = None,
+        leader_exited: bool = False,
+    ) -> bool:
         async with self._lock:
             session = self.sessions.get(session_id)
-            if not session:
+            if not session or not session.is_active:
                 return False
+            if monitored_session is not None and session is not monitored_session:
+                return False
+            if requesting_user_id is not None and session.user_id != requesting_user_id:
+                raise TwitchUpstreamStopForbidden("not_lease_owner")
+            session.is_active = False
+
+        try:
+            if session.lease_generation is not None:
+                owner_user_id = (
+                    int(
+                        requesting_user_id
+                        if requesting_user_id is not None
+                        else session.user_id
+                    )
+                    if (requesting_user_id is not None or session.user_id is not None)
+                    else None
+                )
+                authorization = {
+                    "channel_key": session.channel_key,
+                    "generation": session.lease_generation,
+                    "process_pid": session.streamlink_process.pid,
+                    "process_group_id": session.process_group_id,
+                    "process_start_fingerprint": session.process_start_fingerprint,
+                    "expected_purpose": "LIVE",
+                    "requesting_owner_user_id": owner_user_id,
+                }
+                if leader_exited:
+                    if (
+                        monitored_session is None
+                        or session.streamlink_process.returncode is None
+                    ):
+                        raise PermissionError("leader has not exited")
+                    await self._coordinator.assert_exited_process_cleanup_authorized(
+                        **authorization,
+                        expected_live_session_id=session_id,
+                    )
+                else:
+                    await self._coordinator.assert_stop_authorized(**authorization)
+        except PermissionError as error:
+            session.is_active = True
+            raise TwitchUpstreamStopForbidden("not_lease_owner") from error
+        except BaseException:
+            session.is_active = True
+            raise
 
         logger.info(f"[LIVE] Stopping session {session_id} ({session.streamer_name})")
 
-        # Mark as inactive
-        session.is_active = False
+        await self._reap_process(session.streamlink_process)
+        await self._reap_process(session.ffmpeg_process)
 
-        # Terminate processes gracefully
-        for proc, name in [
-            (session.streamlink_process, "streamlink"),
-            (session.ffmpeg_process, "ffmpeg"),
-        ]:
-            if proc and proc.returncode is None:
-                try:
-                    proc.terminate()
-                    # Wait up to 5 seconds for graceful shutdown
-                    try:
-                        await asyncio.wait_for(proc.wait(), timeout=5.0)
-                    except asyncio.TimeoutError:
-                        logger.warning(
-                            f"[LIVE] {name} process did not terminate"
-                            " gracefully, killing..."
-                        )
-                        proc.kill()
-                        await proc.wait()
-                except Exception as e:
-                    logger.error(f"[LIVE] Error stopping {name}: {e}")
+        if session.lease_generation is not None:
+            await self._coordinator.release(
+                channel_key=session.channel_key,
+                generation=session.lease_generation,
+                reason="live_stopped",
+            )
 
         # Cleanup files
         try:
@@ -397,6 +542,28 @@ class LiveStreamingService:
 
         logger.info(f"[LIVE] Session {session_id} stopped and cleaned up")
         return True
+
+    @staticmethod
+    async def _reap_process(process) -> None:
+        if not process or process.returncode is not None:
+            return
+        try:
+            process_group_id = os.getpgid(process.pid)
+            os.killpg(process_group_id, signal.SIGTERM)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                os.killpg(process_group_id, signal.SIGKILL)
+                await process.wait()
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+        except ProcessLookupError:
+            await process.wait()
+        except Exception:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
 
     def get_session(self, session_id: str) -> Optional[LiveStreamSession]:
         """Get a session by ID and update its access time"""
@@ -441,6 +608,7 @@ class LiveStreamingService:
         streamer_name: str,
         quality: str,
         supported_codecs: str = "h264",
+        enhanced_quality: bool = False,
     ) -> list:
         """Build Streamlink command for live streaming (no file output)"""
         normalized_codecs = self._normalize_supported_codecs(supported_codecs)
@@ -456,15 +624,14 @@ class LiveStreamingService:
             f"--twitch-supported-codecs={normalized_codecs}",
         ]
 
-        # Get fresh OAuth token
         with SessionLocal() as db:
-            token_service = TwitchTokenService(db)
-            oauth_token = await token_service.get_valid_access_token()
-
-            if oauth_token:
-                token_header = f"Authorization=OAuth {oauth_token.strip()}"
-                cmd.append(f"--twitch-api-header={token_header}")
-                logger.debug("[LIVE] Using OAuth token for stream")
+            if enhanced_quality:
+                token_service = TwitchTokenService(db)
+                oauth_token = await token_service.get_valid_access_token()
+                if oauth_token:
+                    token_header = f"Authorization=OAuth {oauth_token.strip()}"
+                    cmd.append(f"--twitch-api-header={token_header}")
+                    logger.debug("[LIVE] Using OAuth token for enhanced stream")
 
             # Get proxy settings from health service
             try:
@@ -524,8 +691,8 @@ class LiveStreamingService:
                     ffmpeg_process.stdin.write(chunk)
                     await ffmpeg_process.stdin.drain()
                 ffmpeg_process.stdin.close()
-        except Exception as e:
-            logger.error(f"[LIVE] Error piping streamlink to ffmpeg: {e}")
+        except Exception as error:
+            logger.error("[LIVE] Stream pipe ended (%s)", type(error).__name__)
 
     async def _monitor_session(self, session_id: str):
         """Monitor a session and auto-cleanup if processes die"""
@@ -536,6 +703,14 @@ class LiveStreamingService:
 
             # Wait for either process to exit
             while session.is_active:
+                if session.lease_generation is not None:
+                    heartbeat_ok = await self._coordinator.heartbeat(
+                        channel_key=session.channel_key,
+                        generation=session.lease_generation,
+                    )
+                    if not heartbeat_ok:
+                        session.is_active = False
+                        break
                 # Check if processes are still running
                 streamlink_done = session.streamlink_process.returncode is not None
                 ffmpeg_done = session.ffmpeg_process.returncode is not None
@@ -545,7 +720,11 @@ class LiveStreamingService:
                         f"[LIVE] Process exited for session {session_id}, "
                         f"cleaning up..."
                     )
-                    await self.stop_stream(session_id)
+                    await self._stop_monitored_session(
+                        session_id,
+                        session,
+                        leader_exited=streamlink_done,
+                    )
                     break
 
                 await asyncio.sleep(2)

--- a/app/services/recording/process_manager.py
+++ b/app/services/recording/process_manager.py
@@ -18,7 +18,9 @@ Dependency Injection:
 
 import logging
 import asyncio
+import os
 import re
+import signal
 import shutil
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Callable, Awaitable
@@ -38,6 +40,10 @@ from app.services.recording.exceptions import ProcessError
 from app.models import Stream
 from app.utils import async_file
 from app.config.constants import ASYNC_DELAYS
+from app.services.twitch_upstream_coordinator import (
+    AUTHENTICATED_TWITCH_ACCOUNT,
+    twitch_upstream_coordinator,
+)
 
 logger = logging.getLogger("streamvault")
 
@@ -68,6 +74,7 @@ class ProcessManager:
         post_processing_callback: Optional[
             Callable[[int, str], Awaitable[None]]
         ] = None,
+        upstream_coordinator=None,
     ):
         """Singleton pattern - return existing instance if available"""
         if cls._instance is None:
@@ -80,6 +87,7 @@ class ProcessManager:
         post_processing_callback: Optional[
             Callable[[int, str], Awaitable[None]]
         ] = None,
+        upstream_coordinator=None,
     ):
         # Only initialize once (singleton)
         if ProcessManager._initialized:
@@ -88,6 +96,8 @@ class ProcessManager:
                 self.config_manager = config_manager
             if post_processing_callback is not None:
                 self.post_processing_callback = post_processing_callback
+            if upstream_coordinator is not None:
+                self.upstream_coordinator = upstream_coordinator
             return
 
         self.active_processes = {}
@@ -97,6 +107,7 @@ class ProcessManager:
         self.ASYNC_DELAYS = ASYNC_DELAYS
         self.config_manager = config_manager
         self.post_processing_callback = post_processing_callback  # Injected dependency
+        self.upstream_coordinator = upstream_coordinator or twitch_upstream_coordinator
 
         # Configuration for long stream handling (avoid streamlink 24h cutoff)
         self.segment_duration_hours = (
@@ -136,6 +147,7 @@ class ProcessManager:
         quality: str,
         recording_id: Optional[int] = None,
         resume_segments_dir: Optional[str] = None,
+        recovery_generation: Optional[int] = None,
     ) -> Optional[asyncio.subprocess.Process]:
         """Start a streamlink recording process for a specific stream
 
@@ -149,11 +161,27 @@ class ProcessManager:
         Returns:
             Process object or None if failed
         """
+        reservation = None
         try:
+            streamer = getattr(stream, "streamer", None)
+            channel_key = getattr(streamer, "twitch_id", None)
+            if channel_key:
+                reservation = await self.upstream_coordinator.reserve(
+                    channel_key=channel_key,
+                    auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+                    purpose="RECOVERY"
+                    if recovery_generation is not None
+                    else "RECORDING",
+                    recording_id=recording_id,
+                    expected_generation=recovery_generation,
+                )
             # Initialize segmented recording for long streams
             segment_info = await self._initialize_segmented_recording(
                 stream, output_path, quality, recording_id, resume_segments_dir
             )
+            if reservation:
+                segment_info["upstream_channel_key"] = reservation.channel_key
+                segment_info["upstream_generation"] = reservation.generation
 
             # Start the first segment
             process = await self._start_segment(
@@ -169,12 +197,59 @@ class ProcessManager:
 
             return process
 
-        except Exception as e:
+        except BaseException as e:
+            if reservation:
+                process_id = f"stream_{stream.id}"
+                owned_process = self.active_processes.get(process_id)
+                stop_authorized = False
+                if owned_process and owned_process.returncode is None:
+                    try:
+                        await self.upstream_coordinator.assert_stop_authorized(
+                            channel_key=reservation.channel_key,
+                            generation=segment_info["upstream_generation"],
+                            process_pid=owned_process.pid,
+                            process_group_id=segment_info["upstream_process_group_id"],
+                            process_start_fingerprint=segment_info[
+                                "upstream_process_start_fingerprint"
+                            ],
+                        )
+                        stop_authorized = True
+                    except (KeyError, PermissionError):
+                        pass
+                released = await self.upstream_coordinator.release(
+                    channel_key=reservation.channel_key,
+                    generation=segment_info.get(
+                        "upstream_generation", reservation.generation
+                    )
+                    if "segment_info" in locals()
+                    else reservation.generation,
+                    reason="recording_start_failed",
+                )
+                if (
+                    owned_process
+                    and owned_process.returncode is None
+                    and (stop_authorized or released)
+                ):
+                    await self._terminate_process_group(
+                        owned_process,
+                        segment_info.get(
+                            "upstream_process_group_id", owned_process.pid
+                        ),
+                        ASYNC_DELAYS.RECORDING_ERROR_RECOVERY,
+                    )
+                    if self.active_processes.get(process_id) is owned_process:
+                        del self.active_processes[process_id]
+                    if self.long_stream_processes.get(process_id) is segment_info:
+                        del self.long_stream_processes[process_id]
+            if isinstance(e, asyncio.CancelledError):
+                raise
             logger.error(
-                f"Failed to start recording process for stream {stream.id}: {e}",
+                "Failed to start recording process for stream %s (%s)",
+                stream.id,
+                type(e).__name__,
                 exc_info=True,
             )
-            raise ProcessError(f"Failed to start recording: {e}")
+            raise ProcessError("Failed to start recording") from e
 
     async def _initialize_segmented_recording(
         self,
@@ -385,7 +460,7 @@ class ProcessManager:
                             "ℹ️ No OAuth token available - H.265/1440p quality unavailable"
                         )
                 except Exception as e:
-                    logger.warning(f"Failed to get OAuth token: {e}")
+                    logger.warning("Failed to get OAuth token (%s)", type(e).__name__)
                     oauth_token = None
 
                 # === STEP 2: Get codec preferences ===
@@ -441,12 +516,8 @@ class ProcessManager:
 
             # Log to structured logging service
             if self.logging_service:
-                # The logging service now automatically creates streamer-specific directories
-                streamlink_log_path = self.logging_service.log_streamlink_start(
-                    streamer_name=streamer_name,
-                    quality=quality,
-                    output_path=segment_path,
-                    cmd=cmd,
+                streamlink_log_path = self.logging_service.get_streamlink_log_path(
+                    streamer_name
                 )
 
                 logger.info(
@@ -487,12 +558,33 @@ class ProcessManager:
 
             # Start the process
             process = await asyncio.create_subprocess_exec(
-                *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
             )
 
             # Publish ownership before any cancellable post-creation work.
             process_id = f"stream_{stream.id}"
             self.active_processes[process_id] = process
+
+            rotation_generation = segment_info.get("upstream_rotation_generation")
+            if (
+                segment_info.get("upstream_channel_key")
+                and rotation_generation != segment_info["upstream_generation"]
+            ):
+                active_lease = await self.upstream_coordinator.activate(
+                    channel_key=segment_info["upstream_channel_key"],
+                    generation=segment_info["upstream_generation"],
+                    process_pid=process.pid,
+                    process_group_id=process.pid,
+                )
+                segment_info["upstream_process_group_id"] = (
+                    active_lease.process_group_id
+                )
+                segment_info["upstream_process_start_fingerprint"] = (
+                    active_lease.process_start_fingerprint
+                )
 
             # Add immediate check to see if process started successfully
             await asyncio.sleep(ASYNC_DELAYS.PROCESS_START_GRACE)
@@ -507,35 +599,19 @@ class ProcessManager:
                 logger.error(
                     f"🎬 PROCESS_FAILED_IMMEDIATELY: PID would be {process.pid}, exit code {process.returncode}"
                 )
-                logger.error(f"🎬 STDOUT: {stdout.decode()}")
-                logger.error(f"🎬 STDERR: {stderr.decode()}")
+                logger.error("Streamlink exited during recording startup")
 
                 # Log to structured logging service
                 if self.logging_service:
-                    self.logging_service.log_streamlink_output(
-                        streamer_name=streamer_name,
-                        stdout=stdout,
-                        stderr=stderr,
-                        exit_code=process.returncode,
-                        log_path=streamlink_log_path,  # Pass the log path from start
-                    )
-
-                    # Also append to the streamer-specific log file using proper logging
                     streamer_logger = logging.getLogger(f"streamlink.{streamer_name}")
                     try:
                         streamer_logger.error(
                             f"PROCESS FAILED IMMEDIATELY (exit code: {process.returncode})"
                         )
-                        if stdout:
-                            streamer_logger.error(f"STDOUT:\n{stdout.decode()}")
-                        if stderr:
-                            streamer_logger.error(f"STDERR:\n{stderr.decode()}")
                     except Exception as e:
                         logger.warning(f"Could not write to streamlink log file: {e}")
 
-                raise ProcessError(
-                    f"Streamlink process failed immediately: {stderr.decode()}"
-                )
+                raise ProcessError("Streamlink process failed immediately")
 
             # Add segment to the list
             segment_info["total_segments"].append(
@@ -597,10 +673,12 @@ class ProcessManager:
 
         except Exception as e:
             logger.error(
-                f"Failed to start segment recording for stream {stream.id}: {e}",
+                "Failed to start segment recording for stream %s (%s)",
+                stream.id,
+                type(e).__name__,
                 exc_info=True,
             )
-            raise ProcessError(f"Failed to start segment recording: {e}")
+            raise ProcessError("Failed to start segment recording") from e
 
     async def _monitor_long_stream(
         self, stream: Stream, segment_info: Dict, quality: str
@@ -610,7 +688,19 @@ class ProcessManager:
 
         try:
             while process_id in self.active_processes:
-                await asyncio.sleep(self.monitor_interval_seconds)
+                await asyncio.sleep(min(self.monitor_interval_seconds, 10))
+
+                if segment_info.get("upstream_channel_key"):
+                    heartbeat_ok = await self.upstream_coordinator.heartbeat(
+                        channel_key=segment_info["upstream_channel_key"],
+                        generation=segment_info["upstream_generation"],
+                    )
+                    if not heartbeat_ok:
+                        logger.warning(
+                            "Recording lease heartbeat was fenced for stream %s",
+                            stream.id,
+                        )
+                        break
 
                 # Check if we need to start a new segment
                 should_rotate = await self._should_rotate_segment(segment_info)
@@ -675,26 +765,170 @@ class ProcessManager:
             if self.active_processes.get(process_id) is not captured_process:
                 return False
 
-            wait_timeout = ASYNC_DELAYS.RECORDING_ERROR_RECOVERY
+            upstream_channel_key = segment_info.get("upstream_channel_key")
+            rotation_generation = None
+            replacement_process = None
+            rotation_succeeded = False
+            failure_reason = "rotation_failed"
             try:
-                if captured_process.returncode is None:
-                    captured_process.terminate()
-                    logger.debug(f"Sent SIGTERM to stream {stream.id} process")
+                if upstream_channel_key:
                     try:
-                        await asyncio.wait_for(
-                            captured_process.wait(), timeout=wait_timeout
+                        begin_task = asyncio.create_task(
+                            self.upstream_coordinator.begin_rotation(
+                                channel_key=upstream_channel_key,
+                                generation=segment_info["upstream_generation"],
+                            )
                         )
-                    except TimeoutError:
-                        captured_process.kill()
-                        logger.debug(f"Sent SIGKILL to stream {stream.id} process")
-                        await asyncio.wait_for(
-                            captured_process.wait(), timeout=wait_timeout
+                        try:
+                            rotation = await asyncio.shield(begin_task)
+                        except asyncio.CancelledError:
+                            rotation = await begin_task
+                            rotation_generation = rotation.generation
+                            segment_info["upstream_generation"] = rotation.generation
+                            segment_info["upstream_rotation_generation"] = (
+                                rotation.generation
+                            )
+                            raise
+                        rotation_generation = rotation.generation
+                        segment_info["upstream_generation"] = rotation.generation
+                        segment_info["upstream_rotation_generation"] = (
+                            rotation.generation
                         )
+                        await self.upstream_coordinator.assert_stop_authorized(
+                            channel_key=upstream_channel_key,
+                            generation=rotation.generation,
+                            process_pid=captured_process.pid,
+                            process_group_id=segment_info["upstream_process_group_id"],
+                            process_start_fingerprint=segment_info[
+                                "upstream_process_start_fingerprint"
+                            ],
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as coordinator_error:
+                        logger.error(
+                            "Segment rotation fencing failed for stream %s (%s)",
+                            stream.id,
+                            type(coordinator_error).__name__,
+                        )
+                        return False
+
+                wait_timeout = ASYNC_DELAYS.RECORDING_ERROR_RECOVERY
+                if captured_process.returncode is None:
+                    if upstream_channel_key:
+                        stopped = await self._terminate_process_group(
+                            captured_process,
+                            segment_info["upstream_process_group_id"],
+                            wait_timeout,
+                        )
+                        if not stopped:
+                            return False
+                    else:
+                        captured_process.terminate()
+                        logger.debug(f"Sent SIGTERM to stream {stream.id} process")
+                        try:
+                            await asyncio.wait_for(
+                                captured_process.wait(), timeout=wait_timeout
+                            )
+                        except TimeoutError:
+                            captured_process.kill()
+                            logger.debug(f"Sent SIGKILL to stream {stream.id} process")
+                            await asyncio.wait_for(
+                                captured_process.wait(), timeout=wait_timeout
+                            )
                 else:
                     await asyncio.wait_for(
                         captured_process.wait(), timeout=wait_timeout
                     )
+
+                if captured_process.returncode is None:
+                    logger.error(
+                        f"Segment rotation could not confirm exit for stream {stream.id}; "
+                        "retaining current ownership"
+                    )
+                    return False
+
+                async with self.lock:
+                    if self.active_processes.get(process_id) is not captured_process:
+                        return False
+                    del self.active_processes[process_id]
+
+                segment_info["segment_count"] += 1
+                base_path = Path(segment_info["base_output_path"])
+                segment_filename = f"{base_path.stem}{self.SEGMENT_PART_IDENTIFIER}{segment_info['segment_count']:03d}.ts"
+                next_segment_path = Path(segment_info["segment_dir"]) / segment_filename
+                segment_info["current_segment_path"] = str(next_segment_path)
+                segment_info["segment_start_time"] = datetime.now()
+
+                failure_reason = "rotation_start_failed"
+                try:
+                    replacement_process = await self._start_segment(
+                        stream, str(next_segment_path), quality, segment_info
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as start_error:
+                    logger.error(
+                        f"Failed to start rotated segment for stream {stream.id} "
+                        f"({type(start_error).__name__})"
+                    )
+                    return False
+
+                if not replacement_process:
+                    logger.error(f"Failed to start new segment for stream {stream.id}")
+                    return False
+
+                if upstream_channel_key:
+                    failure_reason = "rotation_handoff_failed"
+                    try:
+                        handoff_task = asyncio.create_task(
+                            self.upstream_coordinator.handoff_rotation(
+                                channel_key=upstream_channel_key,
+                                generation=segment_info["upstream_generation"],
+                                process_pid=replacement_process.pid,
+                                process_group_id=replacement_process.pid,
+                                purpose="RECORDING",
+                            )
+                        )
+                        try:
+                            handoff = await asyncio.shield(handoff_task)
+                        except asyncio.CancelledError:
+                            handoff = await handoff_task
+                            segment_info["upstream_generation"] = handoff.generation
+                            segment_info["upstream_process_group_id"] = (
+                                handoff.process_group_id
+                            )
+                            segment_info["upstream_process_start_fingerprint"] = (
+                                handoff.process_start_fingerprint
+                            )
+                            segment_info.pop("upstream_rotation_generation", None)
+                            raise
+                        segment_info["upstream_generation"] = handoff.generation
+                        segment_info["upstream_process_group_id"] = (
+                            handoff.process_group_id
+                        )
+                        segment_info["upstream_process_start_fingerprint"] = (
+                            handoff.process_start_fingerprint
+                        )
+                        segment_info.pop("upstream_rotation_generation", None)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as coordinator_error:
+                        logger.error(
+                            "Segment rotation handoff failed for stream %s (%s)",
+                            stream.id,
+                            type(coordinator_error).__name__,
+                        )
+                        return False
+
+                rotation_succeeded = True
+                logger.info(
+                    f"Successfully rotated to segment {segment_info['segment_count']} "
+                    f"for stream {stream.id}"
+                )
+                return True
             except asyncio.CancelledError:
+                failure_reason = "rotation_cancelled"
                 raise
             except Exception as process_error:
                 logger.error(
@@ -702,48 +936,74 @@ class ProcessManager:
                     f"({type(process_error).__name__}); retaining current ownership"
                 )
                 return False
+            finally:
+                if rotation_generation is not None and not rotation_succeeded:
+                    await self._cleanup_failed_rotation(
+                        process_id,
+                        captured_process,
+                        replacement_process,
+                        segment_info,
+                        failure_reason,
+                        wait_timeout=ASYNC_DELAYS.RECORDING_ERROR_RECOVERY,
+                    )
 
-            if captured_process.returncode is None:
-                logger.error(
-                    f"Segment rotation could not confirm exit for stream {stream.id}; "
-                    "retaining current ownership"
-                )
-                return False
-
-            async with self.lock:
-                if self.active_processes.get(process_id) is not captured_process:
-                    return False
-                del self.active_processes[process_id]
-
-            segment_info["segment_count"] += 1
-            base_path = Path(segment_info["base_output_path"])
-            segment_filename = f"{base_path.stem}{self.SEGMENT_PART_IDENTIFIER}{segment_info['segment_count']:03d}.ts"
-            next_segment_path = Path(segment_info["segment_dir"]) / segment_filename
-            segment_info["current_segment_path"] = str(next_segment_path)
-            segment_info["segment_start_time"] = datetime.now()
-
-            try:
-                new_process = await self._start_segment(
-                    stream, str(next_segment_path), quality, segment_info
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception as start_error:
-                logger.error(
-                    f"Failed to start rotated segment for stream {stream.id} "
-                    f"({type(start_error).__name__})"
-                )
-                return False
-
-            if not new_process:
-                logger.error(f"Failed to start new segment for stream {stream.id}")
-                return False
-
-            logger.info(
-                f"Successfully rotated to segment {segment_info['segment_count']} "
-                f"for stream {stream.id}"
+    async def _cleanup_failed_rotation(
+        self,
+        process_id,
+        captured_process,
+        replacement_process,
+        segment_info,
+        reason,
+        *,
+        wait_timeout,
+    ) -> None:
+        channel_key = segment_info["upstream_channel_key"]
+        generation = segment_info["upstream_generation"]
+        try:
+            tracked_process = self.active_processes.get(process_id)
+            process = replacement_process or tracked_process
+            if process is not None and process.returncode is None:
+                if process is captured_process:
+                    process_group_id = segment_info["upstream_process_group_id"]
+                    fingerprint = segment_info["upstream_process_start_fingerprint"]
+                else:
+                    identity = await self.upstream_coordinator.inspect_process_identity(
+                        process.pid
+                    )
+                    process_group_id = identity.process_group_id
+                    fingerprint = identity.fingerprint
+                try:
+                    await self.upstream_coordinator.assert_stop_authorized(
+                        channel_key=channel_key,
+                        generation=generation,
+                        process_pid=process.pid,
+                        process_group_id=process_group_id,
+                        process_start_fingerprint=fingerprint,
+                    )
+                except PermissionError:
+                    pass
+                else:
+                    stopped = await self._terminate_process_group(
+                        process, process_group_id, wait_timeout
+                    )
+                    if stopped:
+                        async with self.lock:
+                            if self.active_processes.get(process_id) is process:
+                                del self.active_processes[process_id]
+            elif process is not None:
+                await process.wait()
+                async with self.lock:
+                    if self.active_processes.get(process_id) is process:
+                        del self.active_processes[process_id]
+        except (OSError, ProcessLookupError, KeyError, AttributeError):
+            pass
+        finally:
+            await self.upstream_coordinator.release(
+                channel_key=channel_key,
+                generation=generation,
+                reason=reason,
             )
-            return True
+            segment_info.pop("upstream_rotation_generation", None)
 
     async def monitor_process(self, process: asyncio.subprocess.Process) -> int:
         """Monitor a recording process until completion with failure detection
@@ -792,6 +1052,12 @@ class ProcessManager:
                             f"{segment_info['stream_id']}"
                         )
                         await self._finalize_segmented_recording(segment_info)
+                        if segment_info.get("upstream_channel_key"):
+                            await self.upstream_coordinator.release(
+                                channel_key=segment_info["upstream_channel_key"],
+                                generation=segment_info["upstream_generation"],
+                                reason="recording_process_exited",
+                            )
                         return 0  # Success for segmented recording
                     finally:
                         async with self.lock:
@@ -816,8 +1082,6 @@ class ProcessManager:
 
                     if stderr:
                         stderr_text = stderr.decode("utf-8", errors="replace")
-                        logger.error(f"Process stderr: {stderr_text[:1000]}")
-
                         # Parse common failure reasons
                         if (
                             "ProxyError" in stderr_text
@@ -931,42 +1195,6 @@ class ProcessManager:
                     except Exception as apprise_error:
                         logger.error(
                             f"Failed to send Apprise notification for recording_completed: {apprise_error}"
-                        )
-
-                # Log to structured logging service
-                if self.logging_service:
-                    # Get streamer name from database for logging
-                    try:
-                        from app.database import SessionLocal
-                        from app.models import Stream
-
-                        with SessionLocal() as db:
-                            # Get stream from process_id in the segment info with eager loading
-                            stream_id = process_id.split("_")[1] if process_id else None
-                            if stream_id:
-                                stream = (
-                                    db.query(Stream)
-                                    .options(joinedload(Stream.streamer))
-                                    .filter(Stream.id == int(stream_id))
-                                    .first()
-                                )
-                                if stream:
-                                    streamer = stream.streamer
-                                    if streamer:
-                                        # Get the log path for this streamer to append output
-                                        log_path = self.logging_service.get_streamlink_log_path(
-                                            streamer.username
-                                        )
-                                        self.logging_service.log_streamlink_output(
-                                            streamer_name=streamer.username,
-                                            stdout=stdout,
-                                            stderr=stderr,
-                                            exit_code=process.returncode or 0,
-                                            log_path=log_path,
-                                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"Could not log streamlink output to structured logging: {e}"
                         )
 
                 return process.returncode or 0
@@ -1433,27 +1661,59 @@ class ProcessManager:
                 )
                 return True  # Process already terminated = success, not failure
 
-            process = self.active_processes.pop(
-                process_id
-            )  # Handle segmented recording cleanup
-            if process_id in self.long_stream_processes:
-                segment_info = self.long_stream_processes[process_id]
+            process = self.active_processes[process_id]
+            segment_info = self.long_stream_processes.get(process_id)
+            if segment_info and segment_info.get("upstream_channel_key"):
+                try:
+                    await self.upstream_coordinator.assert_stop_authorized(
+                        channel_key=segment_info["upstream_channel_key"],
+                        generation=segment_info["upstream_generation"],
+                        process_pid=process.pid,
+                        process_group_id=segment_info["upstream_process_group_id"],
+                        process_start_fingerprint=segment_info[
+                            "upstream_process_start_fingerprint"
+                        ],
+                    )
+                except PermissionError:
+                    logger.warning("Refusing stale stop for process %s", process_id)
+                    return False
+
+            self.active_processes.pop(process_id)
+            if segment_info:
                 if segment_info["monitor_task"]:
                     segment_info["monitor_task"].cancel()
 
             try:
-                process.terminate()
-                await asyncio.wait_for(process.wait(), timeout=timeout)
+                if segment_info and segment_info.get("upstream_channel_key"):
+                    stopped = await self._terminate_process_group(
+                        process,
+                        segment_info["upstream_process_group_id"],
+                        timeout,
+                    )
+                    if not stopped:
+                        self.active_processes[process_id] = process
+                        return False
+                else:
+                    process.terminate()
+                    await asyncio.wait_for(process.wait(), timeout=timeout)
                 logger.info(f"Process {process_id} terminated gracefully")
 
                 # Finalize segmented recording if needed
-                if process_id in self.long_stream_processes:
-                    segment_info = self.long_stream_processes.pop(process_id)
+                if segment_info:
+                    self.long_stream_processes.pop(process_id, None)
                     await self._finalize_segmented_recording(segment_info)
+
+                if segment_info and segment_info.get("upstream_channel_key"):
+                    await self.upstream_coordinator.release(
+                        channel_key=segment_info["upstream_channel_key"],
+                        generation=segment_info["upstream_generation"],
+                        reason="recording_stopped",
+                    )
 
                 return True
             except asyncio.TimeoutError:
                 process.kill()
+                await process.wait()
                 logger.warning(f"Process {process_id} killed after timeout")
 
                 # Still try to finalize if it was segmented
@@ -1463,8 +1723,34 @@ class ProcessManager:
 
                 return True
             except Exception as e:
+                if process.returncode is None:
+                    self.active_processes[process_id] = process
                 logger.error(f"Failed to terminate process {process_id}: {e}")
                 return False
+
+    @staticmethod
+    async def _terminate_process_group(process, process_group_id, timeout) -> bool:
+        if process.returncode is not None:
+            await process.wait()
+            return True
+        try:
+            try:
+                os.killpg(process_group_id, signal.SIGTERM)
+            except ProcessLookupError:
+                process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=timeout)
+            except TimeoutError:
+                try:
+                    os.killpg(process_group_id, signal.SIGKILL)
+                except ProcessLookupError:
+                    process.kill()
+                await asyncio.wait_for(process.wait(), timeout=timeout)
+            return process.returncode is not None
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return False
 
     async def cleanup_all(self):
         """Terminate all active processes"""
@@ -1501,31 +1787,19 @@ class ProcessManager:
             # Terminate all active processes gracefully
             termination_tasks = []
 
-            # Handle regular processes
-            for stream_id, process in list(self.active_processes.items()):
+            for process_id in list(self.active_processes):
                 termination_tasks.append(
-                    self._terminate_process_gracefully(stream_id, process, timeout)
+                    self.terminate_process(process_id, timeout=timeout)
                 )
-
-            # Handle segmented processes
-            for stream_id, segment_info in list(self.long_stream_processes.items()):
-                current_process = segment_info.get("current_process")
-                if current_process:
-                    termination_tasks.append(
-                        self._terminate_process_gracefully(
-                            stream_id, current_process, timeout
-                        )
-                    )
 
             # Wait for all terminations to complete
             if termination_tasks:
                 await asyncio.gather(*termination_tasks, return_exceptions=True)
 
-            # Clear process tracking
-            self.active_processes.clear()
-            self.long_stream_processes.clear()
-
-            logger.info("✅ Process Manager graceful shutdown completed")
+            logger.info(
+                "Process Manager shutdown completed with %s fenced owners retained",
+                len(self.active_processes),
+            )
 
         except Exception as e:
             logger.error(

--- a/app/services/recording/recording_lifecycle_manager.py
+++ b/app/services/recording/recording_lifecycle_manager.py
@@ -205,6 +205,7 @@ class RecordingLifecycleManager:
             streamer_name = streamer.username if streamer else f"streamer_{streamer_id}"
             quality = kwargs.get("quality", "best")
             resume_segments_dir = kwargs.get("resume_segments_dir")
+            recovery_generation = kwargs.get("recovery_generation")
 
             # Log recording start to dedicated file
             if hasattr(self, "recording_logger"):
@@ -221,6 +222,7 @@ class RecordingLifecycleManager:
                 file_path,
                 streamer_id,
                 resume_segments_dir=resume_segments_dir,
+                recovery_generation=recovery_generation,
             )
 
             if success:
@@ -537,6 +539,7 @@ class RecordingLifecycleManager:
         file_path: str,
         streamer_id: int,
         resume_segments_dir: Optional[str] = None,
+        recovery_generation: Optional[int] = None,
     ) -> bool:
         """Start the actual recording process
 
@@ -581,7 +584,9 @@ class RecordingLifecycleManager:
                 stream=stream,
                 output_path=file_path,
                 quality="best",  # TODO: Get quality from recording settings
+                recording_id=recording_id,
                 resume_segments_dir=resume_segments_dir,
+                recovery_generation=recovery_generation,
             )
 
             success = process is not None

--- a/app/services/recording/unified_recovery_service.py
+++ b/app/services/recording/unified_recovery_service.py
@@ -1237,8 +1237,26 @@ class UnifiedRecoveryService:
                     logger.error(f"❌ Recording {recording_id} not found")
                     return False
 
-                stream_id = recording.stream_id
-                streamer_id = recording.streamer_id
+                stream = (
+                    db.query(Stream).filter(Stream.id == recording.stream_id).first()
+                )
+                if not stream or not stream.streamer:
+                    logger.error(
+                        "Recording stream or streamer not found during recovery"
+                    )
+                    return False
+                stream_id = stream.id
+                streamer_id = stream.streamer_id
+                from app.models import TwitchUpstreamLease
+
+                upstream_lease = (
+                    db.query(TwitchUpstreamLease)
+                    .filter(
+                        TwitchUpstreamLease.channel_key == stream.streamer.twitch_id,
+                        TwitchUpstreamLease.state == "RELEASED",
+                    )
+                    .first()
+                )
 
                 # CRITICAL FIX: Mark OLD recording as "stopped" BEFORE starting a new one
                 # This prevents duplicate jobs appearing in the Background Jobs UI
@@ -1255,7 +1273,19 @@ class UnifiedRecoveryService:
                 )
 
             # Start recording - this will automatically handle segment continuation
-            success = await recording_service.start_recording(stream_id, streamer_id)
+            if upstream_lease:
+                success = await recording_service.start_recording(
+                    stream_id,
+                    streamer_id,
+                    resume_segments_dir=str(segments_dir),
+                    recovery_generation=upstream_lease.generation,
+                )
+            else:
+                success = await recording_service.start_recording(
+                    stream_id,
+                    streamer_id,
+                    resume_segments_dir=str(segments_dir),
+                )
 
             if success:
                 logger.info(f"✅ Successfully resumed recording for {streamer_name}")

--- a/app/services/twitch_upstream_coordinator.py
+++ b/app/services/twitch_upstream_coordinator.py
@@ -1,0 +1,747 @@
+import asyncio
+import hashlib
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+import psutil
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models import (
+    GlobalSettings,
+    TwitchUpstreamCoordinationState,
+    TwitchUpstreamLease,
+)
+
+AUTHENTICATED_TWITCH_ACCOUNT = "streamvault-global-twitch-account"
+ACTIVE_STATES = ("STARTING", "ACTIVE", "ROTATING", "RECOVERING")
+PURPOSES = ("RECORDING", "LIVE", "ROTATION", "RECOVERY")
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    process_group_id: int
+    started_at: datetime
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class TwitchUpstreamReservation:
+    channel_key: str
+    auth_key: Optional[str]
+    owner_user_id: Optional[int]
+    recording_id: Optional[int]
+    live_session_id: Optional[str]
+    purpose: str
+    state: str
+    generation: int
+    process_pid: Optional[int] = None
+    process_group_id: Optional[int] = None
+    process_started_at: Optional[datetime] = None
+    process_start_fingerprint: Optional[str] = None
+
+
+class TwitchUpstreamConflict(RuntimeError):
+    def __init__(self, code: str, reason: str, channel_key: str) -> None:
+        super().__init__(reason)
+        self.code = code
+        self.reason = reason
+        self.channel_key = channel_key
+
+    def as_detail(self) -> dict:
+        return {
+            "code": self.code,
+            "reason": self.reason,
+            "channel_key": self.channel_key,
+            "retryable": False,
+        }
+
+
+class ProcessInspector:
+    def inspect(self, pid: int) -> ProcessIdentity:
+        process = psutil.Process(pid)
+        started_at = datetime.fromtimestamp(process.create_time(), tz=timezone.utc)
+        fingerprint = hashlib.sha256(
+            f"{pid}:{process.create_time()}".encode("ascii")
+        ).hexdigest()
+        return ProcessIdentity(
+            pid=pid,
+            process_group_id=os.getpgid(pid),
+            started_at=started_at,
+            fingerprint=fingerprint,
+        )
+
+    def is_exact_process_alive(self, **identity) -> bool:
+        pid = identity.get("process_pid")
+        fingerprint = identity.get("process_start_fingerprint")
+        if pid is None or not fingerprint:
+            return False
+        try:
+            return self.inspect(pid).fingerprint == fingerprint
+        except (OSError, psutil.Error):
+            return False
+
+
+class TwitchUpstreamCoordinator:
+    def __init__(
+        self,
+        session_factory,
+        *,
+        utc_clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        monotonic_clock: Callable[[], float],
+        process_inspector=None,
+        lease_ttl_seconds: int = 30,
+        authenticated_budget: int = 1,
+    ) -> None:
+        self._session_factory = session_factory
+        self._utcnow = utc_clock
+        self._monotonic = monotonic_clock
+        self._process_inspector = process_inspector or ProcessInspector()
+        self._lease_ttl = timedelta(seconds=lease_ttl_seconds)
+        self._authenticated_budget = authenticated_budget
+
+    async def reserve(
+        self,
+        *,
+        channel_key: str,
+        auth_key: Optional[str],
+        purpose: str,
+        owner_user_id: Optional[int] = None,
+        recording_id: Optional[int] = None,
+        live_session_id: Optional[str] = None,
+        expected_generation: Optional[int] = None,
+    ) -> TwitchUpstreamReservation:
+        return await asyncio.to_thread(
+            self._reserve,
+            channel_key,
+            auth_key,
+            purpose,
+            owner_user_id,
+            recording_id,
+            live_session_id,
+            expected_generation,
+        )
+
+    async def activate(
+        self,
+        *,
+        channel_key: str,
+        generation: int,
+        process_pid: int,
+        process_group_id: Optional[int] = None,
+        process_started_at: Optional[datetime] = None,
+        process_start_fingerprint: Optional[str] = None,
+    ) -> TwitchUpstreamReservation:
+        return await asyncio.to_thread(
+            self._activate,
+            channel_key,
+            generation,
+            process_pid,
+            process_group_id,
+            process_started_at,
+            process_start_fingerprint,
+        )
+
+    async def heartbeat(self, *, channel_key: str, generation: int) -> bool:
+        return await asyncio.to_thread(self._heartbeat, channel_key, generation)
+
+    async def begin_rotation(
+        self, *, channel_key: str, generation: int
+    ) -> TwitchUpstreamReservation:
+        return await asyncio.to_thread(self._begin_rotation, channel_key, generation)
+
+    async def handoff_rotation(
+        self,
+        *,
+        channel_key: str,
+        generation: int,
+        process_pid: int,
+        process_group_id: Optional[int] = None,
+        process_started_at: Optional[datetime] = None,
+        process_start_fingerprint: Optional[str] = None,
+        purpose: str = "RECORDING",
+    ) -> TwitchUpstreamReservation:
+        return await asyncio.to_thread(
+            self._handoff_rotation,
+            channel_key,
+            generation,
+            process_pid,
+            process_group_id,
+            process_started_at,
+            process_start_fingerprint,
+            purpose,
+        )
+
+    async def release(
+        self,
+        *,
+        channel_key: str,
+        generation: int,
+        reason: str,
+    ) -> bool:
+        return await asyncio.to_thread(
+            self._release, channel_key, generation, reason[:64]
+        )
+
+    async def reconcile(self, *, batch_size: int = 100) -> int:
+        return await asyncio.to_thread(self._reconcile, batch_size)
+
+    async def inspect_process_identity(self, process_pid: int) -> ProcessIdentity:
+        return await asyncio.to_thread(self._process_inspector.inspect, process_pid)
+
+    async def assert_stop_authorized(
+        self,
+        *,
+        channel_key: str,
+        generation: int,
+        process_pid: int,
+        process_group_id: int,
+        process_start_fingerprint: str,
+        expected_purpose: Optional[str] = None,
+        requesting_owner_user_id: Optional[int] = None,
+    ) -> TwitchUpstreamReservation:
+        return await asyncio.to_thread(
+            self._assert_stop_authorized,
+            channel_key,
+            generation,
+            process_pid,
+            process_group_id,
+            process_start_fingerprint,
+            expected_purpose,
+            requesting_owner_user_id,
+        )
+
+    async def assert_exited_process_cleanup_authorized(
+        self,
+        *,
+        channel_key: str,
+        generation: int,
+        process_pid: int,
+        process_group_id: int,
+        process_start_fingerprint: str,
+        expected_purpose: str,
+        requesting_owner_user_id: Optional[int],
+        expected_live_session_id: str,
+    ) -> TwitchUpstreamReservation:
+        return await asyncio.to_thread(
+            self._assert_exited_process_cleanup_authorized,
+            channel_key,
+            generation,
+            process_pid,
+            process_group_id,
+            process_start_fingerprint,
+            expected_purpose,
+            requesting_owner_user_id,
+            expected_live_session_id,
+        )
+
+    def _reserve(
+        self,
+        channel_key,
+        auth_key,
+        purpose,
+        owner_user_id,
+        recording_id,
+        live_session_id,
+        expected_generation,
+    ):
+        if not channel_key or len(channel_key) > 255:
+            raise ValueError("channel_key must be a non-empty Twitch channel ID")
+        if purpose not in PURPOSES:
+            raise ValueError(f"Unsupported upstream purpose: {purpose}")
+        if purpose == "ROTATION":
+            raise ValueError("ROTATION must use begin_rotation")
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            self._reconcile_expired(db, now, 100)
+            existing = db.execute(
+                select(TwitchUpstreamLease).where(
+                    TwitchUpstreamLease.channel_key == channel_key
+                )
+            ).scalar_one_or_none()
+
+            if existing and existing.state in ACTIVE_STATES:
+                if (
+                    existing.state == "ACTIVE"
+                    and existing.purpose == "LIVE"
+                    and purpose == "LIVE"
+                    and existing.owner_user_id == owner_user_id
+                    and existing.auth_key == auth_key
+                ):
+                    db.commit()
+                    return self._snapshot(existing)
+                if (
+                    existing.purpose == "LIVE"
+                    and purpose == "LIVE"
+                    and existing.owner_user_id == owner_user_id
+                    and existing.auth_key != auth_key
+                ):
+                    self._conflict(
+                        "twitch_upstream_live_policy_conflict",
+                        "live_policy_mismatch",
+                        channel_key,
+                    )
+                self._conflict(
+                    "twitch_upstream_channel_conflict",
+                    "channel_already_reserved",
+                    channel_key,
+                )
+
+            if purpose == "RECOVERY":
+                if not existing or expected_generation != existing.generation:
+                    self._conflict(
+                        "twitch_upstream_channel_conflict",
+                        "recovery_generation_mismatch",
+                        channel_key,
+                    )
+                expired = db.execute(
+                    select(TwitchUpstreamLease.id).where(
+                        TwitchUpstreamLease.id == existing.id,
+                        TwitchUpstreamLease.expires_at < now,
+                    )
+                ).scalar_one_or_none()
+                identity = {
+                    "process_pid": existing.process_pid,
+                    "process_group_id": existing.process_group_id,
+                    "process_started_at": existing.process_started_at,
+                    "process_start_fingerprint": existing.process_start_fingerprint,
+                }
+                if (
+                    existing.state != "RELEASED"
+                    or existing.release_reason != "reconciled_stale_process"
+                    or expired is None
+                    or self._process_inspector.is_exact_process_alive(**identity)
+                ):
+                    self._conflict(
+                        "twitch_upstream_channel_conflict",
+                        "recovery_precondition_failed",
+                        channel_key,
+                    )
+
+            active_count = (
+                db.query(TwitchUpstreamLease)
+                .filter(TwitchUpstreamLease.state.in_(ACTIVE_STATES))
+                .count()
+            )
+            if auth_key is not None:
+                authenticated_count = (
+                    db.query(TwitchUpstreamLease)
+                    .filter(
+                        TwitchUpstreamLease.auth_key.is_not(None),
+                        TwitchUpstreamLease.state.in_(ACTIVE_STATES),
+                    )
+                    .count()
+                )
+                if authenticated_count >= self._authenticated_budget:
+                    self._conflict(
+                        "twitch_upstream_authenticated_budget_exhausted",
+                        "authenticated_budget_exhausted",
+                        channel_key,
+                    )
+
+            settings = db.query(GlobalSettings).first()
+            total_budget = settings.twitch_max_concurrent_upstreams if settings else 5
+            if active_count >= total_budget:
+                self._conflict(
+                    "twitch_upstream_total_budget_exhausted",
+                    "total_budget_exhausted",
+                    channel_key,
+                )
+
+            generation = existing.generation + 1 if existing else 1
+            state = "RECOVERING" if purpose == "RECOVERY" else "STARTING"
+            if existing:
+                lease = existing
+                lease.auth_key = auth_key
+                lease.owner_user_id = owner_user_id
+                lease.recording_id = recording_id
+                lease.live_session_id = live_session_id
+                lease.purpose = purpose
+                lease.state = state
+                lease.generation = generation
+            else:
+                lease = TwitchUpstreamLease(
+                    channel_key=channel_key,
+                    created_at=now,
+                )
+                db.add(lease)
+                lease.auth_key = auth_key
+                lease.owner_user_id = owner_user_id
+                lease.recording_id = recording_id
+                lease.live_session_id = live_session_id
+                lease.purpose = purpose
+                lease.state = state
+                lease.generation = generation
+            lease.process_pid = None
+            lease.process_group_id = None
+            lease.process_started_at = None
+            lease.process_start_fingerprint = None
+            lease.reserved_at = now
+            lease.activated_at = None
+            lease.heartbeat_at = now
+            lease.expires_at = now + self._lease_ttl
+            lease.released_at = None
+            lease.release_reason = None
+            lease.updated_at = now
+            db.flush()
+            result = self._snapshot(lease)
+            db.commit()
+            return result
+        except TwitchUpstreamConflict:
+            db.rollback()
+            raise
+        except IntegrityError:
+            db.rollback()
+            self._conflict(
+                "twitch_upstream_channel_conflict",
+                "channel_already_reserved",
+                channel_key,
+            )
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _activate(
+        self,
+        channel_key,
+        generation,
+        process_pid,
+        process_group_id,
+        process_started_at,
+        process_start_fingerprint,
+    ):
+        identity = self._resolve_identity(
+            process_pid,
+            process_group_id,
+            process_started_at,
+            process_start_fingerprint,
+        )
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            lease = self._lease_for_generation(db, channel_key, generation)
+            if lease.state not in ("STARTING", "RECOVERING"):
+                raise PermissionError("lease is not awaiting activation")
+            self._set_active_identity(lease, identity, now)
+            db.commit()
+            return self._snapshot(lease)
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _heartbeat(self, channel_key, generation):
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            lease = self._lease_for_generation(db, channel_key, generation)
+            if lease.state not in ACTIVE_STATES:
+                return False
+            lease.heartbeat_at = now
+            lease.expires_at = now + self._lease_ttl
+            lease.updated_at = now
+            db.commit()
+            return True
+        except (LookupError, PermissionError):
+            db.rollback()
+            return False
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _begin_rotation(self, channel_key, generation):
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            lease = self._lease_for_generation(db, channel_key, generation)
+            if lease.state != "ACTIVE":
+                raise PermissionError("only an active lease may rotate")
+            lease.generation += 1
+            lease.purpose = "ROTATION"
+            lease.state = "ROTATING"
+            lease.heartbeat_at = now
+            lease.expires_at = now + self._lease_ttl
+            lease.updated_at = now
+            db.commit()
+            return self._snapshot(lease)
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _handoff_rotation(
+        self,
+        channel_key,
+        generation,
+        process_pid,
+        process_group_id,
+        process_started_at,
+        process_start_fingerprint,
+        purpose,
+    ):
+        if purpose not in ("RECORDING", "LIVE"):
+            raise ValueError("rotation handoff purpose must be RECORDING or LIVE")
+        identity = self._resolve_identity(
+            process_pid,
+            process_group_id,
+            process_started_at,
+            process_start_fingerprint,
+        )
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            lease = self._lease_for_generation(db, channel_key, generation)
+            if lease.state != "ROTATING":
+                raise PermissionError("lease is not rotating")
+            lease.purpose = purpose
+            self._set_active_identity(lease, identity, now)
+            db.commit()
+            return self._snapshot(lease)
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _release(self, channel_key, generation, reason):
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            lease = db.execute(
+                select(TwitchUpstreamLease).where(
+                    TwitchUpstreamLease.channel_key == channel_key,
+                    TwitchUpstreamLease.generation == generation,
+                    TwitchUpstreamLease.state.in_(ACTIVE_STATES),
+                )
+            ).scalar_one_or_none()
+            if not lease:
+                db.rollback()
+                return False
+            self._mark_released(lease, now, reason)
+            db.commit()
+            return True
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _reconcile(self, batch_size):
+        now = self._utcnow()
+        db = self._session_factory()
+        try:
+            self._begin_guarded_transaction(db)
+            self._lock_guard(db, now)
+            released = self._reconcile_expired(db, now, batch_size)
+            db.commit()
+            return released
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def _assert_stop_authorized(
+        self,
+        channel_key,
+        generation,
+        process_pid,
+        process_group_id,
+        process_start_fingerprint,
+        expected_purpose,
+        requesting_owner_user_id,
+    ):
+        with self._session_factory() as db:
+            lease = self._lease_for_generation(db, channel_key, generation)
+            identity = {
+                "process_pid": lease.process_pid,
+                "process_group_id": lease.process_group_id,
+                "process_started_at": lease.process_started_at,
+                "process_start_fingerprint": lease.process_start_fingerprint,
+            }
+            if (
+                lease.state not in ACTIVE_STATES
+                or (
+                    lease.process_pid,
+                    lease.process_group_id,
+                    lease.process_start_fingerprint,
+                )
+                != (process_pid, process_group_id, process_start_fingerprint)
+                or (
+                    expected_purpose is not None
+                    and (
+                        lease.purpose != expected_purpose
+                        or lease.owner_user_id != requesting_owner_user_id
+                    )
+                )
+                or not self._process_inspector.is_exact_process_alive(**identity)
+            ):
+                raise PermissionError("stale or foreign process owner")
+            return self._snapshot(lease)
+
+    def _assert_exited_process_cleanup_authorized(
+        self,
+        channel_key,
+        generation,
+        process_pid,
+        process_group_id,
+        process_start_fingerprint,
+        expected_purpose,
+        requesting_owner_user_id,
+        expected_live_session_id,
+    ):
+        with self._session_factory() as db:
+            lease = self._lease_for_generation(db, channel_key, generation)
+            identity = {
+                "process_pid": lease.process_pid,
+                "process_group_id": lease.process_group_id,
+                "process_started_at": lease.process_started_at,
+                "process_start_fingerprint": lease.process_start_fingerprint,
+            }
+            if (
+                lease.state not in ACTIVE_STATES
+                or (
+                    lease.process_pid,
+                    lease.process_group_id,
+                    lease.process_start_fingerprint,
+                )
+                != (process_pid, process_group_id, process_start_fingerprint)
+                or lease.purpose != expected_purpose
+                or lease.owner_user_id != requesting_owner_user_id
+                or lease.live_session_id != expected_live_session_id
+                or self._process_inspector.is_exact_process_alive(**identity)
+            ):
+                raise PermissionError("stale, live, or foreign process owner")
+            return self._snapshot(lease)
+
+    def _begin_guarded_transaction(self, db):
+        if db.get_bind().dialect.name == "sqlite":
+            db.connection().exec_driver_sql("BEGIN IMMEDIATE")
+        else:
+            db.begin()
+
+    def _lock_guard(self, db, now):
+        query = select(TwitchUpstreamCoordinationState).where(
+            TwitchUpstreamCoordinationState.id == 1
+        )
+        if db.get_bind().dialect.name == "postgresql":
+            query = query.with_for_update()
+        guard = db.execute(query).scalar_one_or_none()
+        if guard is None:
+            guard = TwitchUpstreamCoordinationState(
+                id=1, lock_version=0, updated_at=now
+            )
+            db.add(guard)
+            db.flush()
+        guard.lock_version += 1
+        guard.updated_at = now
+
+    def _reconcile_expired(self, db, now, batch_size):
+        leases = db.execute(
+            select(TwitchUpstreamLease)
+            .where(
+                TwitchUpstreamLease.state.in_(ACTIVE_STATES),
+                TwitchUpstreamLease.expires_at < now,
+            )
+            .order_by(TwitchUpstreamLease.expires_at, TwitchUpstreamLease.id)
+            .limit(batch_size)
+        ).scalars()
+        released = 0
+        for lease in leases:
+            identity = {
+                "process_pid": lease.process_pid,
+                "process_group_id": lease.process_group_id,
+                "process_started_at": lease.process_started_at,
+                "process_start_fingerprint": lease.process_start_fingerprint,
+            }
+            if not self._process_inspector.is_exact_process_alive(**identity):
+                self._mark_released(lease, now, "reconciled_stale_process")
+                released += 1
+        return released
+
+    def _resolve_identity(self, pid, group_id, started_at, fingerprint):
+        if group_id is None or started_at is None or fingerprint is None:
+            return self._process_inspector.inspect(pid)
+        return ProcessIdentity(pid, group_id, started_at, fingerprint)
+
+    def _set_active_identity(self, lease, identity, now):
+        lease.state = "ACTIVE"
+        lease.process_pid = identity.pid
+        lease.process_group_id = identity.process_group_id
+        lease.process_started_at = identity.started_at
+        lease.process_start_fingerprint = identity.fingerprint
+        lease.activated_at = now
+        lease.heartbeat_at = now
+        lease.expires_at = now + self._lease_ttl
+        lease.updated_at = now
+
+    @staticmethod
+    def _lease_for_generation(db, channel_key, generation):
+        lease = db.execute(
+            select(TwitchUpstreamLease).where(
+                TwitchUpstreamLease.channel_key == channel_key,
+                TwitchUpstreamLease.generation == generation,
+            )
+        ).scalar_one_or_none()
+        if lease is None:
+            raise PermissionError("stale lease generation")
+        return lease
+
+    @staticmethod
+    def _mark_released(lease, now, reason):
+        lease.state = "RELEASED"
+        lease.released_at = now
+        lease.release_reason = reason[:64]
+        lease.updated_at = now
+
+    @staticmethod
+    def _snapshot(lease):
+        return TwitchUpstreamReservation(
+            channel_key=lease.channel_key,
+            auth_key=lease.auth_key,
+            owner_user_id=lease.owner_user_id,
+            recording_id=lease.recording_id,
+            live_session_id=lease.live_session_id,
+            purpose=lease.purpose,
+            state=lease.state,
+            generation=lease.generation,
+            process_pid=lease.process_pid,
+            process_group_id=lease.process_group_id,
+            process_started_at=lease.process_started_at,
+            process_start_fingerprint=lease.process_start_fingerprint,
+        )
+
+    @staticmethod
+    def _conflict(code, reason, channel_key):
+        raise TwitchUpstreamConflict(code, reason, channel_key)
+
+
+from app.database import SessionLocal  # noqa: E402
+
+twitch_upstream_coordinator = TwitchUpstreamCoordinator(
+    SessionLocal,
+    monotonic_clock=time.monotonic,
+)

--- a/migrations/040_add_twitch_upstream_leases.py
+++ b/migrations/040_add_twitch_upstream_leases.py
@@ -1,0 +1,150 @@
+"""Add durable Twitch upstream leases and their transaction guard."""
+
+import logging
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    inspect,
+    text,
+)
+
+from app.database import engine
+
+logger = logging.getLogger("streamvault")
+
+
+def _tables(metadata):
+    Table("users", metadata, Column("id", Integer, primary_key=True))
+    Table("recordings", metadata, Column("id", Integer, primary_key=True))
+    state = Table(
+        "twitch_upstream_coordination_state",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("lock_version", Integer, nullable=False, server_default="0"),
+        Column("updated_at", DateTime(timezone=True), nullable=False),
+        CheckConstraint("id = 1", name="ck_twitch_upstream_coordination_singleton"),
+    )
+    leases = Table(
+        "twitch_upstream_leases",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("channel_key", String(255), nullable=False),
+        Column("auth_key", String(128), nullable=True),
+        Column(
+            "owner_user_id",
+            Integer,
+            ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        Column(
+            "recording_id",
+            Integer,
+            ForeignKey("recordings.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        Column("live_session_id", String(64), nullable=True),
+        Column("purpose", String(16), nullable=False),
+        Column("state", String(16), nullable=False),
+        Column("generation", Integer, nullable=False),
+        Column("process_pid", Integer, nullable=True),
+        Column("process_group_id", Integer, nullable=True),
+        Column("process_started_at", DateTime(timezone=True), nullable=True),
+        Column("process_start_fingerprint", String(128), nullable=True),
+        Column("reserved_at", DateTime(timezone=True), nullable=False),
+        Column("activated_at", DateTime(timezone=True), nullable=True),
+        Column("heartbeat_at", DateTime(timezone=True), nullable=False),
+        Column("expires_at", DateTime(timezone=True), nullable=False),
+        Column("released_at", DateTime(timezone=True), nullable=True),
+        Column("release_reason", String(64), nullable=True),
+        Column("created_at", DateTime(timezone=True), nullable=False),
+        Column("updated_at", DateTime(timezone=True), nullable=False),
+        CheckConstraint(
+            "purpose IN ('RECORDING', 'LIVE', 'ROTATION', 'RECOVERY')",
+            name="ck_twitch_upstream_leases_purpose",
+        ),
+        CheckConstraint(
+            "state IN ('STARTING', 'ACTIVE', 'ROTATING', 'RECOVERING', 'RELEASED')",
+            name="ck_twitch_upstream_leases_state",
+        ),
+    )
+    Index(
+        "ix_twitch_upstream_leases_state_expiry",
+        leases.c.state,
+        leases.c.expires_at,
+    )
+    Index("ix_twitch_upstream_leases_auth_state", leases.c.auth_key, leases.c.state)
+    Index(
+        "ix_twitch_upstream_leases_owner_state",
+        leases.c.owner_user_id,
+        leases.c.state,
+    )
+    Index("ix_twitch_upstream_leases_recording_id", leases.c.recording_id)
+    Index(
+        "uq_twitch_upstream_leases_channel_key",
+        leases.c.channel_key,
+        unique=True,
+    )
+    return state, leases
+
+
+def upgrade(target_engine=None):
+    target = target_engine or engine
+    inspector = inspect(target)
+    if "global_settings" in inspector.get_table_names() and not any(
+        column["name"] == "twitch_max_concurrent_upstreams"
+        for column in inspector.get_columns("global_settings")
+    ):
+        with target.begin() as connection:
+            connection.execute(
+                text(
+                    "ALTER TABLE global_settings ADD COLUMN "
+                    "twitch_max_concurrent_upstreams INTEGER NOT NULL DEFAULT 5"
+                )
+            )
+
+    metadata = MetaData()
+    state, _leases = _tables(metadata)
+    metadata.create_all(target, tables=[state, _leases], checkfirst=True)
+    with target.begin() as connection:
+        guard_exists = connection.execute(
+            text("SELECT 1 FROM twitch_upstream_coordination_state WHERE id = 1")
+        ).first()
+        if not guard_exists:
+            connection.execute(
+                state.insert().values(
+                    id=1, lock_version=0, updated_at=text("CURRENT_TIMESTAMP")
+                )
+            )
+    logger.info("Migration 040: Twitch upstream coordination schema created")
+
+
+def downgrade(target_engine=None):
+    target = target_engine or engine
+    metadata = MetaData()
+    state, leases = _tables(metadata)
+    with target.begin() as connection:
+        if "twitch_upstream_leases" in inspect(connection).get_table_names():
+            active_lease = connection.execute(
+                text(
+                    "SELECT 1 FROM twitch_upstream_leases "
+                    "WHERE state IN ('STARTING', 'ACTIVE', 'ROTATING', 'RECOVERING') "
+                    "LIMIT 1"
+                )
+            ).first()
+            if active_lease:
+                raise RuntimeError(
+                    "Cannot downgrade while active Twitch upstream leases exist"
+                )
+            for index in list(leases.indexes):
+                index.drop(connection, checkfirst=True)
+            leases.drop(connection, checkfirst=True)
+        state.drop(connection, checkfirst=True)
+    logger.info("Migration 040: Twitch upstream coordination tables dropped")

--- a/tests/test_live_routes.py
+++ b/tests/test_live_routes.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.routes import live as live_routes
+from app.services.live_streaming_service import TwitchUpstreamStopForbidden
+from app.services.twitch_upstream_coordinator import TwitchUpstreamConflict
+
+
+class JsonRequest:
+    headers = {"content-type": "application/json"}
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def json(self):
+        return self.payload
+
+
+class StreamerQuery:
+    def __init__(self, streamers):
+        self.streamers = streamers
+
+    def all(self):
+        return self.streamers
+
+    def filter(self, *args):
+        return self
+
+    def first(self):
+        return self.streamers[0] if self.streamers else None
+
+
+class Database:
+    def __init__(self, streamers):
+        self.streamers = streamers
+
+    def query(self, model):
+        return StreamerQuery(self.streamers)
+
+
+@pytest.mark.asyncio
+async def test_start_route_normalizes_name_and_returns_idempotency(monkeypatch):
+    streamer = SimpleNamespace(username="HandOfBlood", twitch_id="stable-42")
+    calls = []
+
+    class Service:
+        async def start(self):
+            pass
+
+        async def start_stream(self, **values):
+            calls.append(values)
+            return SimpleNamespace(session_id="existing", idempotent=True)
+
+        def get_session(self, session_id):
+            return SimpleNamespace(playback_token="response-only-token")
+
+        @staticmethod
+        def _normalize_supported_codecs(codecs):
+            return codecs
+
+    monkeypatch.setattr(live_routes, "live_streaming_service", Service())
+    response = await live_routes.start_live_stream(
+        "  handofblood  ",
+        JsonRequest(
+            {
+                "quality": "720p",
+                "supported_codecs": "h264,h265",
+                "enhanced_quality": True,
+            }
+        ),
+        db=Database([streamer]),
+        current_user=SimpleNamespace(id=7),
+    )
+
+    assert calls == [
+        {
+            "streamer_name": "HandOfBlood",
+            "channel_key": "stable-42",
+            "quality": "720p",
+            "supported_codecs": "h264,h265",
+            "user_id": "7",
+            "enhanced_quality": True,
+        }
+    ]
+    assert response == {
+        "success": True,
+        "session_id": "existing",
+        "streamer_name": "HandOfBlood",
+        "quality": "720p",
+        "supported_codecs": "h264,h265",
+        "playlist_url": (
+            "/api/live/stream/existing/playlist.m3u8?token=response-only-token"
+        ),
+        "idempotent": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_route_returns_exact_coordinator_conflict(monkeypatch):
+    streamer = SimpleNamespace(username="streamer", twitch_id="stable-43")
+
+    class Service:
+        async def start(self):
+            pass
+
+        async def start_stream(self, **values):
+            raise TwitchUpstreamConflict(
+                "twitch_upstream_authenticated_budget_exhausted",
+                "authenticated_budget_exhausted",
+                values["channel_key"],
+            )
+
+    monkeypatch.setattr(live_routes, "live_streaming_service", Service())
+    with pytest.raises(HTTPException) as raised:
+        await live_routes.start_live_stream(
+            "streamer",
+            JsonRequest({"enhanced_quality": True}),
+            db=Database([streamer]),
+            current_user=SimpleNamespace(id=7),
+        )
+
+    assert raised.value.status_code == 409
+    assert raised.value.detail == {
+        "code": "twitch_upstream_authenticated_budget_exhausted",
+        "reason": "authenticated_budget_exhausted",
+        "channel_key": "stable-43",
+        "retryable": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stop_route_rejects_foreign_user_without_stopping(monkeypatch):
+    stop_calls = []
+
+    class Service:
+        def get_session(self, session_id):
+            return SimpleNamespace(user_id="8")
+
+        async def stop_stream(self, session_id, requesting_user_id):
+            stop_calls.append((session_id, requesting_user_id))
+            raise TwitchUpstreamStopForbidden("not_lease_owner")
+
+    monkeypatch.setattr(live_routes, "live_streaming_service", Service())
+    with pytest.raises(HTTPException) as raised:
+        await live_routes.stop_live_stream(
+            "foreign-session", current_user=SimpleNamespace(id=7)
+        )
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail == {
+        "code": "twitch_upstream_stop_forbidden",
+        "reason": "not_lease_owner",
+    }
+    assert stop_calls == [("foreign-session", "7")]

--- a/tests/test_live_streaming.py
+++ b/tests/test_live_streaming.py
@@ -1,14 +1,17 @@
 """
 Tests for the Live Streaming Service.
 
-Pure unit tests — no database imports, no pytest-asyncio.
+Pure unit tests, no database imports, no pytest-asyncio.
 Tests only logic that doesn't require external services.
 """
 
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 
 def test_live_stream_session_properties():
@@ -270,3 +273,339 @@ def test_live_proxy_lookup_exception_does_not_reach_diagnostics(monkeypatch, cap
     assert not any(arg.startswith("--http-proxy=") for arg in command)
     assert "Could not get proxy" in caplog.text
     assert proxy_url not in caplog.text
+
+
+def test_anonymous_live_does_not_request_twitch_token(monkeypatch):
+    from app.services import live_streaming_service
+
+    class ForbiddenTokenService:
+        def __init__(self, db):
+            raise AssertionError("anonymous Live requested a Twitch token")
+
+    async def no_proxy():
+        return None
+
+    monkeypatch.setattr(
+        live_streaming_service, "TwitchTokenService", ForbiddenTokenService
+    )
+    monkeypatch.setattr(
+        live_streaming_service.proxy_health_service, "get_best_proxy", no_proxy
+    )
+
+    service = live_streaming_service.LiveStreamingService()
+    command = asyncio.run(
+        service._build_streamlink_command(
+            "streamer", "best", supported_codecs="h264,h265"
+        )
+    )
+
+    assert not any(argument.startswith("--twitch-api-header=") for argument in command)
+
+
+def test_enhanced_live_requests_twitch_token_explicitly(monkeypatch):
+    from app.services import live_streaming_service
+
+    calls = []
+
+    class TokenService:
+        def __init__(self, db):
+            calls.append("created")
+
+        async def get_valid_access_token(self):
+            calls.append("requested")
+            return "local-test-token"
+
+    async def no_proxy():
+        return None
+
+    monkeypatch.setattr(live_streaming_service, "TwitchTokenService", TokenService)
+    monkeypatch.setattr(
+        live_streaming_service.proxy_health_service, "get_best_proxy", no_proxy
+    )
+
+    service = live_streaming_service.LiveStreamingService()
+    command = asyncio.run(
+        service._build_streamlink_command(
+            "streamer",
+            "best",
+            supported_codecs="h264",
+            enhanced_quality=True,
+        )
+    )
+
+    assert calls == ["created", "requested"]
+    assert any(argument.startswith("--twitch-api-header=") for argument in command)
+
+
+@pytest.mark.asyncio
+async def test_live_reserves_before_children_and_releases_on_cancellation(
+    monkeypatch, tmp_path
+):
+    from app.services import live_streaming_service
+
+    calls = []
+    activated = asyncio.Event()
+    playlist_wait = asyncio.Event()
+
+    class Coordinator:
+        async def reserve(self, **values):
+            calls.append(("reserve", values))
+            return SimpleNamespace(
+                channel_key=values["channel_key"],
+                generation=1,
+                live_session_id=values["live_session_id"],
+            )
+
+        async def activate(self, **values):
+            calls.append(("activate", values))
+            activated.set()
+            return SimpleNamespace(
+                process_group_id=values["process_group_id"],
+                process_started_at=datetime.utcnow(),
+                process_start_fingerprint="birth-302",
+            )
+
+        async def assert_stop_authorized(self, **values):
+            calls.append(("authorize-stop", values))
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
+
+    class Process:
+        def __init__(self, pid):
+            self.pid = pid
+            self.returncode = None
+            self.stdout = None
+            self.stderr = None
+            self.stdin = None
+            self.terminate_calls = 0
+            self.kill_calls = 0
+
+        def terminate(self):
+            self.terminate_calls += 1
+            self.returncode = -15
+
+        def kill(self):
+            self.kill_calls += 1
+            self.returncode = -9
+
+        async def wait(self):
+            return self.returncode
+
+    processes = [Process(301), Process(302)]
+    subprocess_kwargs = []
+
+    async def create_subprocess(*args, **kwargs):
+        assert calls and calls[0][0] == "reserve"
+        subprocess_kwargs.append(kwargs)
+        return processes[len(subprocess_kwargs) - 1]
+
+    async def wait_for_playlist(*args, **kwargs):
+        await playlist_wait.wait()
+        return True
+
+    async def command(*args, **kwargs):
+        return ["local-streamlink-fixture"]
+
+    monkeypatch.setattr(live_streaming_service.shutil, "which", lambda path: path)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+    monkeypatch.setattr(live_streaming_service.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(live_streaming_service.os, "killpg", lambda pgid, sig: None)
+
+    service = live_streaming_service.LiveStreamingService(
+        coordinator=Coordinator(), output_root=tmp_path
+    )
+    service._wait_for_playlist = wait_for_playlist
+    service._build_streamlink_command = command
+
+    start = asyncio.create_task(
+        service.start_stream(
+            streamer_name="streamer",
+            channel_key="stable-channel-id",
+            user_id="7",
+        )
+    )
+    await activated.wait()
+    start.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start
+
+    assert [name for name, _values in calls] == [
+        "reserve",
+        "activate",
+        "authorize-stop",
+        "release",
+    ]
+    assert all(options["start_new_session"] is True for options in subprocess_kwargs)
+    assert all(process.returncode is not None for process in processes)
+
+
+@pytest.mark.asyncio
+async def test_live_stop_requires_persisted_live_owner_before_signaling(tmp_path):
+    from app.services.live_streaming_service import (
+        LiveStreamSession,
+        LiveStreamingService,
+        TwitchUpstreamStopForbidden,
+    )
+
+    calls = []
+
+    class Coordinator:
+        async def assert_stop_authorized(self, **values):
+            calls.append(("authorize", values))
+            raise PermissionError("durable owner mismatch")
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
+
+    streamlink_process = SimpleNamespace(pid=701, returncode=None)
+    ffmpeg_process = SimpleNamespace(pid=702, returncode=None)
+    session = LiveStreamSession(
+        session_id="session-7",
+        streamer_name="streamer",
+        quality="best",
+        streamlink_process=streamlink_process,
+        ffmpeg_process=ffmpeg_process,
+        output_dir=tmp_path,
+        user_id="7",
+        channel_key="live-stop-channel",
+        lease_generation=3,
+        process_group_id=701,
+        process_start_fingerprint="birth-701",
+    )
+    service = LiveStreamingService(coordinator=Coordinator(), output_root=tmp_path)
+    service.sessions[session.session_id] = session
+    service.user_sessions = {"7": {session.session_id}}
+
+    async def forbidden_reap(process):
+        raise AssertionError("unauthorized process was signaled")
+
+    service._reap_process = forbidden_reap
+
+    with pytest.raises(TwitchUpstreamStopForbidden):
+        await service.stop_stream(session.session_id, requesting_user_id="7")
+
+    assert calls == [
+        (
+            "authorize",
+            {
+                "channel_key": "live-stop-channel",
+                "generation": 3,
+                "process_pid": 701,
+                "process_group_id": 701,
+                "process_start_fingerprint": "birth-701",
+                "expected_purpose": "LIVE",
+                "requesting_owner_user_id": 7,
+            },
+        )
+    ]
+    assert session.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_live_monitor_releases_dead_leader_without_signaling_reused_pid(
+    monkeypatch, tmp_path
+):
+    from app.services import live_streaming_service
+    from app.services.live_streaming_service import (
+        LiveStreamSession,
+        LiveStreamingService,
+    )
+
+    calls = []
+
+    class Coordinator:
+        async def heartbeat(self, **values):
+            calls.append(("heartbeat", values))
+            return True
+
+        async def assert_stop_authorized(self, **values):
+            raise AssertionError("dead leader used the manual stop authorization path")
+
+        async def assert_exited_process_cleanup_authorized(self, **values):
+            calls.append(("authorize-exited-cleanup", values))
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
+
+    class Process:
+        def __init__(self, pid, returncode):
+            self.pid = pid
+            self.returncode = returncode
+            self.kill_calls = 0
+
+        def kill(self):
+            self.kill_calls += 1
+            self.returncode = -9
+
+        async def wait(self):
+            return self.returncode
+
+    streamlink_process = Process(701, 1)
+    ffmpeg_process = Process(702, None)
+    session = LiveStreamSession(
+        session_id="session-7",
+        streamer_name="streamer",
+        quality="best",
+        streamlink_process=streamlink_process,
+        ffmpeg_process=ffmpeg_process,
+        output_dir=tmp_path,
+        user_id="7",
+        channel_key="live-monitor-channel",
+        lease_generation=3,
+        process_group_id=701,
+        process_start_fingerprint="birth-701",
+    )
+    service = LiveStreamingService(coordinator=Coordinator(), output_root=tmp_path)
+    service.sessions[session.session_id] = session
+    service.user_sessions = {"7": {session.session_id}}
+
+    signaled_process_groups = []
+
+    def kill_process_group(process_group_id, sig):
+        signaled_process_groups.append(process_group_id)
+        if process_group_id == ffmpeg_process.pid:
+            ffmpeg_process.returncode = -sig
+
+    monkeypatch.setattr(
+        live_streaming_service.os, "getpgid", lambda process_id: process_id
+    )
+    monkeypatch.setattr(live_streaming_service.os, "killpg", kill_process_group)
+
+    await service._monitor_session(session.session_id)
+
+    assert calls == [
+        (
+            "heartbeat",
+            {"channel_key": "live-monitor-channel", "generation": 3},
+        ),
+        (
+            "authorize-exited-cleanup",
+            {
+                "channel_key": "live-monitor-channel",
+                "generation": 3,
+                "process_pid": 701,
+                "process_group_id": 701,
+                "process_start_fingerprint": "birth-701",
+                "expected_purpose": "LIVE",
+                "requesting_owner_user_id": 7,
+                "expected_live_session_id": "session-7",
+            },
+        ),
+        (
+            "release",
+            {
+                "channel_key": "live-monitor-channel",
+                "generation": 3,
+                "reason": "live_stopped",
+            },
+        ),
+    ]
+    assert signaled_process_groups == [702]
+    assert streamlink_process.kill_calls == 0
+    assert session.session_id not in service.sessions
+    assert session.session_id not in service.user_sessions["7"]

--- a/tests/test_migration_040_twitch_upstream_leases.py
+++ b/tests/test_migration_040_twitch_upstream_leases.py
@@ -1,0 +1,123 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+MIGRATION_NAME = "040_add_twitch_upstream_leases.py"
+MIGRATION_PATH = Path(__file__).resolve().parents[1] / "migrations" / MIGRATION_NAME
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_040", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_repeat_downgrade_and_reupgrade(tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'migration_040.db'}", future=True)
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY)"))
+        connection.execute(text("CREATE TABLE recordings (id INTEGER PRIMARY KEY)"))
+        connection.execute(
+            text("CREATE TABLE global_settings (id INTEGER PRIMARY KEY)")
+        )
+
+    migration = _load_migration()
+    migration.upgrade(engine)
+    migration.upgrade(engine)
+
+    inspector = inspect(engine)
+    assert "twitch_upstream_leases" in inspector.get_table_names()
+    assert "twitch_upstream_coordination_state" in inspector.get_table_names()
+    assert "twitch_max_concurrent_upstreams" in {
+        column["name"] for column in inspector.get_columns("global_settings")
+    }
+    indexes = {
+        index["name"]: index
+        for index in inspector.get_indexes("twitch_upstream_leases")
+    }
+    assert set(indexes) == {
+        "ix_twitch_upstream_leases_state_expiry",
+        "ix_twitch_upstream_leases_auth_state",
+        "ix_twitch_upstream_leases_owner_state",
+        "ix_twitch_upstream_leases_recording_id",
+        "uq_twitch_upstream_leases_channel_key",
+    }
+    assert indexes["uq_twitch_upstream_leases_channel_key"]["unique"]
+    with engine.connect() as connection:
+        guard = connection.execute(
+            text("SELECT id, lock_version FROM twitch_upstream_coordination_state")
+        ).one()
+        assert guard == (1, 0)
+
+    migration.downgrade(engine)
+    assert "twitch_upstream_leases" not in inspect(engine).get_table_names()
+    assert "twitch_upstream_coordination_state" not in inspect(engine).get_table_names()
+
+    migration.upgrade(engine)
+    assert "twitch_upstream_leases" in inspect(engine).get_table_names()
+    engine.dispose()
+
+
+def test_migration_is_discovered() -> None:
+    from app.services.system.migration_service import MigrationService
+
+    scripts = [Path(path).name for path in MigrationService.get_all_migration_scripts()]
+    assert MIGRATION_NAME in scripts
+    assert hasattr(_load_migration(), "upgrade")
+
+
+@pytest.mark.parametrize("state", ["STARTING", "ACTIVE", "ROTATING", "RECOVERING"])
+def test_downgrade_refuses_active_lease_without_changing_schema_or_data(
+    tmp_path, state
+) -> None:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / f'migration_040_{state.lower()}.db'}", future=True
+    )
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY)"))
+        connection.execute(text("CREATE TABLE recordings (id INTEGER PRIMARY KEY)"))
+        connection.execute(
+            text("CREATE TABLE global_settings (id INTEGER PRIMARY KEY)")
+        )
+
+    migration = _load_migration()
+    migration.upgrade(engine)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO twitch_upstream_leases "
+                "(channel_key, purpose, state, generation, reserved_at, heartbeat_at, "
+                "expires_at, created_at, updated_at) VALUES "
+                "(:channel_key, 'RECORDING', :state, 1, CURRENT_TIMESTAMP, "
+                "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, "
+                "CURRENT_TIMESTAMP)"
+            ),
+            {"channel_key": f"channel-{state.lower()}", "state": state},
+        )
+
+    with pytest.raises(RuntimeError, match="active Twitch upstream leases"):
+        migration.downgrade(engine)
+
+    assert {
+        "twitch_upstream_leases",
+        "twitch_upstream_coordination_state",
+    }.issubset(inspect(engine).get_table_names())
+    with engine.connect() as connection:
+        assert connection.execute(
+            text("SELECT channel_key, state FROM twitch_upstream_leases")
+        ).one() == (f"channel-{state.lower()}", state)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "UPDATE twitch_upstream_leases SET state = 'RELEASED', "
+                "released_at = CURRENT_TIMESTAMP"
+            )
+        )
+    migration.downgrade(engine)
+    assert "twitch_upstream_leases" not in inspect(engine).get_table_names()
+    assert "twitch_upstream_coordination_state" not in inspect(engine).get_table_names()
+    engine.dispose()

--- a/tests/test_recording_recovery_resilience.py
+++ b/tests/test_recording_recovery_resilience.py
@@ -34,3 +34,19 @@ def test_process_manager_psutil_flag_reflects_import_result() -> None:
     assert "HAS_PSUTIL = True" in source
     assert "HAS_PSUTIL = False" in source
     assert "self.psutil_available = HAS_PSUTIL" in source
+
+
+def test_recovery_paths_forward_persisted_lease_generation() -> None:
+    startup = (ROOT / "app/services/init/startup_init.py").read_text(encoding="utf-8")
+    unified = (ROOT / "app/services/recording/unified_recovery_service.py").read_text(
+        encoding="utf-8"
+    )
+    process_manager = (ROOT / "app/services/recording/process_manager.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "recovery_generation=upstream_lease.generation" in startup
+    assert "recovery_generation=upstream_lease.generation" in unified
+    assert 'purpose="RECOVERY"' in process_manager
+    assert 'else "RECORDING"' in process_manager
+    assert "expected_generation=recovery_generation" in process_manager

--- a/tests/test_recording_rotation_safety.py
+++ b/tests/test_recording_rotation_safety.py
@@ -1,12 +1,24 @@
 import asyncio
 import importlib
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from app.database import Base
+from app.models import (
+    GlobalSettings,
+    TwitchUpstreamCoordinationState,
+    TwitchUpstreamLease,
+)
 from app.services.recording.process_manager import ProcessManager
 from app.services.recording.exceptions import ProcessError
+from app.services.twitch_upstream_coordinator import (
+    ProcessIdentity,
+    TwitchUpstreamCoordinator,
+)
 
 
 class FakeProcess:
@@ -154,7 +166,7 @@ def install_immediate_exit_start(
     monkeypatch.setattr(
         process_manager_module,
         "ASYNC_DELAYS",
-        SimpleNamespace(PROCESS_START_GRACE=0),
+        SimpleNamespace(PROCESS_START_GRACE=0, RECORDING_ERROR_RECOVERY=1),
     )
     stream = SimpleNamespace(
         id=7,
@@ -391,12 +403,42 @@ async def test_rotation_cancellation_tracks_or_reaps_created_replacement(
         "app.services.recording.process_manager"
     )
     old_process = FakeProcess(returncode=0)
+    old_process.pid = 401
     manager = make_manager(old_process)
     manager.logging_service = None
     segment_info = make_segment_info()
+    segment_info.update(
+        {
+            "upstream_channel_key": "stable-channel",
+            "upstream_generation": 4,
+            "upstream_process_group_id": 401,
+            "upstream_process_start_fingerprint": "birth-401",
+        }
+    )
     replacement = FakeProcess()
     replacement.pid = 1234
     child_created = asyncio.Event()
+    calls = []
+
+    class Coordinator:
+        async def begin_rotation(self, **values):
+            calls.append(("begin", values))
+            return SimpleNamespace(generation=5)
+
+        async def assert_stop_authorized(self, **values):
+            calls.append(("authorize", values))
+
+        async def inspect_process_identity(self, process_pid):
+            return ProcessIdentity(
+                process_pid,
+                process_pid,
+                datetime.now(timezone.utc),
+                f"birth-{process_pid}",
+            )
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
 
     class FakeQuery:
         def first(self):
@@ -442,6 +484,20 @@ async def test_rotation_cancellation_tracks_or_reaps_created_replacement(
         "ASYNC_DELAYS",
         SimpleNamespace(PROCESS_START_GRACE=3600, RECORDING_ERROR_RECOVERY=1),
     )
+    manager.upstream_coordinator = Coordinator()
+
+    async def terminate_process_group(process, process_group_id, timeout):
+        if process is old_process:
+            await process.wait()
+            return True
+        assert process is replacement
+        assert process_group_id == replacement.pid
+        process.returncode = -15
+        process.release.set()
+        await process.wait()
+        return True
+
+    manager._terminate_process_group = terminate_process_group
     stream = SimpleNamespace(
         id=7,
         streamer_id=3,
@@ -459,12 +515,148 @@ async def test_rotation_cancellation_tracks_or_reaps_created_replacement(
     with pytest.raises(asyncio.CancelledError):
         await rotation
 
-    tracked = manager.active_processes.get("stream_7") is replacement
-    reaped = replacement.returncode is not None and replacement.wait_calls > 0
     assert manager.active_processes.get("stream_7") is not old_process
-    assert tracked or reaped, (
-        f"created replacement was orphaned: tracked={tracked}, reaped={reaped}"
+    assert replacement.returncode == -15
+    assert replacement.wait_calls == 1
+    assert [name for name, _values in calls] == [
+        "begin",
+        "authorize",
+        "authorize",
+        "release",
+    ]
+    assert calls[-1][1] == {
+        "channel_key": "stable-channel",
+        "generation": 5,
+        "reason": "rotation_cancelled",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rotation_immediate_child_exit_releases_rotating_generation(
+    monkeypatch,
+) -> None:
+    create_task = asyncio.create_task
+    failed_process = FakeProcess(returncode=1)
+    failed_process.pid = 402
+    manager, stream, _monitor_coroutines = install_immediate_exit_start(
+        monkeypatch, failed_process
     )
+    monkeypatch.setattr(asyncio, "create_task", create_task)
+    old_process = FakeProcess(returncode=0)
+    old_process.pid = 401
+    manager.active_processes["stream_7"] = old_process
+    segment_info = make_segment_info()
+    segment_info.update(
+        {
+            "upstream_channel_key": "stable-channel",
+            "upstream_generation": 4,
+            "upstream_process_group_id": 401,
+            "upstream_process_start_fingerprint": "birth-401",
+        }
+    )
+    calls = []
+
+    class Coordinator:
+        async def begin_rotation(self, **values):
+            calls.append(("begin", values))
+            return SimpleNamespace(generation=5)
+
+        async def assert_stop_authorized(self, **values):
+            calls.append(("authorize", values))
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
+
+    manager.upstream_coordinator = Coordinator()
+
+    assert await manager._rotate_segment(stream, segment_info, "best") is False
+    assert [name for name, _values in calls] == ["begin", "authorize", "release"]
+    assert calls[-1][1] == {
+        "channel_key": "stable-channel",
+        "generation": 5,
+        "reason": "rotation_start_failed",
+    }
+    assert manager.active_processes == {}
+
+
+@pytest.mark.asyncio
+async def test_rotation_failed_handoff_reaps_only_authorized_replacement() -> None:
+    old_process = FakeProcess(returncode=0)
+    old_process.pid = 401
+    replacement = FakeProcess()
+    replacement.pid = 402
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    segment_info.update(
+        {
+            "upstream_channel_key": "stable-channel",
+            "upstream_generation": 4,
+            "upstream_process_group_id": 401,
+            "upstream_process_start_fingerprint": "birth-401",
+        }
+    )
+    calls = []
+
+    class Coordinator:
+        async def begin_rotation(self, **values):
+            calls.append(("begin", values))
+            return SimpleNamespace(generation=5)
+
+        async def assert_stop_authorized(self, **values):
+            calls.append(("authorize", values))
+
+        async def handoff_rotation(self, **values):
+            calls.append(("handoff", values))
+            raise RuntimeError("local handoff failure")
+
+        async def inspect_process_identity(self, process_pid):
+            return ProcessIdentity(
+                process_pid,
+                process_pid,
+                datetime.now(timezone.utc),
+                f"birth-{process_pid}",
+            )
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
+
+    async def start_segment(stream, segment_path, quality, info):
+        manager.active_processes[f"stream_{stream.id}"] = replacement
+        return replacement
+
+    terminated = []
+
+    async def terminate_process_group(process, process_group_id, timeout):
+        terminated.append((process, process_group_id))
+        process.returncode = -15
+        process.release.set()
+        await process.wait()
+        return True
+
+    manager.upstream_coordinator = Coordinator()
+    manager._start_segment = start_segment
+    manager._terminate_process_group = terminate_process_group
+
+    assert (
+        await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+        is False
+    )
+    assert [name for name, _values in calls] == [
+        "begin",
+        "authorize",
+        "handoff",
+        "authorize",
+        "release",
+    ]
+    assert terminated == [(replacement, replacement.pid)]
+    assert replacement.kill_calls == 0
+    assert calls[-1][1] == {
+        "channel_key": "stable-channel",
+        "generation": 5,
+        "reason": "rotation_handoff_failed",
+    }
 
 
 @pytest.mark.asyncio
@@ -531,3 +723,253 @@ async def test_immediate_exit_cleanup_preserves_newer_owners(
     assert manager.long_stream_processes["stream_7"] is newer_segment_info
     assert failed_process.communicate_calls == 1
     assert monitor_coroutines == []
+
+
+@pytest.mark.asyncio
+async def test_rotation_uses_generation_fenced_handoff() -> None:
+    old_process = FakeProcess()
+    old_process.pid = 401
+    manager = make_manager(old_process)
+    segment_info = make_segment_info()
+    segment_info.update(
+        {
+            "upstream_channel_key": "stable-channel",
+            "upstream_generation": 4,
+            "upstream_process_group_id": 401,
+            "upstream_process_start_fingerprint": "birth-401",
+        }
+    )
+    calls = []
+
+    class Coordinator:
+        async def begin_rotation(self, **values):
+            calls.append(("begin", values))
+            return SimpleNamespace(generation=5)
+
+        async def assert_stop_authorized(self, **values):
+            calls.append(("authorize", values))
+
+        async def handoff_rotation(self, **values):
+            calls.append(("handoff", values))
+            return SimpleNamespace(
+                generation=5,
+                process_group_id=402,
+                process_start_fingerprint="birth-402",
+            )
+
+    replacement = FakeProcess()
+    replacement.pid = 402
+
+    async def start_segment(stream, segment_path, quality, info):
+        manager.active_processes[f"stream_{stream.id}"] = replacement
+        return replacement
+
+    manager.upstream_coordinator = Coordinator()
+    manager._start_segment = start_segment
+
+    rotated = await manager._rotate_segment(SimpleNamespace(id=7), segment_info, "best")
+
+    assert rotated is True
+    assert [name for name, _values in calls] == ["begin", "authorize", "handoff"]
+    assert calls[1][1]["generation"] == 5
+    assert calls[2][1]["generation"] == 5
+    assert segment_info["upstream_generation"] == 5
+
+
+@pytest.mark.asyncio
+async def test_rotation_real_coordinator_hands_off_replacement(
+    monkeypatch, tmp_path
+) -> None:
+    process_manager_module = importlib.import_module(
+        "app.services.recording.process_manager"
+    )
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'rotation.db'}",
+        future=True,
+        connect_args={"check_same_thread": False, "timeout": 30},
+    )
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            TwitchUpstreamCoordinationState.__table__,
+            TwitchUpstreamLease.__table__,
+            GlobalSettings.__table__,
+        ],
+    )
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    started_at = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+    class Inspector:
+        def inspect(self, pid):
+            return ProcessIdentity(pid, pid, started_at, f"birth-{pid}")
+
+        def is_exact_process_alive(self, **identity):
+            return True
+
+    coordinator = TwitchUpstreamCoordinator(
+        Session,
+        utc_clock=lambda: started_at,
+        monotonic_clock=lambda: 1.0,
+        process_inspector=Inspector(),
+    )
+    reservation = await coordinator.reserve(
+        channel_key="stable-rotation-channel",
+        auth_key=None,
+        purpose="RECORDING",
+        recording_id=12,
+    )
+    active = await coordinator.activate(
+        channel_key=reservation.channel_key,
+        generation=reservation.generation,
+        process_pid=401,
+        process_group_id=401,
+        process_started_at=started_at,
+        process_start_fingerprint="birth-401",
+    )
+
+    old_process = FakeProcess()
+    old_process.pid = 401
+    replacement = FakeProcess()
+    replacement.pid = 402
+    manager = make_manager(old_process)
+    manager.logging_service = None
+    manager.upstream_coordinator = coordinator
+    segment_info = make_segment_info()
+    segment_info.update(
+        {
+            "upstream_channel_key": active.channel_key,
+            "upstream_generation": active.generation,
+            "upstream_process_group_id": active.process_group_id,
+            "upstream_process_start_fingerprint": active.process_start_fingerprint,
+        }
+    )
+    events = []
+
+    class FakeQuery:
+        def first(self):
+            return None
+
+        def filter(self, *args):
+            return self
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def query(self, *args):
+            return FakeQuery()
+
+    class FakeTokenService:
+        def __init__(self, db):
+            pass
+
+        async def get_valid_access_token(self):
+            return None
+
+    class FakeNotificationService:
+        async def send_recording_notification(self, **kwargs):
+            return None
+
+    async def create_subprocess(*args, **kwargs):
+        events.append("replacement_started")
+        return replacement
+
+    async def stop_process_group(process, process_group_id, timeout):
+        assert process is old_process
+        assert process_group_id == 401
+        events.append("old_group_stopped")
+        process.returncode = -15
+        process.release.set()
+        await process.wait()
+        return True
+
+    monkeypatch.setattr("app.database.SessionLocal", FakeSession)
+    monkeypatch.setattr(
+        "app.services.system.twitch_token_service.TwitchTokenService",
+        FakeTokenService,
+    )
+    monkeypatch.setattr(
+        "app.services.notifications.external_notification_service.ExternalNotificationService",
+        FakeNotificationService,
+    )
+    monkeypatch.setattr(
+        process_manager_module,
+        "get_streamlink_command",
+        lambda **kwargs: ["harmless-local-command"],
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+    monkeypatch.setattr(
+        process_manager_module,
+        "ASYNC_DELAYS",
+        SimpleNamespace(PROCESS_START_GRACE=0, RECORDING_ERROR_RECOVERY=1),
+    )
+    manager._terminate_process_group = stop_process_group
+    stream = SimpleNamespace(
+        id=7,
+        streamer_id=3,
+        streamer=SimpleNamespace(username="local-test"),
+        title="",
+        category_name="",
+    )
+
+    rotated = await manager._rotate_segment(stream, segment_info, "best")
+
+    assert rotated is True
+    assert events == ["old_group_stopped", "replacement_started"]
+    with Session() as db:
+        lease = db.query(TwitchUpstreamLease).one()
+        assert (lease.state, lease.generation, lease.process_pid) == (
+            "ACTIVE",
+            2,
+            402,
+        )
+        assert lease.process_start_fingerprint == "birth-402"
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recording_immediate_exit_releases_reserved_generation(
+    monkeypatch, tmp_path
+) -> None:
+    failed_process = FakeProcess(returncode=1)
+    failed_process.pid = 501
+    manager, stream, _monitor_coroutines = install_immediate_exit_start(
+        monkeypatch, failed_process
+    )
+    stream.streamer.twitch_id = "stable-recording-channel"
+    calls = []
+
+    class Coordinator:
+        async def reserve(self, **values):
+            calls.append(("reserve", values))
+            return SimpleNamespace(channel_key=values["channel_key"], generation=1)
+
+        async def activate(self, **values):
+            calls.append(("activate", values))
+            return SimpleNamespace(
+                generation=1,
+                process_group_id=501,
+                process_start_fingerprint="birth-501",
+            )
+
+        async def release(self, **values):
+            calls.append(("release", values))
+            return True
+
+    manager.upstream_coordinator = Coordinator()
+
+    with pytest.raises(ProcessError):
+        await manager.start_recording_process(
+            stream,
+            str(tmp_path / "recording.ts"),
+            "best",
+            recording_id=12,
+        )
+
+    assert [name for name, _values in calls] == ["reserve", "activate", "release"]
+    assert calls[0][1]["channel_key"] == "stable-recording-channel"
+    assert calls[0][1]["recording_id"] == 12
+    assert manager.active_processes == {}

--- a/tests/test_twitch_upstream_coordinator.py
+++ b/tests/test_twitch_upstream_coordinator.py
@@ -1,0 +1,430 @@
+import asyncio
+import socket
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.models import (
+    GlobalSettings,
+    TwitchUpstreamCoordinationState,
+    TwitchUpstreamLease,
+)
+from app.services.twitch_upstream_coordinator import (
+    AUTHENTICATED_TWITCH_ACCOUNT,
+    TwitchUpstreamConflict,
+    TwitchUpstreamCoordinator,
+)
+
+
+@pytest.fixture(autouse=True)
+def block_network_egress(monkeypatch):
+    def blocked(*args, **kwargs):
+        raise AssertionError("coordinator tests must not use network egress")
+
+    monkeypatch.setattr(socket, "create_connection", blocked)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+    def utcnow(self) -> datetime:
+        return self.now
+
+    def monotonic(self) -> float:
+        return 1.0
+
+    def advance(self, seconds: int) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+class FakeProcessInspector:
+    def __init__(self) -> None:
+        self.alive_fingerprints = set()
+
+    def is_exact_process_alive(self, **identity) -> bool:
+        return identity.get("process_start_fingerprint") in self.alive_fingerprints
+
+
+def make_coordinator(tmp_path, name="coordinator.db"):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / name}",
+        future=True,
+        connect_args={"check_same_thread": False, "timeout": 30},
+    )
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            TwitchUpstreamCoordinationState.__table__,
+            TwitchUpstreamLease.__table__,
+            GlobalSettings.__table__,
+        ],
+    )
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    clock = FakeClock()
+    inspector = FakeProcessInspector()
+    coordinator = TwitchUpstreamCoordinator(
+        Session,
+        utc_clock=clock.utcnow,
+        monotonic_clock=clock.monotonic,
+        process_inspector=inspector,
+    )
+    return engine, Session, clock, inspector, coordinator
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_channel_reservations_have_one_winner(tmp_path) -> None:
+    engine, Session, _clock, _inspector, coordinator = make_coordinator(tmp_path)
+    ready = 0
+    all_ready = asyncio.Event()
+    release = asyncio.Event()
+
+    async def contender(index: int):
+        nonlocal ready
+        ready += 1
+        if ready == 24:
+            all_ready.set()
+        await release.wait()
+        try:
+            return await coordinator.reserve(
+                channel_key="stable-twitch-id",
+                auth_key=None,
+                purpose="LIVE",
+                owner_user_id=index + 1,
+                live_session_id=f"session-{index}",
+            )
+        except TwitchUpstreamConflict as conflict:
+            return conflict.code
+
+    tasks = [asyncio.create_task(contender(index)) for index in range(24)]
+    await all_ready.wait()
+    release.set()
+    results = await asyncio.gather(*tasks)
+
+    winners = [result for result in results if not isinstance(result, str)]
+    assert len(winners) == 1
+    assert winners[0].channel_key == "stable-twitch-id"
+    assert winners[0].generation == 1
+    assert results.count("twitch_upstream_channel_conflict") == 23
+
+    with Session() as db:
+        leases = db.query(TwitchUpstreamLease).all()
+        assert len(leases) == 1
+        assert leases[0].state == "STARTING"
+        assert leases[0].live_session_id == winners[0].live_session_id
+
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_generation_fencing_rotation_and_pid_reuse(tmp_path) -> None:
+    engine, _Session, clock, inspector, coordinator = make_coordinator(tmp_path)
+    started_at = clock.utcnow()
+    reservation = await coordinator.reserve(
+        channel_key="channel-1",
+        auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+        purpose="RECORDING",
+        recording_id=9,
+    )
+    active = await coordinator.activate(
+        channel_key=reservation.channel_key,
+        generation=reservation.generation,
+        process_pid=101,
+        process_group_id=101,
+        process_started_at=started_at,
+        process_start_fingerprint="birth-101-a",
+    )
+    inspector.alive_fingerprints.add("birth-101-a")
+    clock.advance(31)
+    assert await coordinator.reconcile() == 0
+
+    rotating = await coordinator.begin_rotation(
+        channel_key=active.channel_key, generation=active.generation
+    )
+    assert rotating.state == "ROTATING"
+    assert rotating.generation == 2
+    await coordinator.assert_stop_authorized(
+        channel_key=rotating.channel_key,
+        generation=rotating.generation,
+        process_pid=101,
+        process_group_id=101,
+        process_start_fingerprint="birth-101-a",
+    )
+    replacement = await coordinator.handoff_rotation(
+        channel_key=rotating.channel_key,
+        generation=rotating.generation,
+        process_pid=101,
+        process_group_id=101,
+        process_started_at=clock.utcnow(),
+        process_start_fingerprint="birth-101-b",
+    )
+    assert replacement.state == "ACTIVE"
+    assert replacement.purpose == "RECORDING"
+
+    with pytest.raises(PermissionError):
+        await coordinator.assert_stop_authorized(
+            channel_key=active.channel_key,
+            generation=active.generation,
+            process_pid=101,
+            process_group_id=101,
+            process_start_fingerprint="birth-101-a",
+        )
+    assert not await coordinator.release(
+        channel_key=active.channel_key,
+        generation=active.generation,
+        reason="stale_monitor",
+    )
+
+    # The PID was reused, but the exact birth fingerprint differs.
+    inspector.alive_fingerprints = {"birth-101-a"}
+    clock.advance(31)
+    assert await coordinator.reconcile() == 1
+    recovered = await coordinator.reserve(
+        channel_key="channel-1",
+        auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+        purpose="RECOVERY",
+        recording_id=9,
+        expected_generation=replacement.generation,
+    )
+    assert recovered.state == "RECOVERING"
+    assert recovered.generation == 3
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_idempotency_policy_and_global_budgets(tmp_path) -> None:
+    engine, Session, clock, _inspector, coordinator = make_coordinator(
+        tmp_path, "budgets.db"
+    )
+    with Session() as db:
+        db.add(GlobalSettings(id=1, twitch_max_concurrent_upstreams=3))
+        db.commit()
+
+    live = await coordinator.reserve(
+        channel_key="live-channel",
+        auth_key=None,
+        purpose="LIVE",
+        owner_user_id=1,
+        live_session_id="session-original",
+    )
+    live = await coordinator.activate(
+        channel_key=live.channel_key,
+        generation=live.generation,
+        process_pid=201,
+        process_group_id=201,
+        process_started_at=clock.utcnow(),
+        process_start_fingerprint="birth-201",
+    )
+    duplicate = await coordinator.reserve(
+        channel_key="live-channel",
+        auth_key=None,
+        purpose="LIVE",
+        owner_user_id=1,
+        live_session_id="session-new",
+    )
+    assert duplicate.live_session_id == "session-original"
+    assert duplicate.generation == live.generation
+
+    with pytest.raises(TwitchUpstreamConflict) as policy:
+        await coordinator.reserve(
+            channel_key="live-channel",
+            auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+            purpose="LIVE",
+            owner_user_id=1,
+            live_session_id="enhanced",
+        )
+    assert policy.value.code == "twitch_upstream_live_policy_conflict"
+
+    await coordinator.reserve(
+        channel_key="anonymous-channel",
+        auth_key=None,
+        purpose="LIVE",
+        owner_user_id=2,
+        live_session_id="anonymous",
+    )
+    await coordinator.reserve(
+        channel_key="authenticated-channel",
+        auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+        purpose="RECORDING",
+        recording_id=10,
+    )
+    with pytest.raises(TwitchUpstreamConflict) as authenticated:
+        await coordinator.reserve(
+            channel_key="second-authenticated-channel",
+            auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+            purpose="RECORDING",
+            recording_id=11,
+        )
+    assert authenticated.value.code == "twitch_upstream_authenticated_budget_exhausted"
+    with pytest.raises(TwitchUpstreamConflict) as total:
+        await coordinator.reserve(
+            channel_key="fourth-anonymous-channel",
+            auth_key=None,
+            purpose="LIVE",
+            owner_user_id=3,
+            live_session_id="fourth",
+        )
+    assert total.value.code == "twitch_upstream_total_budget_exhausted"
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recording_and_live_collide_on_stable_channel(tmp_path) -> None:
+    engine, _Session, _clock, _inspector, coordinator = make_coordinator(
+        tmp_path, "mixed.db"
+    )
+    await coordinator.reserve(
+        channel_key="stable-mixed-channel",
+        auth_key=AUTHENTICATED_TWITCH_ACCOUNT,
+        purpose="RECORDING",
+        recording_id=22,
+    )
+
+    with pytest.raises(TwitchUpstreamConflict) as conflict:
+        await coordinator.reserve(
+            channel_key="stable-mixed-channel",
+            auth_key=None,
+            purpose="LIVE",
+            owner_user_id=3,
+            live_session_id="must-not-start",
+        )
+
+    assert conflict.value.as_detail() == {
+        "code": "twitch_upstream_channel_conflict",
+        "reason": "channel_already_reserved",
+        "channel_key": "stable-mixed-channel",
+        "retryable": False,
+    }
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_live_stop_authorization_uses_durable_owner_and_purpose(tmp_path) -> None:
+    engine, Session, clock, _inspector, coordinator = make_coordinator(
+        tmp_path, "live-stop.db"
+    )
+    live = await coordinator.reserve(
+        channel_key="live-stop-channel",
+        auth_key=None,
+        purpose="LIVE",
+        owner_user_id=7,
+        live_session_id="session-7",
+    )
+    live = await coordinator.activate(
+        channel_key=live.channel_key,
+        generation=live.generation,
+        process_pid=701,
+        process_group_id=701,
+        process_started_at=clock.utcnow(),
+        process_start_fingerprint="birth-701",
+    )
+    _inspector.alive_fingerprints.add("birth-701")
+
+    authorized = await coordinator.assert_stop_authorized(
+        channel_key=live.channel_key,
+        generation=live.generation,
+        process_pid=701,
+        process_group_id=701,
+        process_start_fingerprint="birth-701",
+        expected_purpose="LIVE",
+        requesting_owner_user_id=7,
+    )
+    assert authorized.live_session_id == "session-7"
+
+    for generation, owner_user_id in ((live.generation, 8), (0, 7)):
+        with pytest.raises(PermissionError):
+            await coordinator.assert_stop_authorized(
+                channel_key=live.channel_key,
+                generation=generation,
+                process_pid=701,
+                process_group_id=701,
+                process_start_fingerprint="birth-701",
+                expected_purpose="LIVE",
+                requesting_owner_user_id=owner_user_id,
+            )
+
+    recording = await coordinator.reserve(
+        channel_key="recording-stop-channel",
+        auth_key=None,
+        purpose="RECORDING",
+        recording_id=17,
+    )
+    recording = await coordinator.activate(
+        channel_key=recording.channel_key,
+        generation=recording.generation,
+        process_pid=702,
+        process_group_id=702,
+        process_started_at=clock.utcnow(),
+        process_start_fingerprint="birth-702",
+    )
+    _inspector.alive_fingerprints.add("birth-702")
+    for purpose in ("RECORDING", "RECOVERY"):
+        with Session() as db:
+            lease = (
+                db.query(TwitchUpstreamLease)
+                .filter_by(channel_key=recording.channel_key)
+                .one()
+            )
+            lease.purpose = purpose
+            db.commit()
+        with pytest.raises(PermissionError):
+            await coordinator.assert_stop_authorized(
+                channel_key=recording.channel_key,
+                generation=recording.generation,
+                process_pid=702,
+                process_group_id=702,
+                process_start_fingerprint="birth-702",
+                expected_purpose="LIVE",
+                requesting_owner_user_id=7,
+            )
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recovery_rejects_merely_released_live_process(tmp_path) -> None:
+    engine, Session, clock, inspector, coordinator = make_coordinator(
+        tmp_path, "recovery-guard.db"
+    )
+    reservation = await coordinator.reserve(
+        channel_key="recovery-guard-channel",
+        auth_key=None,
+        purpose="RECORDING",
+        recording_id=23,
+    )
+    active = await coordinator.activate(
+        channel_key=reservation.channel_key,
+        generation=reservation.generation,
+        process_pid=801,
+        process_group_id=801,
+        process_started_at=clock.utcnow(),
+        process_start_fingerprint="birth-801",
+    )
+    inspector.alive_fingerprints.add("birth-801")
+    clock.advance(31)
+    assert await coordinator.release(
+        channel_key=active.channel_key,
+        generation=active.generation,
+        reason="recording_stopped",
+    )
+
+    with pytest.raises(TwitchUpstreamConflict) as raised:
+        await coordinator.reserve(
+            channel_key=active.channel_key,
+            auth_key=None,
+            purpose="RECOVERY",
+            recording_id=23,
+            expected_generation=active.generation,
+        )
+
+    assert raised.value.reason == "recovery_precondition_failed"
+    with Session() as db:
+        lease = db.query(TwitchUpstreamLease).one()
+        assert (lease.state, lease.purpose, lease.generation) == (
+            "RELEASED",
+            "RECORDING",
+            active.generation,
+        )
+    engine.dispose()


### PR DESCRIPTION
## Summary
- add durable Twitch upstream leases and a database-backed coordinator with channel, authenticated-account, and total-budget arbitration
- fence Recording, Live, rotation, recovery, stop, cancellation, and cleanup by lease generation and exact process identity
- add migration 040, configurable total upstream capacity, anonymous-default Live, machine-readable conflicts, and persisted Live-owner checks

Closes #783

## Threat model
This changes user-controlled process starts, credentials, authorization, process-group ownership, recovery fencing, persistent state, and denial-of-service limits. The implementation stores no command line, OAuth value, proxy credential, signed URL, header, or playback token in a lease. Live stops require the stored LIVE owner, generation, and process identity. Reused PIDs and stale generations are rejected.

## Rollout
Migration 040 is additive. New starts reserve durable leases before child creation. Existing recordings are not restarted or terminated during deployment. Reconciliation releases only expired leases whose exact process identity is no longer live.

## Rollback
Do not downgrade while active lease rows exist. Drain or reconcile leases first. Migration 040 rejects a downgrade while STARTING, ACTIVE, ROTATING, or RECOVERING rows are present.

## Verification
- `uvx ruff check app/`
- `uvx ruff format --check app/`
- `uvx ruff check` and format check for six changed Python test files
- `/opt/data/tmp/streamvault-783-venv/bin/python -m pytest tests/ -q` -> 244 passed, 2 skipped
- `python -m app.migrations_init`
- `npm run lint`, `npm run lint:tokens`, `npm run type-check`, `npm run build`
- `git diff --check` and tracked changed-file Unicode dash scan

Local Docker Buildx is unavailable on this host (`docker: 'buildx' is not a docker command`), so Docker validation remains required on the exact PR head in CI before review or merge.
